### PR TITLE
fix slice range

### DIFF
--- a/pkg/suggestion/hyperband_service.go
+++ b/pkg/suggestion/hyperband_service.go
@@ -142,7 +142,7 @@ func (h *HyperBandSuggestService) makeChildBracket(ctx context.Context, c api.Ma
 	child := Bracket{}
 
 	if sconf.OptimizationType == api.OptimizationType_MINIMIZE {
-		child = parent[n:]
+		child = parent[len(parent) - n:]
 	} else if sconf.OptimizationType == api.OptimizationType_MAXIMIZE {
 		child = parent[:n]
 	}


### PR DESCRIPTION
Fix slice range when minimize optimization, in this PR.
This prevents "index out of range" of tids from occurring in later for loops.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/226)
<!-- Reviewable:end -->
