### PR TITLE
add starttime and completiontime to worker

### DIFF
--- a/pkg/api/operators/apis/studyjob/v1alpha1/studyjob_types.go
+++ b/pkg/api/operators/apis/studyjob/v1alpha1/studyjob_types.go
@@ -67,10 +67,12 @@ type StudyJobStatus struct {
 }
 
 type WorkerCondition struct {
-	WorkerID      string    `json:"workerid,omitempty"`
-	Kind          string    `json:"kind,omitempty"`
-	Condition     Condition `json:"conditon,omitempty"`
-	ObjctiveValue *float64  `jsob:"objctiveValue,omitempty"`
+	WorkerID       string      `json:"workerid,omitempty"`
+	Kind           string      `json:"kind,omitempty"`
+	Condition      Condition   `json:"conditon,omitempty"`
+	ObjctiveValue  *float64    `jsob:"objctiveValue,omitempty"`
+	StartTime      metav1.Time `json:"startTime,omitempty"`
+	CompletionTime metav1.Time `json:"completionTime,omitempty"`
 }
 
 type TrialSet struct {

--- a/pkg/controller/studyjobcontroller/studyjob_controller.go
+++ b/pkg/controller/studyjobcontroller/studyjob_controller.go
@@ -433,6 +433,7 @@ func (r *ReconcileStudyJobController) checkStatus(instance *katibv1alpha1.StudyJ
 							if ctime.Before(cjob.Status.LastScheduleTime) && len(cjob.Status.Active) == 0 {
 								r.saveModel(c, instance.Status.StudyID, instance.Status.Trials[i].TrialID, instance.Status.Trials[i].WorkerList[j].WorkerID)
 								instance.Status.Trials[i].WorkerList[j].Condition = katibv1alpha1.ConditionCompleted
+								instance.Status.Trials[i].WorkerList[j].CompletionTime = metav1.Now()
 								update = true
 								_, err := c.UpdateWorkerState(
 									context.Background(),
@@ -550,6 +551,7 @@ func (r *ReconcileStudyJobController) getAndRunSuggestion(instance *katibv1alpha
 						WorkerID:  wid,
 						Kind:      wkind,
 						Condition: katibv1alpha1.ConditionCreated,
+						StartTime: metav1.Now(),
 					},
 				},
 			},


### PR DESCRIPTION

In order to accurately control the resources, we need to get the start and end time of the worker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/236)
<!-- Reviewable:end -->
