### PR TITLE
Adding distributed pytorch example for katib

### DIFF
--- a/examples/pytorchjob-example.yaml
+++ b/examples/pytorchjob-example.yaml
@@ -38,56 +38,38 @@ spec:
            pytorchReplicaSpecs:
             Master:
               replicas: 1
-              restartPolicy: Never
+              restartPolicy: OnFailure
               template:
                 spec:
                   containers:
                     - name: pytorch
-                      image: gcr.io/kubeflow-ci/pytorch-mnist-with-summary:0.4
+                      image: gcr.io/kubeflow-ci/pytorch-mnist-with-summary:1.0
                       imagePullPolicy: Always
                       command:
                         - "python"
-                        - "/opt/pytorch_dist_mnist/mnist_with_summary.py"
+                        - "/opt/pytorch_dist_mnist/dist_mnist_with_summary.py"
                         {{- with .HyperParameters}}
                         {{- range .}}
                         - "{{.Name}}={{.Value}}"
                         {{- end}}
                         {{- end}}
-  metricsCollectorSpec:
-    retain: true
-    goTemplate:
-      rawTemplate: |-
-        apiVersion: batch/v1beta1
-        kind: CronJob
-        metadata:
-          name: {{.WorkerID}}
-          namespace: kubeflow
-        spec:
-          schedule: "*/1 * * * *"
-          successfulJobsHistoryLimit: 15
-          failedJobsHistoryLimit: 15
-          jobTemplate:
-            spec:
+            Worker:
+              replicas: 2
+              restartPolicy: OnFailure
               template:
                 spec:
-                  serviceAccountName: metrics-collector
                   containers:
-                  - name: {{.WorkerID}}
-                    image: johnugeorge/metrics-collector
-                    args:
-                    - "./metricscollector"
-                    - "-s"
-                    - "{{.StudyID}}"
-                    - "-t"
-                    - "{{.TrialID}}"
-                    - "-w"
-                    - "{{.WorkerID}}"
-                    - "-k"
-                    - "{{.WorkerKind}}"
-                    - "-n"
-                    - "{{.NameSpace}}"
-                  restartPolicy: Never
-
+                    - name: pytorch
+                      image: gcr.io/kubeflow-ci/pytorch-mnist-with-summary:1.0
+                      imagePullPolicy: Always
+                      command:
+                        - "python"
+                        - "/opt/pytorch_dist_mnist/dist_mnist_with_summary.py"
+                        {{- with .HyperParameters}}
+                        {{- range .}}
+                        - "{{.Name}}={{.Value}}"
+                        {{- end}}
+                        {{- end}}
   suggestionSpec:
     suggestionAlgorithm: "random"
     requestNumber: 3


### PR DESCRIPTION
1. Added distributed pytorch mnist example
2. Since all changes are merged into the default metric collector,  overriden metric collector is removed from the example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/309)
<!-- Reviewable:end -->
