### PR TITLE
Properly initialize CI cluster credential

### DIFF
--- a/test/scripts/unit-test.sh
+++ b/test/scripts/unit-test.sh
@@ -34,21 +34,9 @@ gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS
 
 echo "Configuring kubectl"
 
-gcloud container clusters describe ${CLUSTER_NAME} \
-  --zone ${ZONE} \
-  --format 'value(masterAuth.clusterCaCertificate)'|  base64 -d > ca.pem
-
-gcloud container clusters describe ${CLUSTER_NAME} \
-  --zone ${ZONE} \
-  --format 'value(masterAuth.clientCertificate)'  |  base64 -d > client.pem
-
-gcloud container clusters describe ${CLUSTER_NAME} \
-  --zone ${ZONE} \
-  --format 'value(masterAuth.clientKey)' |  base64 -d > key.rsa
-
-kubectl config set-credentials temp-admin --username=admin --client-certificate=./client.pem --client-key=./key.rsa
-kubectl config set-context temp-context --cluster=$(kubectl config get-clusters | grep ${CLUSTER_NAME}) --user=temp-admin
-kubectl config use-context temp-context
+gcloud --project ${PROJECT} container clusters get-credentials ${CLUSTER_NAME} \
+  --zone ${ZONE}
+kubectl config set-context $(kubectl config current-context) --namespace=default
 
 kubectl apply -f - <<EOF
 apiVersion: v1


### PR DESCRIPTION
It has been using the cluster where argo ran

Hopefully fixes #359

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/360)
<!-- Reviewable:end -->
