### PR TITLE
Include go dependencies in developer-guide.md

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -2,7 +2,9 @@
 
 ## Requirements
 
-- Docker (17.05 or later.)
+- [Go](https://golang.org/)
+- [Dep](https://golang.github.io/dep/)
+- [Docker](https://docs.docker.com/) (17.05 or later.)
 
 ## Build from source code
 


### PR DESCRIPTION
Easier for new-to-go developers to get up and running.

Looks like Google protobufs might also be a dependency?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/369)
<!-- Reviewable:end -->
