### PR TITLE
fix timing to determine slice size in grid search

### DIFF
--- a/pkg/suggestion/grid_service.go
+++ b/pkg/suggestion/grid_service.go
@@ -168,10 +168,10 @@ func (s *GridSuggestService) GetSuggestions(ctx context.Context, in *api.GetSugg
 	if reqnum == 0 {
 		reqnum = len(grids)
 	}
-	trials := make([]*api.Trial, reqnum)
 	if iteration+reqnum > len(grids) {
 		reqnum = len(grids) - iteration
 	}
+	trials := make([]*api.Trial, reqnum)
 	if reqnum <= 0 {
 		return &api.GetSuggestionsReply{Trials: []*api.Trial{}}, err
 	}


### PR DESCRIPTION
Fix timing to determine slice size. With this fix, error due to the empty part of the slice doesn't occur.
(Fixes: https://github.com/kubeflow/katib/issues/215)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/271)
<!-- Reviewable:end -->
