### PR TITLE
Fix incorrectly set namespace

### DIFF
--- a/manifests/vizier/db/secret.yaml
+++ b/manifests/vizier/db/secret.yaml
@@ -3,6 +3,6 @@ kind: Secret
 type: Opaque
 metadata:
   name: vizier-db-secrets
-  namespace: katib
+  namespace: kubeflow
 data:
   MYSQL_ROOT_PASSWORD: test


### PR DESCRIPTION
Commit b6f8e07d26a ("Update manifests (#246)") has just changed the
namespace as a whole. This new manifest should be updated as well.

Fixes: 67e94c7697b ("Set MYSQL_ROOT_PASSWORD via Secret (#253)")
Signed-off-by: Koichiro Den <den@valinux.co.jp>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/260)
<!-- Reviewable:end -->
