### PR TITLE
Allow studyjobcontroller to delete pods

### DIFF
--- a/manifests/studyjobcontroller/rbac.yaml
+++ b/manifests/studyjobcontroller/rbac.yaml
@@ -14,6 +14,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  - pods/status
+  verbs:
+  - "*"
+- apiGroups:
   - batch
   resources:
   - jobs


### PR DESCRIPTION
After https://github.com/kubeflow/katib/pull/256, when StudyJobs are deleted we need to manually delete pods created by the study jobs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/278)
<!-- Reviewable:end -->
