### PR TITLE
Fix the package version in training container

### DIFF
--- a/examples/NAS-training-containers/cifar10/requirements.txt
+++ b/examples/NAS-training-containers/cifar10/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow-gpu
-keras
+tensorflow-gpu==1.12.0
+keras=2.2.4

--- a/examples/NAS-training-containers/cifar10/requirements.txt
+++ b/examples/NAS-training-containers/cifar10/requirements.txt
@@ -1,2 +1,2 @@
 tensorflow-gpu==1.12.0
-keras=2.2.4
+keras==2.2.4


### PR DESCRIPTION
Fix the package version of tensorflow-gpu to be 1.12.0 and keras to be 2.2.4.

The training container uses CUAD 9.0, which is compatible with tensorflow-gpu 1.12. The default version of tensorflow-gpu in pip has just changed to 1.13.1, which uses CUDA 10.0. Not specifying the tf version will lead to cuda library not found error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/418)
<!-- Reviewable:end -->
