### PR TITLE
Use same deploy.sh when deploy katib components

### DIFF
--- a/examples/MinikubeDemo/deploy.sh
+++ b/examples/MinikubeDemo/deploy.sh
@@ -2,18 +2,4 @@
 set -x
 set -e
 minikube start --disk-size 50g --memory 4096 --cpus 4
-kubectl apply -f ../../manifests/0-namespace.yaml
-kubectl apply -f ../../manifests/pv
-kubectl apply -f ../../manifests/vizier/db
-kubectl apply -f ../../manifests/vizier/core
-kubectl apply -f ../../manifests/vizier/ui
-kubectl apply -f ../../manifests/vizier/suggestion/random
-kubectl apply -f ../../manifests/vizier/suggestion/grid
-kubectl apply -f ../../manifests/vizier/suggestion/hyperband
-kubectl apply -f ../../manifests/vizier/earlystopping/medianstopping
-kubectl apply -f ../../manifests/studyjobcontroller/crd.yaml
-kubectl apply -f ../../manifests/studyjobcontroller/rbac.yaml
-kubectl apply -f ../../manifests/studyjobcontroller/mcrbac.yaml
-kubectl apply -f ../../manifests/studyjobcontroller/workerConfigMap.yaml
-kubectl apply -f ../../manifests/studyjobcontroller/metricsControllerConfigMap.yaml
-kubectl apply -f ../../manifests/studyjobcontroller/studyjobcontroller.yaml
+bash ../../scripts/deploy.sh


### PR DESCRIPTION
We need to fix two deploy.sh when components updated, so I fixed deploy.sh in MinikubeDemo to use scripts/deploy.sh for maintainability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/284)
<!-- Reviewable:end -->
