### PR TITLE
fix imagepull not found issue

### DIFF
--- a/examples/MinikubeDemo/manifests/vizier/suggestion/hyperband/deployment.yaml
+++ b/examples/MinikubeDemo/manifests/vizier/suggestion/hyperband/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: vizier-suggestion-hayperband
-        image: katib/suggestion-hayperband
+        image: katib/suggestion-hyperband
         ports:
         - name: api
           containerPort: 6789


### PR DESCRIPTION


```
# docker pull katib/suggestion-hayperband
Using default tag: latest
Error response from daemon: repository katib/suggestion-hayperband not found: does not exist or no pull access
```