### PR TITLE
enlarge max of check status grpc

### DIFF
--- a/pkg/controller/studyjobcontroller/studyjob_controller.go
+++ b/pkg/controller/studyjobcontroller/studyjob_controller.go
@@ -47,6 +47,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+const maxMsgSize = 1<<31 - 1
+
 /**
 * USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
 * business logic.  Delete these comments after modifying this file.*
@@ -364,7 +366,11 @@ func (r *ReconcileStudyJobController) checkStatus(instance *katibv1alpha1.StudyJ
 	if instance.Status.Condition == katibv1alpha1.ConditionCompleted || instance.Status.Condition == katibv1alpha1.ConditionFailed {
 		nextSuggestionSchedule = false
 	}
-	conn, err := grpc.Dial(pkg.ManagerAddr, grpc.WithInsecure())
+	opts := []grpc.DialOption{
+		grpc.WithInsecure(),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)),
+	}
+	conn, err := grpc.Dial(pkg.ManagerAddr, opts...)
 	if err != nil {
 		log.Printf("Connect katib manager error %v", err)
 		instance.Status.Condition = katibv1alpha1.ConditionFailed


### PR DESCRIPTION
Avoid ResourceExhausted error when the log of a worker is very long.
Signed-off-by: YujiOshima <yuji.oshima0x3fd@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/200)
<!-- Reviewable:end -->
