### PR TITLE
Corrected typos in hyperband example yml

### DIFF
--- a/examples/MinikubeDemo/manifests/vizier/suggestion/hyperband/deployment.yaml
+++ b/examples/MinikubeDemo/manifests/vizier/suggestion/hyperband/deployment.yaml
@@ -1,23 +1,23 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: vizier-suggestion-hayperband
+  name: vizier-suggestion-hyperband
   namespace: katib
   labels:
     app: vizier
-    component: suggestion-hayperband
+    component: suggestion-hyperband
 spec:
   replicas: 1
   template:
     metadata:
-      name: vizier-suggestion-hayperband
+      name: vizier-suggestion-hyperband
       labels:
         app: vizier
-        component: suggestion-hayperband
+        component: suggestion-hyperband
     spec:
       containers:
-      - name: vizier-suggestion-hayperband
-        image: katib/suggestion-hayperband
+      - name: vizier-suggestion-hyperband
+        image: katib/suggestion-hyperband
         ports:
         - name: api
           containerPort: 6789

--- a/examples/MinikubeDemo/manifests/vizier/suggestion/hyperband/service.yaml
+++ b/examples/MinikubeDemo/manifests/vizier/suggestion/hyperband/service.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: vizier-suggestion-hayperband
+  name: vizier-suggestion-hyperband
   namespace: katib
   labels:
     app: vizier
-    component: suggestion-hayperband
+    component: suggestion-hyperband
 spec:
   type: ClusterIP
   ports:
@@ -14,4 +14,4 @@ spec:
       name: api
   selector:
     app: vizier
-    component: suggestion-hayperband
+    component: suggestion-hyperband


### PR DESCRIPTION
Corrected typos in hyperband example yml, from 'hayperband' to 'hyperband' in order to make it possible to deploy the pods and services.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/146)
<!-- Reviewable:end -->
