### PR TITLE
Fix CRD validation

### DIFF
--- a/manifests/studyjobcontroller/crd.yaml
+++ b/manifests/studyjobcontroller/crd.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   group: kubeflow.org
   version: v1alpha1
+  scope: Namespaced
   names:
     kind: StudyJob
     singular: studyjob


### PR DESCRIPTION
While CustomResourceDefinition.spec.scope defaults to Namespaced,
omitting this generates a validation error. Just supply the default.

Signed-off-by: IWAMOTO Toshihiro <iwamoto@valinux.co.jp>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/191)
<!-- Reviewable:end -->
