### PR TITLE
Add xgboost example using Bayesian optimization

### DIFF
--- a/examples/xgboost-bayesian-example.yaml
+++ b/examples/xgboost-bayesian-example.yaml
@@ -1,0 +1,70 @@
+apiVersion: "kubeflow.org/v1alpha1"
+kind: StudyJob
+metadata:
+  namespace: kubeflow
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: xgboost-example
+
+spec:
+  studyName: xgboost-example
+  owner: crd
+  optimizationtype: minimize
+  objectivevaluename: mean_absolute_error
+  optimizationgoal: 10000
+  requestcount: 10
+  metricsnames:
+    - mean_absolute_error
+
+  parameterconfigs:
+    - name: --learning-rate
+      parametertype: double
+      feasible:
+        min: "0.05"
+        max: "0.15"
+    - name: --n-estimators
+      parametertype: int
+      feasible:
+        min: "10000"
+        max: "30000"
+
+  workerSpec:
+    goTemplate:
+      rawTemplate: |-
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: {{.WorkerID}}
+          namespace: kubeflow
+        spec:
+          template:
+            spec:
+              containers:
+              - name: {{.WorkerID}}
+                image: gcr.io/kubeflow-examples/ames-housing:latest
+                volumeMounts:
+                - mountPath: "/mnt/xgboost"
+                  name: datadir
+                command:
+                - "python"
+                - "housing.py"
+                - "--train-input=/ames_dataset/train.csv"
+                - "--model-file=/ames_dataset/housing_{{.WorkerID}}.dat"
+                {{- with .HyperParameters}}
+                {{- range .}}
+                - "{{.Name}}={{.Value}}"
+                {{- end}}
+                {{- end}}
+              volumes:
+              - name: datadir
+                persistentVolumeClaim:
+                claimName: claim
+              restartPolicy: Never
+
+  suggestionSpec:
+    suggestionAlgorithm: "bayesianoptimization"
+    suggestionParameters:
+      -
+          name: "burn_in"
+          value: "5"
+    requestNumber: 10

--- a/examples/xgboost-bayesian-example.yaml
+++ b/examples/xgboost-bayesian-example.yaml
@@ -13,8 +13,6 @@ spec:
   objectivevaluename: mean_absolute_error
   optimizationgoal: 10000
   requestcount: 10
-  metricsnames:
-    - mean_absolute_error
 
   parameterconfigs:
     - name: --learning-rate
@@ -38,6 +36,9 @@ spec:
           namespace: kubeflow
         spec:
           template:
+            # The training worker uses the Ames housing example found at
+            # https://github.com/kubeflow/examples/tree/master/xgboost_ames_housing.
+            # Please first follow the steps and create the required prerequisites.
             spec:
               containers:
               - name: {{.WorkerID}}


### PR DESCRIPTION
This example uses the image built from https://github.com/kubeflow/examples/tree/master/xgboost_ames_housing.

The hyperparameters being tuned are:
- Number of boost trees
- learning rate

We are trying to minimize the mean_absolute_error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/320)
<!-- Reviewable:end -->
