### PR TITLE
Extend studyjob client API 

### DIFF
--- a/pkg/manager/studyjobclient/studyjobclient.go
+++ b/pkg/manager/studyjobclient/studyjobclient.go
@@ -50,13 +50,7 @@ func NewStudyjobClient(config *rest.Config) (*StudyjobClient, error) {
 
 func (s *StudyjobClient) GetStudyJobList(namespace ...string) (*studyjobv1alpha1.StudyJobList, error) {
 	result := &studyjobv1alpha1.StudyJobList{}
-	var ns string
-	if len(namespace) == 0 {
-		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-		ns = strings.TrimSpace(string(data))
-	} else {
-		ns = namespace[0]
-	}
+	ns := getNamespace(namespace...)
 	err := s.client.
 		Get().
 		Namespace(ns).
@@ -68,13 +62,7 @@ func (s *StudyjobClient) GetStudyJobList(namespace ...string) (*studyjobv1alpha1
 
 func (s *StudyjobClient) CreateStudyJob(studyJob *studyjobv1alpha1.StudyJob, namespace ...string) (*studyjobv1alpha1.StudyJob, error) {
 	result := &studyjobv1alpha1.StudyJob{}
-	var ns string
-	if len(namespace) == 0 {
-		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-		ns = strings.TrimSpace(string(data))
-	} else {
-		ns = namespace[0]
-	}
+	ns := getNamespace(namespace...)
 	err := s.client.
 		Post().
 		Namespace(ns).
@@ -86,13 +74,7 @@ func (s *StudyjobClient) CreateStudyJob(studyJob *studyjobv1alpha1.StudyJob, nam
 }
 
 func (s *StudyjobClient) GetWorkerTemplates(namespace ...string) (map[string]string, error) {
-	var ns string
-	if len(namespace) == 0 {
-		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-		ns = strings.TrimSpace(string(data))
-	} else {
-		ns = namespace[0]
-	}
+	ns := getNamespace(namespace...)
 	cm, err := s.clientset.CoreV1().ConfigMaps(ns).Get("worker-template", metav1.GetOptions{})
 	if err != nil {
 		return map[string]string{}, err
@@ -101,13 +83,7 @@ func (s *StudyjobClient) GetWorkerTemplates(namespace ...string) (map[string]str
 }
 
 func (s *StudyjobClient) UpdateWorkerTemplates(newWorkerTemplates map[string]string, namespace ...string) error {
-	var ns string
-	if len(namespace) == 0 {
-		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-		ns = strings.TrimSpace(string(data))
-	} else {
-		ns = namespace[0]
-	}
+	ns := getNamespace(namespace...)
 	cm, err := s.clientset.CoreV1().ConfigMaps(ns).Get("worker-template", metav1.GetOptions{})
 	if err != nil {
 		return err
@@ -118,13 +94,7 @@ func (s *StudyjobClient) UpdateWorkerTemplates(newWorkerTemplates map[string]str
 }
 
 func (s *StudyjobClient) GetMetricsCollectorTemplates(namespace ...string) (map[string]string, error) {
-	var ns string
-	if len(namespace) == 0 {
-		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-		ns = strings.TrimSpace(string(data))
-	} else {
-		ns = namespace[0]
-	}
+	ns := getNamespace(namespace...)
 	cm, err := s.clientset.CoreV1().ConfigMaps(ns).Get("metricscollector-template", metav1.GetOptions{})
 	if err != nil {
 		return map[string]string{}, err
@@ -133,13 +103,7 @@ func (s *StudyjobClient) GetMetricsCollectorTemplates(namespace ...string) (map[
 }
 
 func (s *StudyjobClient) UpdateMetricsCollectorTemplates(newMCTemplates map[string]string, namespace ...string) error {
-	var ns string
-	if len(namespace) == 0 {
-		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-		ns = strings.TrimSpace(string(data))
-	} else {
-		ns = namespace[0]
-	}
+	ns := getNamespace(namespace...)
 	cm, err := s.clientset.CoreV1().ConfigMaps(ns).Get("metricscollector-template", metav1.GetOptions{})
 	if err != nil {
 		return err
@@ -147,4 +111,12 @@ func (s *StudyjobClient) UpdateMetricsCollectorTemplates(newMCTemplates map[stri
 	cm.Data = newMCTemplates
 	_, err = s.clientset.CoreV1().ConfigMaps(ns).Update(cm)
 	return err
+}
+
+func getNamespace(namespace ...string) string {
+	if len(namespace) == 0 {
+		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		return strings.TrimSpace(string(data))
+	}
+	return namespace[0]
 }

--- a/pkg/manager/studyjobclient/studyjobclient.go
+++ b/pkg/manager/studyjobclient/studyjobclient.go
@@ -48,10 +48,15 @@ func NewStudyjobClient(config *rest.Config) (*StudyjobClient, error) {
 	}, nil
 }
 
-func (s *StudyjobClient) GetStudyJobList() (*studyjobv1alpha1.StudyJobList, error) {
+func (s *StudyjobClient) GetStudyJobList(namespace ...string) (*studyjobv1alpha1.StudyJobList, error) {
 	result := &studyjobv1alpha1.StudyJobList{}
-	data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-	ns := strings.TrimSpace(string(data))
+	var ns string
+	if namespace == nil {
+		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		ns = strings.TrimSpace(string(data))
+	} else {
+		ns = namespace[0]
+	}
 	err := s.client.
 		Get().
 		Namespace(ns).
@@ -61,10 +66,15 @@ func (s *StudyjobClient) GetStudyJobList() (*studyjobv1alpha1.StudyJobList, erro
 	return result, err
 }
 
-func (s *StudyjobClient) CreateStudyJob(studyJob *studyjobv1alpha1.StudyJob) (*studyjobv1alpha1.StudyJob, error) {
+func (s *StudyjobClient) CreateStudyJob(studyJob *studyjobv1alpha1.StudyJob, namespace ...string) (*studyjobv1alpha1.StudyJob, error) {
 	result := &studyjobv1alpha1.StudyJob{}
-	data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-	ns := strings.TrimSpace(string(data))
+	var ns string
+	if namespace == nil {
+		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		ns = strings.TrimSpace(string(data))
+	} else {
+		ns = namespace[0]
+	}
 	err := s.client.
 		Post().
 		Namespace(ns).
@@ -75,9 +85,14 @@ func (s *StudyjobClient) CreateStudyJob(studyJob *studyjobv1alpha1.StudyJob) (*s
 	return result, err
 }
 
-func (s *StudyjobClient) GetWorkerTemplates() (map[string]string, error) {
-	data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-	ns := strings.TrimSpace(string(data))
+func (s *StudyjobClient) GetWorkerTemplates(namespace ...string) (map[string]string, error) {
+	var ns string
+	if namespace == nil {
+		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		ns = strings.TrimSpace(string(data))
+	} else {
+		ns = namespace[0]
+	}
 	cm, err := s.clientset.CoreV1().ConfigMaps(ns).Get("worker-template", metav1.GetOptions{})
 	if err != nil {
 		return map[string]string{}, err
@@ -85,9 +100,14 @@ func (s *StudyjobClient) GetWorkerTemplates() (map[string]string, error) {
 	return cm.Data, nil
 }
 
-func (s *StudyjobClient) UpdateWorkerTemplates(newWorkerTemplates map[string]string) error {
-	data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-	ns := strings.TrimSpace(string(data))
+func (s *StudyjobClient) UpdateWorkerTemplates(newWorkerTemplates map[string]string, namespace ...string) error {
+	var ns string
+	if namespace == nil {
+		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		ns = strings.TrimSpace(string(data))
+	} else {
+		ns = namespace[0]
+	}
 	cm, err := s.clientset.CoreV1().ConfigMaps(ns).Get("worker-template", metav1.GetOptions{})
 	if err != nil {
 		return err
@@ -97,9 +117,14 @@ func (s *StudyjobClient) UpdateWorkerTemplates(newWorkerTemplates map[string]str
 	return err
 }
 
-func (s *StudyjobClient) GetMetricsCollectorTemplates() (map[string]string, error) {
-	data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-	ns := strings.TrimSpace(string(data))
+func (s *StudyjobClient) GetMetricsCollectorTemplates(namespace ...string) (map[string]string, error) {
+	var ns string
+	if namespace == nil {
+		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		ns = strings.TrimSpace(string(data))
+	} else {
+		ns = namespace[0]
+	}
 	cm, err := s.clientset.CoreV1().ConfigMaps(ns).Get("metricscollector-template", metav1.GetOptions{})
 	if err != nil {
 		return map[string]string{}, err
@@ -107,9 +132,14 @@ func (s *StudyjobClient) GetMetricsCollectorTemplates() (map[string]string, erro
 	return cm.Data, nil
 }
 
-func (s *StudyjobClient) UpdateMetricsCollectorTemplates(newMCTemplates map[string]string) error {
-	data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-	ns := strings.TrimSpace(string(data))
+func (s *StudyjobClient) UpdateMetricsCollectorTemplates(newMCTemplates map[string]string, namespace ...string) error {
+	var ns string
+	if namespace == nil {
+		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		ns = strings.TrimSpace(string(data))
+	} else {
+		ns = namespace[0]
+	}
 	cm, err := s.clientset.CoreV1().ConfigMaps(ns).Get("metricscollector-template", metav1.GetOptions{})
 	if err != nil {
 		return err

--- a/pkg/manager/studyjobclient/studyjobclient.go
+++ b/pkg/manager/studyjobclient/studyjobclient.go
@@ -51,7 +51,7 @@ func NewStudyjobClient(config *rest.Config) (*StudyjobClient, error) {
 func (s *StudyjobClient) GetStudyJobList(namespace ...string) (*studyjobv1alpha1.StudyJobList, error) {
 	result := &studyjobv1alpha1.StudyJobList{}
 	var ns string
-	if namespace == nil {
+	if len(namespace) == 0 {
 		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 		ns = strings.TrimSpace(string(data))
 	} else {
@@ -69,7 +69,7 @@ func (s *StudyjobClient) GetStudyJobList(namespace ...string) (*studyjobv1alpha1
 func (s *StudyjobClient) CreateStudyJob(studyJob *studyjobv1alpha1.StudyJob, namespace ...string) (*studyjobv1alpha1.StudyJob, error) {
 	result := &studyjobv1alpha1.StudyJob{}
 	var ns string
-	if namespace == nil {
+	if len(namespace) == 0 {
 		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 		ns = strings.TrimSpace(string(data))
 	} else {
@@ -87,7 +87,7 @@ func (s *StudyjobClient) CreateStudyJob(studyJob *studyjobv1alpha1.StudyJob, nam
 
 func (s *StudyjobClient) GetWorkerTemplates(namespace ...string) (map[string]string, error) {
 	var ns string
-	if namespace == nil {
+	if len(namespace) == 0 {
 		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 		ns = strings.TrimSpace(string(data))
 	} else {
@@ -102,7 +102,7 @@ func (s *StudyjobClient) GetWorkerTemplates(namespace ...string) (map[string]str
 
 func (s *StudyjobClient) UpdateWorkerTemplates(newWorkerTemplates map[string]string, namespace ...string) error {
 	var ns string
-	if namespace == nil {
+	if len(namespace) == 0 {
 		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 		ns = strings.TrimSpace(string(data))
 	} else {
@@ -119,7 +119,7 @@ func (s *StudyjobClient) UpdateWorkerTemplates(newWorkerTemplates map[string]str
 
 func (s *StudyjobClient) GetMetricsCollectorTemplates(namespace ...string) (map[string]string, error) {
 	var ns string
-	if namespace == nil {
+	if len(namespace) == 0 {
 		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 		ns = strings.TrimSpace(string(data))
 	} else {
@@ -134,7 +134,7 @@ func (s *StudyjobClient) GetMetricsCollectorTemplates(namespace ...string) (map[
 
 func (s *StudyjobClient) UpdateMetricsCollectorTemplates(newMCTemplates map[string]string, namespace ...string) error {
 	var ns string
-	if namespace == nil {
+	if len(namespace) == 0 {
 		data, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 		ns = strings.TrimSpace(string(data))
 	} else {


### PR DESCRIPTION
I added namespace parameter to studyJob client API functions.
After this we can use the API not only inside containers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/288)
<!-- Reviewable:end -->
