### PR TITLE
make job name contain the name of studyjob

### DIFF
--- a/pkg/api/operators/apis/studyjob/v1alpha1/studyjob_types.go
+++ b/pkg/api/operators/apis/studyjob/v1alpha1/studyjob_types.go
@@ -31,6 +31,7 @@ type StudyJobSpec struct {
 	OptimizationType     OptimizationType      `json:"optimizationtype,omitempty"`
 	OptimizationGoal     *float64              `json:"optimizationgoal,omitempty"`
 	ObjectiveValueName   string                `json:"objectivevaluename,omitempty"`
+	RequestCount         int                   `json:"requestCount,omitempty"`
 	MetricsNames         []string              `json:"metricsnames,omitempty"`
 	ParameterConfigs     []ParameterConfig     `json:"parameterconfigs,omitempty"`
 	WorkerSpec           *WorkerSpec           `json:"workerSpec,omitempty"`

--- a/pkg/controller/studyjobcontroller/studyjob_controller.go
+++ b/pkg/controller/studyjobcontroller/studyjob_controller.go
@@ -477,6 +477,9 @@ func (r *ReconcileStudyJobController) checkStatus(instance *katibv1alpha1.StudyJ
 			log.Printf("Check Goal failed %v", err)
 		}
 	}
+	if instance.Status.SuggestionCount > instance.Spec.RequestCount{
+		nextSuggestionSchedule = false
+	}
 	if nextSuggestionSchedule {
 		return r.getAndRunSuggestion(instance, c, ns)
 	} else {


### PR DESCRIPTION
The original job name is random, which is not conducive to further monitoring of the job, so make the job name support the name of the studyjob.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/187)
<!-- Reviewable:end -->
