### PR TITLE
Changed deploy.sh to take username and password for GKE deployment

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -48,12 +48,12 @@ kubectl apply -f manifests/modeldb/db
 kubectl apply -f manifests/modeldb/backend
 kubectl apply -f manifests/modeldb/frontend
 kubectl apply -f manifests/vizier/db
-kubectl ${USERNAME} ${PASSWORD} apply apply -f manifests/vizier/core
+kubectl ${USERNAME} ${PASSWORD} apply -f manifests/vizier/core
 kubectl apply -f manifests/vizier/suggestion/random
 kubectl apply -f manifests/vizier/suggestion/grid
 kubectl apply -f manifests/vizier/suggestion/hyperband
 kubectl apply -f manifests/studyjobcontroller/crd.yaml
-kubectl ${USERNAME} ${PASSWORD} apply apply -f manifests/studyjobcontroller/rbac.yaml
+kubectl ${USERNAME} ${PASSWORD} apply -f manifests/studyjobcontroller/rbac.yaml
 kubectl apply -f manifests/studyjobcontroller/workerConfigMap.yaml
 kubectl apply -f manifests/studyjobcontroller/metricsControllerConfigMap.yaml
 kubectl apply -f manifests/studyjobcontroller/studyjobcontroller.yaml

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -19,6 +19,28 @@ set -o nounset
 set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
+USERNAME=""
+PASSWORD=""
+
+usage_exit() {
+        echo "Usage: $0 [-u username] [-p password]" 1>&2
+        exit 1
+}
+
+while getopts u:p:h OPT
+do
+    case ${OPT} in
+        u)  USERNAME="--username=${OPTARG}"
+            ;;
+        p)  PASSWORD="--password=${OPTARG}"
+            ;;
+        h)  usage_exit
+            ;;
+        \?) usage_exit
+            ;;
+    esac
+done
+shift $((OPTIND-1))
 
 cd ${SCRIPT_ROOT}
 kubectl apply -f manifests/0-namespace.yaml
@@ -26,12 +48,12 @@ kubectl apply -f manifests/modeldb/db
 kubectl apply -f manifests/modeldb/backend
 kubectl apply -f manifests/modeldb/frontend
 kubectl apply -f manifests/vizier/db
-kubectl apply -f manifests/vizier/core
+kubectl ${USERNAME} ${PASSWORD} apply apply -f manifests/vizier/core
 kubectl apply -f manifests/vizier/suggestion/random
 kubectl apply -f manifests/vizier/suggestion/grid
 kubectl apply -f manifests/vizier/suggestion/hyperband
 kubectl apply -f manifests/studyjobcontroller/crd.yaml
-kubectl apply -f manifests/studyjobcontroller/rbac.yaml
+kubectl ${USERNAME} ${PASSWORD} apply apply -f manifests/studyjobcontroller/rbac.yaml
 kubectl apply -f manifests/studyjobcontroller/workerConfigMap.yaml
 kubectl apply -f manifests/studyjobcontroller/metricsControllerConfigMap.yaml
 kubectl apply -f manifests/studyjobcontroller/studyjobcontroller.yaml


### PR DESCRIPTION
What:
- Added args for deploy.sh to be used to specify admin username and password in case of GKE deployment, necessary for creating cluster RBAC.
The username and password can be obtained with the following command.

gcloud container clusters describe (cluster-name) --zone=(zone-name)  --format json | jq '[.masterAuth.password, .masterAuth.username]'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/164)
<!-- Reviewable:end -->
