### PR TITLE
Add fault tolerance support for trial failure

### DIFF
--- a/pkg/suggestion/NAS_Reinforcement_Learning/README.md
+++ b/pkg/suggestion/NAS_Reinforcement_Learning/README.md
@@ -122,6 +122,8 @@ This neural architecture can be visualized as
 
 ## To Do
 1. Add 'micro' mode, which means searching for a neural cell instead of the whole neural network.
-2. Change LSTM cell from self defined functions in LSTM.py to `tf.nn.rnn_cell.LSTMCell`
-3. Store the suggestion checkpoint to PVC to protect against unexpected nasrl service pod restarts
-4. Add `RequestCount` into API so that the suggestion can clean the information of completed studies.
+2. Add supoort for recurrent neural networks and build a training container for the Penn Treebank task.
+3. Add parameter sharing, if possible.
+4. Change LSTM cell from self defined functions in LSTM.py to `tf.nn.rnn_cell.LSTMCell`
+5. Store the suggestion checkpoint to PVC to protect against unexpected nasrl service pod restarts
+6. Add `RequestCount` into API so that the suggestion can clean the information of completed studies.

--- a/pkg/suggestion/NAS_Reinforcement_Learning/README.md
+++ b/pkg/suggestion/NAS_Reinforcement_Learning/README.md
@@ -121,6 +121,7 @@ This neural architecture can be visualized as
 ![a neural netowrk architecure example](example.png)
 
 ## To Do
-1. Change LSTM cell from self defined functions in LSTM.py to `tf.nn.rnn_cell.LSTMCell`
-2. Store the suggestion checkpoint to PVC to protect against unexpected nasrl service pod restarts
-3. Add `RequestCount` into API so that the suggestion can clean the information of completed studies.
+1. Add 'micro' mode, which means searching for a nerual network cell instead of the whole nerual netowrk.
+2. Change LSTM cell from self defined functions in LSTM.py to `tf.nn.rnn_cell.LSTMCell`
+3. Store the suggestion checkpoint to PVC to protect against unexpected nasrl service pod restarts
+4. Add `RequestCount` into API so that the suggestion can clean the information of completed studies.

--- a/pkg/suggestion/NAS_Reinforcement_Learning/README.md
+++ b/pkg/suggestion/NAS_Reinforcement_Learning/README.md
@@ -121,7 +121,7 @@ This neural architecture can be visualized as
 ![a neural netowrk architecure example](example.png)
 
 ## To Do
-1. Add 'micro' mode, which means searching for a nerual network cell instead of the whole nerual netowrk.
+1. Add 'micro' mode, which means searching for a neural cell instead of the whole neural network.
 2. Change LSTM cell from self defined functions in LSTM.py to `tf.nn.rnn_cell.LSTMCell`
 3. Store the suggestion checkpoint to PVC to protect against unexpected nasrl service pod restarts
 4. Add `RequestCount` into API so that the suggestion can clean the information of completed studies.

--- a/pkg/suggestion/nasrl_service.py
+++ b/pkg/suggestion/nasrl_service.py
@@ -285,7 +285,7 @@ class NasrlService(api_pb2_grpc.SuggestionServicer):
                     # 2. If calling GetEvaluationResult() for RECALL_LIMIT times all return None, 
                     #    then respawn the previous trials
                     # 3. If respawning the trials for RESPAWAN_LIMIT times still cannot collect valid results,
-                    #    then fail the task becuase it may indicate that the training container has errors.
+                    #    then fail the task because it may indicate that the training container has errors.
 
                     recall_count = 0
                     while result is None:

--- a/pkg/suggestion/nasrl_service.py
+++ b/pkg/suggestion/nasrl_service.py
@@ -284,7 +284,7 @@ class NasrlService(api_pb2_grpc.SuggestionServicer):
                     # 1. Try to call GetEvaluationResult() again
                     # 2. If calling GetEvaluationResult() for RECALL_LIMIT times all return None, 
                     #    then respawn the previous trials
-                    # 3. If respawning the trials for RESPAWAN_LIMIT times still cannot collect valid results,
+                    # 3. If respawning the trials for RESPAWN_LIMIT times still cannot collect valid results,
                     #    then fail the task because it may indicate that the training container has errors.
 
                     recall_count = 0


### PR DESCRIPTION
In practice, even the training container is correctly implemented, trials may fail due to a variety of reasons such as insufficient GPU memories. If trials fail, `GetEvaluationResult()` will return None. The suggestion should be able to handle that exception. My solution is: 

- If not all the trials failed, use the metrics of the successful ones to do the update
- If all the trials failed:
  1. Firstly, try to respawn the previous trials after sleeping for `RESPAWN_SLEEP` seconds.
  2. If respawning the trials for `RESPAWN_LIMIT` times still cannot collect valid results, then fail the task because it may indicate that the training container has errors.

Besides, this PR also fixes some small bugs and adds some important TODOs.

An example of fault handling output
```
---------------------------------------------------------------------------
Suggestion Step 1 for StudyJob nas-example-1 (ID: e9850c4a885acb19)
---------------------------------------------------------------------------
>>> 2 Trials succeeded, 1 Trials failed:
p55d6ef3720fec95: Failed
n8f94938e123b38d: 0.6475
g30851e3c259d07a: 0.6709
The average is 0.6592

>>> Suggestion updated. LSTM Controller Reward: 44.43968200683594
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/424)
<!-- Reviewable:end -->
