### PR TITLE
Add serviceAccountName in UI deployment

### DIFF
--- a/manifests/v1alpha1/vizier/ui/deployment.yaml
+++ b/manifests/v1alpha1/vizier/ui/deployment.yaml
@@ -23,6 +23,7 @@ spec:
         ports:
         - name: ui
           containerPort: 80
+      serviceAccountName: katib-ui
 #        resources:
 #          requests:
 #            cpu: 500m


### PR DESCRIPTION
We missed Service Account in Katib UI deployment. 
We should add it, since we have rbac for the UI: https://github.com/kubeflow/katib/blob/master/manifests/v1alpha1/vizier/ui/rbac.yaml#L19

/assign @hougangliu @YujiOshima 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/469)
<!-- Reviewable:end -->
