### PR TITLE
save logs after check status

### DIFF
--- a/pkg/manager/worker/kubernetes/kubernetes.go
+++ b/pkg/manager/worker/kubernetes/kubernetes.go
@@ -171,8 +171,11 @@ func (d *KubernetesWorkerInterface) UpdateWorkerStatus(studyId string) error {
 	}
 	for _, w := range ws {
 		if w.Status == api.State_RUNNING {
-			d.StoreWorkerLog(w.WorkerId)
 			c, err := d.IsWorkerComplete(w.WorkerId)
+			if err != nil {
+				return err
+			}
+			err = d.StoreWorkerLog(w.WorkerId)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fix drop logs bug.
Log collection should be done after worker status is checked.

Signed-off-by: YujiOshima <yuji.oshima0x3fd@gmail.com>