### PR TITLE
Manual suggest

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -37,7 +37,7 @@ func (s *server) CreateStudy(ctx context.Context, in *api_pb.CreateStudyRequest)
 	if in.StudyConfig.JobId != "" {
 		get_study_id, _ := dbIf.GetStudyIDfromJob(in.StudyConfig.JobId)
 		if get_study_id != "" {
-			return &api_pb.CreateStudyReply{StudyId: get_study_id}, status.Errorf(codes.AlreadyExists, "Job UUID is already registerd.")
+			return &api_pb.CreateStudyReply{StudyId: get_study_id}, status.Errorf(codes.AlreadyExists, "StudyJob with UUID %s registered already", in.StudyConfig.JobId)
 		}
 	}
 	studyID, err := dbIf.CreateStudy(in.StudyConfig)

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -17,13 +17,22 @@ func TestCreateStudy(t *testing.T) {
 	mockDB := mockdb.NewMockVizierDBInterface(ctrl)
 	mockModelStore := mockmodelstore.NewMockModelStore(ctrl)
 	sid := "teststudy"
+	jobid := "teststudyjob"
 	sc := &api.StudyConfig{
 		Name:               "test",
 		Owner:              "admin",
 		OptimizationType:   1,
 		ObjectiveValueName: "obj_name",
+		JobId:              jobid,
+		JobType:            "HP",
 	}
 	dbIf = mockDB
+	mockDB.EXPECT().RegisterStudyJob(
+		jobid,
+		sid,
+		"HP",
+	).Return(nil)
+	mockDB.EXPECT().GetStudyIDfromJob(jobid).Return("", nil)
 	mockDB.EXPECT().CreateStudy(
 		sc,
 	).Return(sid, nil)

--- a/cmd/suggestion/manual/Dockerfile
+++ b/cmd/suggestion/manual/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:alpine AS build-env
+# The GOPATH in the image is /go.
+ADD . /go/src/github.com/kubeflow/katib
+WORKDIR /go/src/github.com/kubeflow/katib/cmd/suggestion/manual
+RUN go build -o manual
+
+FROM alpine:3.7
+WORKDIR /app
+COPY --from=build-env /go/src/github.com/kubeflow/katib/cmd/suggestion/manual /app/
+ENTRYPOINT ["./manual"]

--- a/cmd/suggestion/manual/main.go
+++ b/cmd/suggestion/manual/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"log"
+	"net"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+
+	pb "github.com/kubeflow/katib/pkg/api"
+	"github.com/kubeflow/katib/pkg/suggestion"
+)
+
+func main() {
+	listener, err := net.Listen("tcp", suggestion.DefaultPort)
+	if err != nil {
+		log.Fatalf("Failed to listen: %v", err)
+	}
+	size := 1<<31 - 1
+	s := grpc.NewServer(grpc.MaxRecvMsgSize(size), grpc.MaxSendMsgSize(size))
+	pb.RegisterSuggestionServer(s, suggestion.NewManualSuggestService())
+	reflection.Register(s)
+	log.Println("Manual Suggestion Service")
+	if err = s.Serve(listener); err != nil {
+		log.Fatalf("Failed to serve: %v", err)
+	}
+}

--- a/examples/MinikubeDemo.md
+++ b/examples/MinikubeDemo.md
@@ -173,7 +173,7 @@ You can
 * Rerun a best trial.
 
 In Manual Suggestion, only one trial will be created in a studyjob.
-RequestCount and RequestNumber in yaml will be ignored.
+RequestCount and RequestNumber in yaml will be rewrited to 1.
 
 ## UI
 You can check your study results with Web UI.

--- a/examples/MinikubeDemo.md
+++ b/examples/MinikubeDemo.md
@@ -160,6 +160,21 @@ In this demo, the eta is 3 and the R is 9.
 kubectl apply -f hypb-example.yaml
 ```
 
+### Manual suggestion
+Manual Suggestion is a special suggeston.
+Generate trial in two way in manual suggestion.
+
+* Specify all parameters manually. [manual-example.yaml](./manual-example.yaml)
+* Use Trial ID that is created in the past. [manual-example-tid.yaml](manual-example-tid.yaml) (You should replace STUDYID and TRIALID with valid values.)
+
+You can
+* Add a new trial to completed trial.
+* Set a initial value for hyper-parameter search manually.
+* Rerun a best trial.
+
+In Manual Suggestion, only one trial will be created in a studyjob.
+RequestCount and RequestNumber in yaml will be ignored.
+
 ## UI
 You can check your study results with Web UI.
 Acsess to `http://127.0.0.1:8000/katib`

--- a/examples/manual-example-tid.yaml
+++ b/examples/manual-example-tid.yaml
@@ -1,0 +1,42 @@
+apiVersion: "kubeflow.org/v1alpha1"
+kind: StudyJob
+metadata:
+  namespace: kubeflow
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: manual-example-tid
+spec:
+  reusestudyid: STUDYID
+  workerSpec:
+    goTemplate:
+        rawTemplate: |-
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: {{.WorkerID}}
+            namespace: kubeflow
+          spec:
+            template:
+              spec:
+                imagePullSecrets:
+                  - name: gitlabregcred
+                containers:
+                - name: {{.WorkerID}}
+                  image: katib/mxnet-mnist-example
+                  command:
+                  - "python"
+                  - "/mxnet/example/image-classification/train_mnist.py"
+                  - "--batch-size=32"
+                  {{- with .HyperParameters}}
+                  {{- range .}}
+                  - "{{.Name}}={{.Value}}"
+                  {{- end}}
+                  {{- end}}
+                restartPolicy: Never
+  suggestionSpec:
+    suggestionAlgorithm: "manual"
+    suggestionParameters:
+      - 
+          name: "trialid"
+          value: "TRIALID"
+    requestNumber: 1

--- a/examples/manual-example-tid.yaml
+++ b/examples/manual-example-tid.yaml
@@ -39,4 +39,3 @@ spec:
       - 
           name: "trialid"
           value: "TRIALID"
-    requestNumber: 1

--- a/examples/manual-example.yaml
+++ b/examples/manual-example.yaml
@@ -11,7 +11,6 @@ spec:
   optimizationtype: maximize
   objectivevaluename: Validation-accuracy
   optimizationgoal: 0.99
-  requestcount: 10
   metricsnames:
     - accuracy
   parameterconfigs:
@@ -70,4 +69,3 @@ spec:
       - 
           name: "--optimizer"
           value: "sgd"
-    requestNumber: 1

--- a/examples/manual-example.yaml
+++ b/examples/manual-example.yaml
@@ -1,0 +1,73 @@
+apiVersion: "kubeflow.org/v1alpha1"
+kind: StudyJob
+metadata:
+  namespace: kubeflow
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: manual-example
+spec:
+  studyName: manual-example
+  owner: crd
+  optimizationtype: maximize
+  objectivevaluename: Validation-accuracy
+  optimizationgoal: 0.99
+  requestcount: 10
+  metricsnames:
+    - accuracy
+  parameterconfigs:
+    - name: --lr
+      parametertype: double
+      feasible:
+        min: "0.01"
+        max: "0.03"
+    - name: --num-layers
+      parametertype: int
+      feasible:
+        min: "1"
+        max: "4"
+    - name: --optimizer
+      parametertype: categorical
+      feasible:
+        list:
+        - sgd
+        - adam
+        - ftrl
+  workerSpec:
+    goTemplate:
+        rawTemplate: |-
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: {{.WorkerID}}
+            namespace: kubeflow
+          spec:
+            template:
+              spec:
+                imagePullSecrets:
+                  - name: gitlabregcred
+                containers:
+                - name: {{.WorkerID}}
+                  image: katib/mxnet-mnist-example
+                  command:
+                  - "python"
+                  - "/mxnet/example/image-classification/train_mnist.py"
+                  - "--batch-size=32"
+                  {{- with .HyperParameters}}
+                  {{- range .}}
+                  - "{{.Name}}={{.Value}}"
+                  {{- end}}
+                  {{- end}}
+                restartPolicy: Never
+  suggestionSpec:
+    suggestionAlgorithm: "manual"
+    suggestionParameters:
+      - 
+          name: "--lr"
+          value: "0.02"
+      - 
+          name: "--num-layers"
+          value: "2"
+      - 
+          name: "--optimizer"
+          value: "sgd"
+    requestNumber: 1

--- a/manifests/vizier/suggestion/manual/deployment.yaml
+++ b/manifests/vizier/suggestion/manual/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: vizier-suggestion-manual
+  namespace: kubeflow
+  labels:
+    app: vizier
+    component: suggestion-manual
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: vizier-suggestion-manual
+      labels:
+        app: vizier
+        component: suggestion-manual
+    spec:
+      containers:
+      - name: vizier-suggestion-manual
+        image: katib/suggestion-manual
+        ports:
+        - name: api
+          containerPort: 6789
+        imagePullPolicy: Always
+#        resources:
+#          requests:
+#            cpu: 500m
+#            memory: 500M
+#          limits:
+#            cpu: 500m
+#            memory: 500M

--- a/manifests/vizier/suggestion/manual/service.yaml
+++ b/manifests/vizier/suggestion/manual/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vizier-suggestion-manual
+  namespace: kubeflow
+  labels:
+    app: vizier
+    component: suggestion-manual
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6789
+      protocol: TCP
+      name: api
+  selector:
+    app: vizier
+    component: suggestion-manual

--- a/pkg/api/api.pb.go
+++ b/pkg/api/api.pb.go
@@ -2302,6 +2302,7 @@ type ManagerClient interface {
 	CreateStudy(ctx context.Context, in *CreateStudyRequest, opts ...grpc.CallOption) (*CreateStudyReply, error)
 	// *
 	// Get a Study Config from DB by ID of Study.
+	// Return AlreadyExists error when the Job UID in GetStudyRequest is already exist in DB.
 	GetStudy(ctx context.Context, in *GetStudyRequest, opts ...grpc.CallOption) (*GetStudyReply, error)
 	// *
 	// Delete a Study from DB by Study ID.
@@ -2609,6 +2610,7 @@ type ManagerServer interface {
 	CreateStudy(context.Context, *CreateStudyRequest) (*CreateStudyReply, error)
 	// *
 	// Get a Study Config from DB by ID of Study.
+	// Return AlreadyExists error when the Job UID in GetStudyRequest is already exist in DB.
 	GetStudy(context.Context, *GetStudyRequest) (*GetStudyReply, error)
 	// *
 	// Delete a Study from DB by Study ID.

--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -17,6 +17,7 @@ service Manager {
     /**
      * Create a Study from Study Config.
      * Generate a unique ID and store the Study to DB.
+     * Return AlreadyExists error when the Job UID in GetStudyRequest is already exist in DB.
      */
     rpc CreateStudy(CreateStudyRequest) returns (CreateStudyReply){
         option (google.api.http) = {
@@ -26,7 +27,6 @@ service Manager {
     };
     /** 
      * Get a Study Config from DB by ID of Study.
-     * Return AlreadyExists error when the Job UID in GetStudyRequest is already exist in DB.
      */
     rpc GetStudy(GetStudyRequest) returns (GetStudyReply){
         option (google.api.http) = {

--- a/pkg/api/api.proto
+++ b/pkg/api/api.proto
@@ -26,6 +26,7 @@ service Manager {
     };
     /** 
      * Get a Study Config from DB by ID of Study.
+     * Return AlreadyExists error when the Job UID in GetStudyRequest is already exist in DB.
      */
     rpc GetStudy(GetStudyRequest) returns (GetStudyReply){
         option (google.api.http) = {

--- a/pkg/api/api.swagger.json
+++ b/pkg/api/api.swagger.json
@@ -211,7 +211,7 @@
     },
     "/api/Manager/GetStudy/{study_id}": {
       "get": {
-        "summary": "* \nGet a Study Config from DB by ID of Study.",
+        "summary": "* \nGet a Study Config from DB by ID of Study.\nReturn AlreadyExists error when the Job UID in GetStudyRequest is already exist in DB.",
         "operationId": "GetStudy",
         "responses": {
           "200": {

--- a/pkg/api/gen-doc/api.md
+++ b/pkg/api/gen-doc/api.md
@@ -1448,7 +1448,7 @@ https://cloud.google.com/service-infrastructure/docs/service-management/referenc
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
 | CreateStudy | [CreateStudyRequest](#api.CreateStudyRequest) | [CreateStudyReply](#api.CreateStudyRequest) | Create a Study from Study Config. Generate a unique ID and store the Study to DB. |
-| GetStudy | [GetStudyRequest](#api.GetStudyRequest) | [GetStudyReply](#api.GetStudyRequest) | Get a Study Config from DB by ID of Study. |
+| GetStudy | [GetStudyRequest](#api.GetStudyRequest) | [GetStudyReply](#api.GetStudyRequest) | Get a Study Config from DB by ID of Study. Return AlreadyExists error when the Job UID in GetStudyRequest is already exist in DB. |
 | DeleteStudy | [DeleteStudyRequest](#api.DeleteStudyRequest) | [DeleteStudyReply](#api.DeleteStudyRequest) | Delete a Study from DB by Study ID. |
 | GetStudyList | [GetStudyListRequest](#api.GetStudyListRequest) | [GetStudyListReply](#api.GetStudyListRequest) | Get all Study Configs from DB. |
 | CreateTrial | [CreateTrialRequest](#api.CreateTrialRequest) | [CreateTrialReply](#api.CreateTrialRequest) | Create a Trial from Trial Config. Generate a unique ID and store the Trial to DB. |

--- a/pkg/api/gen-doc/index.html
+++ b/pkg/api/gen-doc/index.html
@@ -3008,7 +3008,8 @@ Generate a unique ID and store the Study to DB.</p></td>
                 <td>GetStudy</td>
                 <td><a href="#api.GetStudyRequest">GetStudyRequest</a></td>
                 <td><a href="#api.GetStudyReply">GetStudyReply</a></td>
-                <td><p>Get a Study Config from DB by ID of Study.</p></td>
+                <td><p>Get a Study Config from DB by ID of Study.
+Return AlreadyExists error when the Job UID in GetStudyRequest is already exist in DB.</p></td>
               </tr>
             
               <tr>

--- a/pkg/api/operators/apis/studyjob/v1alpha1/studyjob_types.go
+++ b/pkg/api/operators/apis/studyjob/v1alpha1/studyjob_types.go
@@ -39,6 +39,7 @@ type StudyJobSpec struct {
 	EarlyStoppingSpec    *EarlyStoppingSpec    `json:"earlyStoppingSpec,omitempty"`
 	MetricsCollectorSpec *MetricsCollectorSpec `json:"metricsCollectorSpec,omitempty"`
 	NasConfig            *NasConfig            `json:"nasConfig,omitempty"`
+	ReuseStudyID         string                `json:"reusestudyid,omitempty"`
 }
 
 // StudyJobStatus defines the observed state of StudyJob

--- a/pkg/api/python/api_pb2.py
+++ b/pkg/api/python/api_pb2.py
@@ -4330,6 +4330,7 @@ try:
     def GetStudy(self, request, context):
       """* 
       Get a Study Config from DB by ID of Study.
+      Return AlreadyExists error when the Job UID in GetStudyRequest is already exist in DB.
       """
       context.set_code(grpc.StatusCode.UNIMPLEMENTED)
       context.set_details('Method not implemented!')
@@ -4759,6 +4760,7 @@ try:
     def GetStudy(self, request, context):
       """* 
       Get a Study Config from DB by ID of Study.
+      Return AlreadyExists error when the Job UID in GetStudyRequest is already exist in DB.
       """
       context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
     def DeleteStudy(self, request, context):
@@ -4901,6 +4903,7 @@ try:
     def GetStudy(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
       """* 
       Get a Study Config from DB by ID of Study.
+      Return AlreadyExists error when the Job UID in GetStudyRequest is already exist in DB.
       """
       raise NotImplementedError()
     GetStudy.future = None

--- a/pkg/api/python/api_pb2_grpc.py
+++ b/pkg/api/python/api_pb2_grpc.py
@@ -165,6 +165,7 @@ class ManagerServicer(object):
   def GetStudy(self, request, context):
     """* 
     Get a Study Config from DB by ID of Study.
+    Return AlreadyExists error when the Job UID in GetStudyRequest is already exist in DB.
     """
     context.set_code(grpc.StatusCode.UNIMPLEMENTED)
     context.set_details('Method not implemented!')

--- a/pkg/controller/studyjob/katib_api_util.go
+++ b/pkg/controller/studyjob/katib_api_util.go
@@ -59,8 +59,8 @@ func initializeStudy(instance *katibv1alpha1.StudyJob, ns string) (bool, error) 
 		instance.Status.StudyID = instance.Spec.ReuseStudyID
 	} else {
 		studyConfig, err := populateStudyConf(instance)
-		instance.Status.Condition = katibv1alpha1.ConditionFailed
 		if err != nil {
+			instance.Status.Condition = katibv1alpha1.ConditionFailed
 			return true, err
 		}
 		log.Printf("Create Study %s", studyConfig.Name)

--- a/pkg/controller/studyjob/katib_api_util.go
+++ b/pkg/controller/studyjob/katib_api_util.go
@@ -67,7 +67,7 @@ func initializeStudy(instance *katibv1alpha1.StudyJob, ns string) (bool, error) 
 				//Duplicate create study request
 				return false, nil
 			} else {
-				log.Printf("Create Study Error: ", err)
+				log.Printf("Create Study Error: %v", err)
 				return true, err
 			}
 		}

--- a/pkg/controller/studyjob/katib_api_util.go
+++ b/pkg/controller/studyjob/katib_api_util.go
@@ -35,6 +35,11 @@ func initializeStudy(instance *katibv1alpha1.StudyJob, ns string) (bool, error) 
 	if instance.Spec.SuggestionSpec.SuggestionAlgorithm == "" {
 		instance.Spec.SuggestionSpec.SuggestionAlgorithm = "manual"
 	}
+	if instance.Spec.SuggestionSpec.SuggestionAlgorithm == "manual" {
+		//Manual Suggestion is an one-shot job.
+		instance.Spec.RequestCount = 1
+		instance.Spec.SuggestionSpec.RequestNumber = 1
+	}
 	instance.Status.Condition = katibv1alpha1.ConditionRunning
 	conn, err := grpc.Dial(pkg.ManagerAddr, grpc.WithInsecure())
 	if err != nil {

--- a/pkg/db/db_init.go
+++ b/pkg/db/db_init.go
@@ -7,7 +7,8 @@ import (
 
 func (d *dbConn) DBInit() {
 	db := d.db
-	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS studies
+	var err error
+	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS studies
 		(id CHAR(16) PRIMARY KEY,
 		name VARCHAR(255),
 		owner VARCHAR(255),
@@ -16,10 +17,18 @@ func (d *dbConn) DBInit() {
 		parameter_configs TEXT,
 		tags TEXT,
 		objective_value_name VARCHAR(255),
-		metrics TEXT,
-		job_id TEXT)`)
+		metrics TEXT)`)
 	if err != nil {
 		log.Fatalf("Error creating studies table: %v", err)
+	}
+
+	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS studyjobs
+		(job_uuid CHAR(36) PRIMARY KEY,
+		study_id CHAR(16),
+		job_type TEXT,
+		FOREIGN KEY(study_id) REFERENCES studies(id) ON DELETE CASCADE)`)
+	if err != nil {
+		log.Fatalf("Error creating studyjob table: %v", err)
 	}
 
 	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS study_permissions

--- a/pkg/mock/db/db.go
+++ b/pkg/mock/db/db.go
@@ -158,6 +158,32 @@ func (mr *MockVizierDBInterfaceMockRecorder) GetStudyConfig(arg0 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStudyConfig", reflect.TypeOf((*MockVizierDBInterface)(nil).GetStudyConfig), arg0)
 }
 
+// GetStudyIDfromJob mocks base method
+func (m *MockVizierDBInterface) GetStudyIDfromJob(arg0 string) (string, error) {
+	ret := m.ctrl.Call(m, "GetStudyIDfromJob", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStudyIDfromJob indicates an expected call of GetStudyIDfromJob
+func (mr *MockVizierDBInterfaceMockRecorder) GetStudyIDfromJob(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStudyIDfromJob", reflect.TypeOf((*MockVizierDBInterface)(nil).GetStudyIDfromJob), arg0)
+}
+
+// GetStudyJobList mocks base method
+func (m *MockVizierDBInterface) GetStudyJobList(arg0 string) ([]string, error) {
+	ret := m.ctrl.Call(m, "GetStudyJobList", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStudyJobList indicates an expected call of GetStudyJobList
+func (mr *MockVizierDBInterfaceMockRecorder) GetStudyJobList(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStudyJobList", reflect.TypeOf((*MockVizierDBInterface)(nil).GetStudyJobList), arg0)
+}
+
 // GetStudyList mocks base method
 func (m *MockVizierDBInterface) GetStudyList() ([]string, error) {
 	ret := m.ctrl.Call(m, "GetStudyList")
@@ -299,6 +325,18 @@ func (m *MockVizierDBInterface) GetWorkerTimestamp(arg0 string) (*time.Time, err
 // GetWorkerTimestamp indicates an expected call of GetWorkerTimestamp
 func (mr *MockVizierDBInterfaceMockRecorder) GetWorkerTimestamp(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkerTimestamp", reflect.TypeOf((*MockVizierDBInterface)(nil).GetWorkerTimestamp), arg0)
+}
+
+// RegisterStudyJob mocks base method
+func (m *MockVizierDBInterface) RegisterStudyJob(arg0, arg1, arg2 string) error {
+	ret := m.ctrl.Call(m, "RegisterStudyJob", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RegisterStudyJob indicates an expected call of RegisterStudyJob
+func (mr *MockVizierDBInterfaceMockRecorder) RegisterStudyJob(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterStudyJob", reflect.TypeOf((*MockVizierDBInterface)(nil).RegisterStudyJob), arg0, arg1, arg2)
 }
 
 // SelectOne mocks base method

--- a/pkg/suggestion/manual_service.go
+++ b/pkg/suggestion/manual_service.go
@@ -1,0 +1,157 @@
+package suggestion
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/kubeflow/katib/pkg"
+	"github.com/kubeflow/katib/pkg/api"
+	"google.golang.org/grpc"
+)
+
+type ManualSuggestService struct {
+}
+
+func NewManualSuggestService() *ManualSuggestService {
+	return &ManualSuggestService{}
+}
+
+func (s *ManualSuggestService) ValidateParameter(pvalue string, pc *api.ParameterConfig) error {
+	switch pc.ParameterType {
+	case api.ParameterType_INT:
+		imin, _ := strconv.Atoi(pc.Feasible.Min)
+		imax, _ := strconv.Atoi(pc.Feasible.Max)
+		ivalue, err := strconv.Atoi(pvalue)
+		if err != nil {
+			return err
+		}
+		if ivalue < imin || ivalue > imax {
+			return fmt.Errorf("%s :Parameter outof range", pc.Name)
+		}
+	case api.ParameterType_DOUBLE:
+		dmin, _ := strconv.ParseFloat(pc.Feasible.Min, 64)
+		dmax, _ := strconv.ParseFloat(pc.Feasible.Max, 64)
+		dvalue, err := strconv.ParseFloat(pvalue, 64)
+		if err != nil {
+			return err
+		}
+		if dvalue < dmin || dvalue > dmax {
+			return fmt.Errorf("%s :Parameter outof range", pc.Name)
+		}
+	case api.ParameterType_CATEGORICAL:
+		ok := false
+		for _, l := range pc.Feasible.List {
+			if l == pvalue {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return fmt.Errorf("%s :Parameter outof range", pc.Name)
+		}
+	case api.ParameterType_DISCRETE:
+		ok := false
+		for _, l := range pc.Feasible.List {
+			if l == pvalue {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return fmt.Errorf("%s :Parameter outof range", pc.Name)
+		}
+	}
+	return nil
+}
+
+func (s *ManualSuggestService) ParseParameters(ctx context.Context, c api.ManagerClient, studyId string, sconf *api.StudyConfig, params []*api.SuggestionParameter) (*api.Trial, error) {
+	mparam := map[string]string{}
+	var tid string
+	for _, param := range params {
+		if strings.ToLower(param.Name) == "trialid" {
+			tid = param.Value
+		} else if param.Name == "SuggestionCount" {
+			scount, _ := strconv.Atoi(param.Value)
+			if scount > 0 {
+				return nil, nil
+			}
+		} else {
+			mparam[param.Name] = param.Value
+		}
+	}
+	if tid != "" {
+		gtreq := &api.GetTrialRequest{
+			TrialId: tid,
+		}
+		gtrep, err := c.GetTrial(ctx, gtreq)
+		if err != nil {
+			return nil, err
+		}
+		return gtrep.Trial, nil
+	}
+	trial := &api.Trial{
+		StudyId:      studyId,
+		ParameterSet: make([]*api.Parameter, len(sconf.ParameterConfigs.Configs)),
+	}
+	for i, pc := range sconf.ParameterConfigs.Configs {
+		if pvalue, ok := mparam[pc.Name]; ok {
+			err := s.ValidateParameter(pvalue, pc)
+			if err != nil {
+				return nil, err
+			}
+			trial.ParameterSet[i] = &api.Parameter{}
+			trial.ParameterSet[i].Name = pc.Name
+			trial.ParameterSet[i].Value = pvalue
+		} else {
+			return nil, fmt.Errorf("%s :Parameter is not includes", pc.Name)
+		}
+	}
+	ctreq := &api.CreateTrialRequest{
+		Trial: trial,
+	}
+	ctret, err := c.CreateTrial(ctx, ctreq)
+	if err != nil {
+		return nil, err
+	}
+	trial.TrialId = ctret.TrialId
+	return trial, nil
+}
+
+func (s *ManualSuggestService) GetSuggestions(ctx context.Context, in *api.GetSuggestionsRequest) (*api.GetSuggestionsReply, error) {
+	conn, err := grpc.Dial(pkg.ManagerAddr, grpc.WithInsecure())
+	if err != nil {
+		log.Fatalf("could not connect: %v", err)
+		return &api.GetSuggestionsReply{}, err
+	}
+	defer conn.Close()
+	c := api.NewManagerClient(conn)
+	screq := &api.GetStudyRequest{
+		StudyId: in.StudyId,
+	}
+	scr, err := c.GetStudy(ctx, screq)
+	if err != nil {
+		log.Fatalf("GetStudyConf failed: %v", err)
+		return &api.GetSuggestionsReply{}, err
+	}
+	spreq := &api.GetSuggestionParametersRequest{
+		ParamId: in.ParamId,
+	}
+	spr, err := c.GetSuggestionParameters(ctx, spreq)
+	if err != nil {
+		log.Printf("GetParameter failed: %v", err)
+		return &api.GetSuggestionsReply{}, err
+	}
+	t, err := s.ParseParameters(ctx, c, in.StudyId, scr.StudyConfig, spr.SuggestionParameters)
+	if err != nil {
+		log.Printf("Parse Parameter failed: %v", err)
+		return &api.GetSuggestionsReply{}, err
+	}
+	sT := []*api.Trial{}
+	if t != nil {
+		sT = append(sT, t)
+	}
+	return &api.GetSuggestionsReply{Trials: sT}, nil
+}

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -360,7 +360,7 @@ func (k *KatibUIHandler) UpdateWorkerTemplate(w http.ResponseWriter, r *http.Req
 	}
 	err := k.studyjobClient.UpdateWorkerTemplates(wt)
 	if err != nil {
-		log.Print("fail to UpdateWorkerTemplate %v", err)
+		log.Printf("fail to UpdateWorkerTemplate %v", err)
 	}
 }
 
@@ -400,7 +400,7 @@ func (k *KatibUIHandler) UpdateMetricsCollectorTemplate(w http.ResponseWriter, r
 	}
 	err := k.studyjobClient.UpdateMetricsCollectorTemplates(mt)
 	if err != nil {
-		log.Print("fail to UpdateMetricsCollectorTemplate %v", err)
+		log.Printf("fail to UpdateMetricsCollectorTemplate %v", err)
 	}
 }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -35,6 +35,7 @@ echo "Building REST API for core image..."
 docker build -t ${PREFIX}/vizier-core-rest -f ${CMD_PREFIX}/manager-rest/Dockerfile .
 
 echo "Building suggestion images..."
+docker build -t ${PREFIX}/suggestion-manual:${DTAG} -f ${CMD_PREFIX}/suggestion/manual/Dockerfile .
 docker build -t ${PREFIX}/suggestion-random -f ${CMD_PREFIX}/suggestion/random/Dockerfile .
 docker build -t ${PREFIX}/suggestion-grid -f ${CMD_PREFIX}/suggestion/grid/Dockerfile .
 docker build -t ${PREFIX}/suggestion-hyperband -f ${CMD_PREFIX}/suggestion/hyperband/Dockerfile .

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -28,6 +28,7 @@ kubectl apply -f manifests/vizier/db
 kubectl apply -f manifests/vizier/core
 kubectl apply -f manifests/vizier/core-rest
 kubectl apply -f manifests/vizier/ui
+kubectl apply -f manifests/vizier/suggestion/manual
 kubectl apply -f manifests/vizier/suggestion/random
 kubectl apply -f manifests/vizier/suggestion/grid
 kubectl apply -f manifests/vizier/suggestion/hyperband

--- a/test/scripts/build-suggestion-manual.sh
+++ b/test/scripts/build-suggestion-manual.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This shell script is used to build an image from our argo workflow
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export PATH=${GOPATH}/bin:/usr/local/go/bin:${PATH}
+REGISTRY="${GCP_REGISTRY}"
+PROJECT="${GCP_PROJECT}"
+GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}-suggestion-manual
+VERSION=$(git describe --tags --always --dirty)
+
+echo "Activating service-account"
+gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+
+echo "Copy source to GOPATH"
+mkdir -p ${GO_DIR}
+cp -r cmd ${GO_DIR}/cmd
+cp -r pkg ${GO_DIR}/pkg
+cp -r vendor ${GO_DIR}/vendor
+
+cd ${GO_DIR}
+
+cp cmd/suggestion/manual/Dockerfile .
+gcloud container builds submit . --tag=${REGISTRY}/${REPO_NAME}/suggestion-manual:${VERSION} --project=${PROJECT}

--- a/test/scripts/run-tests.sh
+++ b/test/scripts/run-tests.sh
@@ -68,6 +68,7 @@ sed -i -e "s@image: katib\/vizier-core-rest@image: ${REGISTRY}\/${REPO_NAME}\/vi
 sed -i -e "s@image: katib\/katib-ui@image: ${REGISTRY}\/${REPO_NAME}\/katib-ui:${VERSION}@" manifests/vizier/ui/deployment.yaml
 sed -i -e "s@type: NodePort@type: ClusterIP@" -e "/nodePort: 30678/d" manifests/vizier/core/service.yaml
 sed -i -e "s@image: katib\/studyjob-controller@image: ${REGISTRY}\/${REPO_NAME}\/studyjob-controller:${VERSION}@" manifests/studyjobcontroller/studyjobcontroller.yaml
+sed -i -e "s@image: katib\/suggestion-manual@image: ${REGISTRY}\/${REPO_NAME}\/suggestion-manual:${VERSION}@" manifests/vizier/suggestion/manual/deployment.yaml
 sed -i -e "s@image: katib\/suggestion-random@image: ${REGISTRY}\/${REPO_NAME}\/suggestion-random:${VERSION}@" manifests/vizier/suggestion/random/deployment.yaml
 sed -i -e "s@image: katib\/suggestion-grid@image: ${REGISTRY}\/${REPO_NAME}\/suggestion-grid:${VERSION}@" manifests/vizier/suggestion/grid/deployment.yaml
 sed -i -e "s@image: katib\/suggestion-hyperband@image: ${REGISTRY}\/${REPO_NAME}\/suggestion-hyperband:${VERSION}@" manifests/vizier/suggestion/hyperband/deployment.yaml

--- a/test/scripts/run-tests.sh
+++ b/test/scripts/run-tests.sh
@@ -77,6 +77,7 @@ sed -i -e "s@image: katib\/earlystopping-medianstopping@image: ${REGISTRY}\/${RE
 sed -i -e '/volumeMounts:/,$d' manifests/vizier/db/deployment.yaml
 
 cat manifests/vizier/core/deployment.yaml
+kubectl delete ns kubeflow --ignore-not-found
 ./scripts/deploy.sh
 
 TIMEOUT=120

--- a/test/scripts/unit-test.sh
+++ b/test/scripts/unit-test.sh
@@ -50,6 +50,7 @@ kubectl config set-credentials temp-admin --username=admin --client-certificate=
 kubectl config set-context temp-context --cluster=$(kubectl config get-clusters | grep ${CLUSTER_NAME}) --user=temp-admin
 kubectl config use-context temp-context
 
+kubectl delete pod mysql-ut --ignore-not-found
 kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Pod

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -226,6 +226,10 @@
                     template: "build-cli",
                   },
                   {
+                    name: "build-suggestion-manual",
+                    template: "build-suggestion-manual",
+                  },
+                  {
                     name: "build-suggestion-random",
                     template: "build-suggestion-random",
                   },
@@ -349,6 +353,9 @@
             $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTemplate("build-cli", testWorkerImage, [
               "test/scripts/build-cli.sh",
             ]),  // build-cli
+            $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTemplate("build-suggestion-manual", testWorkerImage, [
+              "test/scripts/build-suggestion-manual.sh",
+            ]),  // build-suggestion-manual
             $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTemplate("build-suggestion-random", testWorkerImage, [
               "test/scripts/build-suggestion-random.sh",
             ]),  // build-suggestion-random


### PR DESCRIPTION
You can run one-shot suggestion.
Generate trial in two way in manual suggestion.
* Specify all parameters manually.  https://github.com/YujiOshima/hp-tuning/blob/eff191d3f4191e8097f26914f8931aca181fe911/examples/manual-example.yaml
* Use Trial ID that is created in the past. https://github.com/YujiOshima/hp-tuning/blob/eff191d3f4191e8097f26914f8931aca181fe911/examples/manual-example-tid.yaml

By this PR, you can reuse studyID. ref https://github.com/YujiOshima/hp-tuning/blob/eff191d3f4191e8097f26914f8931aca181fe911/examples/manual-example-tid.yaml#L9
It enables
* Add a new trial to completed trial.
* Set a initial value of hyper-parameter serch by manual suggestion. Then run a bayse-opt suggestion.
* Run multiple suggestion paralelly.
* Rerun a best trial.

Related #122 #346 

Signed-off-by: YujiOshima <yuji.oshima0x3fd@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/352)
<!-- Reviewable:end -->
