### PR TITLE
Metric collector must fail on error

### DIFF
--- a/cmd/metricscollector/main.go
+++ b/cmd/metricscollector/main.go
@@ -78,8 +78,7 @@ func main() {
 	}
 	mls, err := mc.CollectWorkerLog(*workerID, *workerKind, screp.StudyConfig.ObjectiveValueName, screp.StudyConfig.Metrics, *namespace)
 	if err != nil {
-		log.Printf("Failed to collect logs: %v", err)
-		return
+		log.Fatalf("Failed to collect logs: %v", err)
 	}
 	rmreq := &api.ReportMetricsLogsRequest{
 		StudyId:        *studyID,
@@ -87,8 +86,7 @@ func main() {
 	}
 	_, err = c.ReportMetricsLogs(ctx, rmreq)
 	if err != nil {
-		log.Printf("Failed to Report logs: %v", err)
-		return
+		log.Fatalf("Failed to Report logs: %v", err)
 	}
 	log.Printf("Metrics reported. :\n%v", mls)
 	return

--- a/manifests/studyjobcontroller/metricsControllerConfigMap.yaml
+++ b/manifests/studyjobcontroller/metricsControllerConfigMap.yaml
@@ -16,6 +16,7 @@ data:
       failedJobsHistoryLimit: 1
       jobTemplate:
         spec:
+          backoffLimit: 0
           template:
             spec:
               serviceAccountName: metrics-collector


### PR DESCRIPTION
Instead of returning, metric collector must fail if unable to collect logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/405)
<!-- Reviewable:end -->
