### PR TITLE
Use log.Printf instead of log.Print

### DIFF
--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -360,7 +360,7 @@ func (k *KatibUIHandler) UpdateWorkerTemplate(w http.ResponseWriter, r *http.Req
 	}
 	err := k.studyjobClient.UpdateWorkerTemplates(wt)
 	if err != nil {
-		log.Print("fail to UpdateWorkerTemplate %v", err)
+		log.Printf("fail to UpdateWorkerTemplate %v", err)
 	}
 }
 
@@ -400,7 +400,7 @@ func (k *KatibUIHandler) UpdateMetricsCollectorTemplate(w http.ResponseWriter, r
 	}
 	err := k.studyjobClient.UpdateMetricsCollectorTemplates(mt)
 	if err != nil {
-		log.Print("fail to UpdateMetricsCollectorTemplate %v", err)
+		log.Printf("fail to UpdateMetricsCollectorTemplate %v", err)
 	}
 }
 


### PR DESCRIPTION
In order to supress "Print call has possible formatting directive" warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/364)
<!-- Reviewable:end -->
