### PR TITLE
Fix path to API protobuf in developer guide

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -22,8 +22,7 @@ You can build all images from source.
 
 ## Implement new suggestion algorithm
 
-Suggestion API is defined as GRPC service at `API/api.proto`.
-You can attach new algorithm easily.
+Suggestion API is defined as GRPC service at `pkg/api/api.proto`. Source code is [here](https://github.com/kubeflow/katib/blob/master/pkg/api/api.proto). You can attach new algorithm easily.
 
 - implement suggestion API
 - make k8s service named vizier-suggestion-{ algorithm-name } and expose port 6789


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/403

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/415)
<!-- Reviewable:end -->
