### PR TITLE
Fix labels matching the job operator implementation

### DIFF
--- a/pkg/manager/metricscollector/metricscollector.go
+++ b/pkg/manager/metricscollector/metricscollector.go
@@ -39,11 +39,11 @@ func NewMetricsCollector() (*MetricsCollector, error) {
 func (d *MetricsCollector) CollectWorkerLog(wID string, wkind string, objectiveValueName string, metrics []string, namespace string) (*api.MetricsLogSet, error) {
 	labelMap := make(map[string]string)
 	if wkind == studyjob.TFJobWorker {
-		labelMap["tf_job_name"] = wID
-		labelMap["tf_job_role"] = "master"
+		labelMap["tf-job-name"] = wID
+		labelMap["tf-job-role"] = "master"
 	} else if wkind == studyjob.PyTorchJobWorker {
-		labelMap["pytorch_job_name"] = wID
-		labelMap["pytorch_job_role"] = "master"
+		labelMap["pytorch-job-name"] = wID
+		labelMap["pytorch-job-role"] = "master"
 	} else {
 		labelMap["job-name"] = wID
 	}


### PR DESCRIPTION
Labels were renamed in job operators:
Related: https://github.com/kubeflow/pytorch-operator/pull/146 https://github.com/kubeflow/tf-operator/pull/951

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/447)
<!-- Reviewable:end -->
