### PR TITLE
omit empty fields for studyjob status

### DIFF
--- a/pkg/api/operators/apis/studyjob/v1alpha1/studyjob_types.go
+++ b/pkg/api/operators/apis/studyjob/v1alpha1/studyjob_types.go
@@ -59,8 +59,8 @@ type StudyJobStatus struct {
 
 	Condition                Condition  `json:"condition,omitempty"`
 	StudyID                  string     `json:"studyid,omitempty"`
-	SuggestionParameterID    string     `json:"suggestionParameterId"`
-	EarlyStoppingParameterID string     `json:"earlyStoppingParameterId"`
+	SuggestionParameterID    string     `json:"suggestionParameterId,omitempty"`
+	EarlyStoppingParameterID string     `json:"earlyStoppingParameterId,omitempty"`
 	Trials                   []TrialSet `json:"trials,omitempty"`
 	BestObjectiveValue       *float64   `json:"bestObjectiveValue,omitempty"`
 	BestTrialID              string     `json:"bestTrialId,omitempty"`


### PR DESCRIPTION
EarlyStoppingParameterID should not be shown in studyjob status to mislead user since EarlyStopping feature cannot work now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/336)
<!-- Reviewable:end -->
