### PR TITLE
pin mxnet/python image version

### DIFF
--- a/examples/worker-config.yml
+++ b/examples/worker-config.yml
@@ -1,4 +1,4 @@
-image: "mxnet/python"
+image: "mxnet/python:1.2.0_cpu"
 command: 
     - "python"
     - "/mxnet/example/image-classification/train_mnist.py"


### PR DESCRIPTION
The mxnet/python image version was updated on docker hub, the worker pods in the example study fail to start. mxnet folder seems to be missing from / in the latest image, I see the following error in the logs - 
`python: can't open file '/mxnet/example/image-classification/train_mnist.py': [Errno 2] No such file or directory`