### PR TITLE
Prevent pod restarts caused by slow db boot

### DIFF
--- a/manifests/vizier/db/deployment.yaml
+++ b/manifests/vizier/db/deployment.yaml
@@ -31,6 +31,15 @@ spec:
         ports:
         - name: dbapi
           containerPort: 3306
+        readinessProbe:
+          exec:
+            command:
+            - "/bin/bash"
+            - "-c"
+            - "mysql -D $$MYSQL_DATABASE -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'"
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          timeoutSeconds: 1
         volumeMounts:
         - name: katib-mysql
           mountPath: /var/lib/mysql

--- a/manifests/vizier/db/secret.yaml
+++ b/manifests/vizier/db/secret.yaml
@@ -5,4 +5,4 @@ metadata:
   name: vizier-db-secrets
   namespace: kubeflow
 data:
-  MYSQL_ROOT_PASSWORD: test
+  MYSQL_ROOT_PASSWORD: dGVzdA== # "test"

--- a/pkg/db/interface_test.go
+++ b/pkg/db/interface_test.go
@@ -64,6 +64,25 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func TestOpenSQLConn(t *testing.T) {
+	_, _, err := sqlmock.New()
+	if err != nil {
+		fmt.Printf("error opening db: %v\n", err)
+		os.Exit(1)
+	}
+	mysqlAddr := os.Getenv("TEST_MYSQL")
+	if mysqlAddr != "" {
+		_, err := openSQLConn("mysql", "root:test123@tcp("+mysqlAddr+")/vizier", time.Second, 3*time.Second)
+		if err != nil {
+			t.Errorf("openSQLConn error: %v", err)
+		}
+	}
+	_, err = openSQLConn("mysql", "root:test123@tcp(dummy)/vizier", time.Second, 3*time.Second)
+	if err.Error() != "Timeout waiting for DB conn successfully opened." {
+		t.Errorf("openSQLConn should timeout but got error: %v", err)
+	}
+}
+
 func TestCreateStudy(t *testing.T) {
 	var in api.StudyConfig
 	in.ParameterConfigs = new(api.StudyConfig_ParameterConfigs)


### PR DESCRIPTION
When we run `./scripts/deploy.sh` for the first time, `vizier-core` is highly likely to undergo a few times of "Pod Restart". This is because `vizier-db` takes much longer time to become ready. This PR intends to have `vizier-core` wait for DB to become ready, so that we no longer see any pod Restart if all components are properly deployed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/261)
<!-- Reviewable:end -->
