### PR TITLE
Delete modeldb from unit tests

### DIFF
--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -8,14 +8,12 @@ import (
 
 	api "github.com/kubeflow/katib/pkg/api"
 	mockdb "github.com/kubeflow/katib/pkg/mock/db"
-	mockmodelstore "github.com/kubeflow/katib/pkg/mock/modelstore"
 )
 
 func TestCreateStudy(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockDB := mockdb.NewMockVizierDBInterface(ctrl)
-	mockModelStore := mockmodelstore.NewMockModelStore(ctrl)
 	sid := "teststudy"
 	sc := &api.StudyConfig{
 		Name:               "test",
@@ -27,16 +25,9 @@ func TestCreateStudy(t *testing.T) {
 	mockDB.EXPECT().CreateStudy(
 		sc,
 	).Return(sid, nil)
-	ssr := &api.SaveStudyRequest{
-		StudyName:   "test",
-		Owner:       "admin",
-		Description: "StudyID: " + sid,
-	}
-	mockModelStore.EXPECT().SaveStudy(ssr).Return(nil)
 
-	s := &server{
-		msIf: mockModelStore,
-	}
+	s := &server{}
+
 	req := &api.CreateStudyRequest{StudyConfig: sc}
 	ret, err := s.CreateStudy(context.Background(), req)
 	if err != nil {
@@ -50,11 +41,8 @@ func TestGetStudies(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockDB := mockdb.NewMockVizierDBInterface(ctrl)
-	mockModelStore := mockmodelstore.NewMockModelStore(ctrl)
 	sid := []string{"teststudy1", "teststudy2"}
-	s := &server{
-		msIf: mockModelStore,
-	}
+	s := &server{}
 	dbIf = mockDB
 	sc := []*api.StudyConfig{
 		&api.StudyConfig{

--- a/pkg/db/interface_test.go
+++ b/pkg/db/interface_test.go
@@ -12,7 +12,6 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/protobuf/jsonpb"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 
 	api "github.com/kubeflow/katib/pkg/api"
 )

--- a/pkg/db/interface_test.go
+++ b/pkg/db/interface_test.go
@@ -12,8 +12,8 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/protobuf/jsonpb"
-
 	api "github.com/kubeflow/katib/pkg/api"
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 var dbInterface, mysqlInterface VizierDBInterface

--- a/test/scripts/create-cluster.sh
+++ b/test/scripts/create-cluster.sh
@@ -33,7 +33,7 @@ echo "Creating GPU cluster"
 gcloud --project ${PROJECT} beta container clusters create ${CLUSTER_NAME} \
     --zone ${ZONE} \
     --accelerator type=nvidia-tesla-k80,count=1 \
-    --cluster-version 1.10
+    --cluster-version 1.11
 echo "Configuring kubectl"
 gcloud --project ${PROJECT} container clusters get-credentials ${CLUSTER_NAME} \
     --zone ${ZONE}


### PR DESCRIPTION
I deleted ModelDB from unit tests in db. 
Right now, Katib doesn't use ModelDB.
As well, I changed version of cluster to 1.11 to pass presubmit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/391)
<!-- Reviewable:end -->
