### PR TITLE
Change datadir for avoid failure due to lost+found

### DIFF
--- a/manifests/vizier/db/deployment.yaml
+++ b/manifests/vizier/db/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       containers:
       - name: vizier-db
         image: mysql:8.0.3
+        args:
+        - --datadir
+        - /var/lib/mysql/datadir
         env:
           - name: MYSQL_ROOT_PASSWORD
             valueFrom:


### PR DESCRIPTION
I try to run katib on GKE, but vizier-db cannot start with following error.
```
Initializing database
2019-03-14T07:13:42.050153Z 0 [Note] Basedir set to /usr/
2019-03-14T07:13:42.050470Z 0 [Warning] The syntax '--symbolic-links/-s' is deprecated and will be removed in a future release
2019-03-14T07:13:42.051712Z 0 [ERROR] --initialize specified but the data directory has files in it. Aborting.
2019-03-14T07:13:42.051812Z 0 [ERROR] Aborting
```
It is due to `lost+found` directory in mounted path.

This PR is a same solution as below.
https://github.com/kubeflow/kubeflow/blob/4e6c645eeee0915999c33bf6772d2a996cb55ee4/kubeflow/katib/vizier.libsonnet#L303-L306

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/432)
<!-- Reviewable:end -->
