### PR TITLE
make job name contain the name of studyjob

### DIFF
--- a/pkg/db/db_init.go
+++ b/pkg/db/db_init.go
@@ -55,7 +55,7 @@ func (d *db_conn) DB_Init() {
 	}
 
 	_, err = db.Exec("CREATE TABLE IF NOT EXISTS worker_metrics" +
-		"(worker_id CHAR(16) NOT NULL, " +
+		"(worker_id CHAR(32) NOT NULL, " +
 		"id INT AUTO_INCREMENT PRIMARY KEY, " +
 		"time DATETIME(6), " +
 		"name VARCHAR(255), " +

--- a/pkg/db/interface.go
+++ b/pkg/db/interface.go
@@ -686,7 +686,18 @@ func (d *db_conn) CreateWorker(worker *api.Worker) (string, error) {
 	var worker_id string
 	i := 3
 	for true {
-		worker_id = generate_randid()
+	        row = d.db.QueryRow("SELECT name FROM studies WHERE id = ?",worker.StudyId)
+		switch {
+		case row == sql.ErrNoRows:
+			log.Printf("No studyId with that ID")
+		case row != nil:
+			log.Fatalf("error: %v", row)
+		}
+		err = row.Scan(&worker_id)
+		if err != nil{
+			return nil, err
+		}
+		worker_id += generate_randid()
 		_, err = d.db.Exec("INSERT INTO workers VALUES (?, ?, ?, ?, ?, ?, ?)",
 			worker_id, worker.StudyId, worker.TrialId, worker.Type,
 			api.State_PENDING, worker.TemplatePath, strings.Join(tags, ",\n"))


### PR DESCRIPTION
The original job name is random, which is not conducive to further monitoring of the job, so make the job name support the name of the studyjob