### PR TITLE
Update k8s cluster version to 1.10

### DIFF
--- a/test/scripts/create-cluster.sh
+++ b/test/scripts/create-cluster.sh
@@ -33,7 +33,7 @@ echo "Creating GPU cluster"
 gcloud --project ${PROJECT} beta container clusters create ${CLUSTER_NAME} \
     --zone ${ZONE} \
     --accelerator type=nvidia-tesla-k80,count=1 \
-    --cluster-version 1.9
+    --cluster-version 1.10
 echo "Configuring kubectl"
 gcloud --project ${PROJECT} container clusters get-credentials ${CLUSTER_NAME} \
     --zone ${ZONE}


### PR DESCRIPTION
K8s cluster 1.9 is no more supported in us-east1-d zone which is used for ci tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/286)
<!-- Reviewable:end -->
