### PR TITLE
refactor(suggestion): Use interface

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,6 +34,14 @@
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
+  digest = "1:9187ad53cd8b43cc82d1615ca6319503735fd87cd2b4dbeb80c57831e9affd79"
+  name = "github.com/caicloud/serving-controller"
+  packages = ["pkg/consts"]
+  pruneopts = "T"
+  revision = "bec825cac979e73109541ca7518dd6b96ce9e68a"
+  version = "v0.0.1-rc.5"
+
+[[projects]]
   digest = "1:9f42202ac457c462ad8bb9642806d275af9ab4850cf0b1960b9c6f083d4a309a"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -51,6 +59,14 @@
   pruneopts = "T"
   revision = "85d198d05a92d31823b852b4a5928114912e8949"
   version = "v2.9.0"
+
+[[projects]]
+  digest = "1:7fc160b460a6fc506b37fcca68332464c3f2cd57b6e3f111f26c5bbfd2d5518e"
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
 
 [[projects]]
   digest = "1:2cd7915ab26ede7d95b8749e6b1f933f1c6d5398030684e6505940a10f31cfda"
@@ -261,6 +277,25 @@
   version = "v0.5.0"
 
 [[projects]]
+  digest = "1:071bcbf82c289fba4d3f63c876bf4f0ba7eda625cd60795e0a03ccbf949e517a"
+  name = "github.com/hashicorp/hcl"
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token",
+  ]
+  pruneopts = "T"
+  revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:8f20c8dd713564fa97299fbcb77d729c6de9c33f3222812a76e6ecfaef80fd61"
   name = "github.com/hpcloud/tail"
   packages = [
@@ -326,6 +361,14 @@
   version = "v0.4.0"
 
 [[projects]]
+  digest = "1:d7cc16f6f66fd3f5864ff77480288704b02e5263f6f243dae62b43fdf4bb638e"
+  name = "github.com/magiconair/properties"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "de8848e004dd33dc07a2947b3d76f618a7fc7ef1"
+  version = "v1.8.1"
+
+[[projects]]
   branch = "master"
   digest = "1:4be65cb3a11626a0d89fc72b34f62a8768040512d45feb086184ac30fdfbef65"
   name = "github.com/mailru/easyjson"
@@ -352,6 +395,14 @@
   packages = ["."]
   pruneopts = "T"
   revision = "81af80346b1a01caae0cbc27fd3c1ba5b11e189f"
+
+[[projects]]
+  digest = "1:53bc4cd4914cd7cd52139990d5170d6dc99067ae31c56530621b18b35fc30318"
+  name = "github.com/mitchellh/mapstructure"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
+  version = "v1.1.2"
 
 [[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
@@ -428,6 +479,14 @@
   version = "v1.2"
 
 [[projects]]
+  digest = "1:abc5966f690dedc4943d8bed4cdddb0c4fb6e4490ff7702fa4ce2a7c35efbaf7"
+  name = "github.com/pelletier/go-toml"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "728039f679cbcd4f6a54e080d2219a4c4928c546"
+  version = "v1.4.0"
+
+[[projects]]
   branch = "master"
   digest = "1:0c29d499ffc3b9f33e7136444575527d0c3a9463a89b3cbeda0523b737f910b3"
   name = "github.com/petar/GoLLRB"
@@ -483,6 +542,14 @@
   version = "v1.2.1"
 
 [[projects]]
+  digest = "1:08d65904057412fc0270fc4812a1c90c594186819243160dc779a402d4b6d0bc"
+  name = "github.com/spf13/cast"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "8c9545af88b134710ab1cd196795e7f2388358d7"
+  version = "v1.3.0"
+
+[[projects]]
   digest = "1:8be8b3743fc9795ec21bbd3e0fc28ff6234018e1a269b0a7064184be95ac13e0"
   name = "github.com/spf13/cobra"
   packages = ["."]
@@ -491,12 +558,28 @@
   version = "v0.0.3"
 
 [[projects]]
+  digest = "1:1b753ec16506f5864d26a28b43703c58831255059644351bbcb019b843950900"
+  name = "github.com/spf13/jwalterweatherman"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "94f6ae3ed3bceceafa716478c5fbf8d29ca601a1"
+  version = "v1.1.0"
+
+[[projects]]
   digest = "1:0f775ea7a72e30d5574267692aaa9ff265aafd15214a7ae7db26bc77f2ca04dc"
   name = "github.com/spf13/pflag"
   packages = ["."]
   pruneopts = "T"
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
+
+[[projects]]
+  digest = "1:2eeca55c5718eafa5ee2538e920ca43a30c334acfed5404ac650ecda1c06e97c"
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "9e56dacc08fbbf8c9ee2dbc717553c758ce42bc9"
+  version = "v1.3.2"
 
 [[projects]]
   digest = "1:365b8ecb35a5faf5aa0ee8d798548fc9cd4200cb95d77a5b0b285ac881bae499"
@@ -1059,6 +1142,7 @@
   analyzer-version = 1
   input-imports = [
     "git.apache.org/thrift.git/lib/go/thrift",
+    "github.com/caicloud/serving-controller/pkg/consts",
     "github.com/emicklei/go-restful",
     "github.com/go-sql-driver/mysql",
     "github.com/golang/glog",
@@ -1076,6 +1160,7 @@
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
     "github.com/pressly/chi",
+    "github.com/spf13/viper",
     "golang.org/x/net/context",
     "google.golang.org/genproto/googleapis/api/annotations",
     "google.golang.org/grpc",

--- a/cmd/katib-controller/v1alpha2/main.go
+++ b/cmd/katib-controller/v1alpha2/main.go
@@ -39,17 +39,17 @@ func main() {
 	logf.SetLogger(logf.ZapLogger(false))
 	log := logf.Log.WithName("entrypoint")
 
-	var fakeExperimentSuggestion string
+	var experimentSuggestionName string
 
-	flag.StringVar(&fakeExperimentSuggestion, "experiment-suggestion-implementation",
+	flag.StringVar(&experimentSuggestionName, "experiment-suggestion-name",
 		"default", "The implementation of suggestion interface in experiment controller (default|fake)")
 
 	flag.Parse()
 
-	viper.Set(consts.ConfigFakeExperimentSuggestion, fakeExperimentSuggestion)
+	viper.Set(consts.ConfigExperimentSuggestionName, experimentSuggestionName)
 	log.Info("Config:",
-		consts.ConfigFakeExperimentSuggestion,
-		viper.GetString(consts.ConfigFakeExperimentSuggestion))
+		consts.ConfigExperimentSuggestionName,
+		viper.GetString(consts.ConfigExperimentSuggestionName))
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()

--- a/cmd/katib-controller/v1alpha2/main.go
+++ b/cmd/katib-controller/v1alpha2/main.go
@@ -39,10 +39,10 @@ func main() {
 	logf.SetLogger(logf.ZapLogger(false))
 	log := logf.Log.WithName("entrypoint")
 
-	var fakeExperimentSuggestion bool
+	var fakeExperimentSuggestion string
 
-	flag.BoolVar(&fakeExperimentSuggestion, "fake-experiment-suggestion",
-		false, "Use the fake suggestion in experiment controller")
+	flag.StringVar(&fakeExperimentSuggestion, "experiment-suggestion-implementation",
+		"default", "The implementation of suggestion interface in experiment controller (default|fake)")
 
 	flag.Parse()
 

--- a/cmd/katib-controller/v1alpha2/main.go
+++ b/cmd/katib-controller/v1alpha2/main.go
@@ -20,49 +20,70 @@ limitations under the License.
 package main
 
 import (
-	"log"
+	"flag"
+	"os"
 
-	"github.com/kubeflow/katib/pkg/api/operators/apis"
-	controller "github.com/kubeflow/katib/pkg/controller/v1alpha2"
+	"github.com/spf13/viper"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+
+	"github.com/kubeflow/katib/pkg/api/operators/apis"
+	controller "github.com/kubeflow/katib/pkg/controller/v1alpha2"
+	"github.com/kubeflow/katib/pkg/controller/v1alpha2/consts"
 )
 
 func main() {
 	logf.SetLogger(logf.ZapLogger(false))
+	log := logf.Log.WithName("entrypoint")
+
+	var fakeExperimentSuggestion bool
+
+	flag.BoolVar(&fakeExperimentSuggestion, "fake-experiment-suggestion",
+		false, "Use the fake suggestion in experiment controller")
+
+	flag.Parse()
+
+	viper.Set(consts.ConfigFakeExperimentSuggestion, fakeExperimentSuggestion)
+	log.Info("Config:",
+		consts.ConfigFakeExperimentSuggestion,
+		viper.GetString(consts.ConfigFakeExperimentSuggestion))
+
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
-		log.Printf("config.GetConfig()")
-		log.Fatal(err)
+		log.Error(err, "Fail to get the config")
+		os.Exit(1)
 	}
 
 	// Create a new katib controller to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{})
 	if err != nil {
-		log.Printf("manager.New")
-		log.Fatal(err)
+		log.Error(err, "unable add APIs to scheme")
+		os.Exit(1)
 	}
 
-	log.Printf("Registering Components.")
+	log.Info("Registering Components.")
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Printf("apis.AddToScheme")
-		log.Fatal(err)
+		log.Error(err, "Fail to create the manager")
+		os.Exit(1)
 	}
 
-	// Setup katib controller
+	// Setup all Controllers
+	log.Info("Setting up controller")
 	if err := controller.AddToManager(mgr); err != nil {
-		log.Printf("controller.AddToManager(mgr)")
-		log.Fatal(err)
+		log.Error(err, "unable to register controllers to the manager")
+		os.Exit(1)
 	}
 
-	log.Printf("Starting the Cmd.")
-
-	// Starting the katib controller
-	log.Fatal(mgr.Start(signals.SetupSignalHandler()))
+	// Start the Cmd
+	log.Info("Starting the Cmd.")
+	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+		log.Error(err, "unable to run the manager")
+		os.Exit(1)
+	}
 }

--- a/pkg/controller/v1alpha2/consts/const.go
+++ b/pkg/controller/v1alpha2/consts/const.go
@@ -1,5 +1,5 @@
 package consts
 
 const (
-	ConfigFakeExperimentSuggestion string = "fake-experiment-suggestion"
+	ConfigExperimentSuggestionName string = "experiment-suggestion-name"
 )

--- a/pkg/controller/v1alpha2/consts/const.go
+++ b/pkg/controller/v1alpha2/consts/const.go
@@ -1,0 +1,5 @@
+package consts
+
+const (
+	ConfigFakeExperimentSuggestion string = "fake-experiment-suggestion"
+)

--- a/pkg/controller/v1alpha2/experiment/experiment_controller.go
+++ b/pkg/controller/v1alpha2/experiment/experiment_controller.go
@@ -83,7 +83,7 @@ func newSuggestion(config string) suggestion.Suggestion {
 		return suggestion.New()
 	default:
 		log.Info("No valid name specified, using the default suggestion implementation",
-			"implementation", implementation)
+			"implementation", config)
 		return suggestion.New()
 	}
 }

--- a/pkg/controller/v1alpha2/experiment/experiment_controller.go
+++ b/pkg/controller/v1alpha2/experiment/experiment_controller.go
@@ -37,8 +37,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
 
-	experimentv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/experiment/v1alpha2"
-	trialv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/trial/v1alpha2"
+	experimentsv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/experiment/v1alpha2"
+	trialsv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/trial/v1alpha2"
 	"github.com/kubeflow/katib/pkg/controller/v1alpha2/consts"
 	"github.com/kubeflow/katib/pkg/controller/v1alpha2/experiment/suggestion"
 	suggestionfake "github.com/kubeflow/katib/pkg/controller/v1alpha2/experiment/suggestion/fake"
@@ -85,7 +85,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to Experiment
-	err = c.Watch(&source.Kind{Type: &experimentv1alpha2.Experiment{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(&source.Kind{Type: &experimentsv1alpha2.Experiment{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		log.Error(err, "Experiment watch failed")
 		return err
@@ -93,10 +93,10 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// Watch for trials for the experiments
 	err = c.Watch(
-		&source.Kind{Type: &trialv1alpha2.Trial{}},
+		&source.Kind{Type: &trialsv1alpha2.Trial{}},
 		&handler.EnqueueRequestForOwner{
 			IsController: true,
-			OwnerType:    &experimentv1alpha2.Experiment{},
+			OwnerType:    &experimentsv1alpha2.Experiment{},
 		})
 
 	if err != nil {
@@ -118,7 +118,7 @@ func addWebhook(mgr manager.Manager) error {
 		Mutating().
 		Operations(admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update).
 		WithManager(mgr).
-		ForType(&experimentv1alpha2.Experiment{}).
+		ForType(&experimentsv1alpha2.Experiment{}).
 		Handlers(&experimentDefaulter{}).
 		Build()
 	if err != nil {
@@ -129,7 +129,7 @@ func addWebhook(mgr manager.Manager) error {
 		Validating().
 		Operations(admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update).
 		WithManager(mgr).
-		ForType(&experimentv1alpha2.Experiment{}).
+		ForType(&experimentsv1alpha2.Experiment{}).
 		Handlers(&experimentValidator{}).
 		Build()
 	if err != nil {
@@ -139,11 +139,11 @@ func addWebhook(mgr manager.Manager) error {
 		CertDir: "/tmp/cert",
 		BootstrapOptions: &webhook.BootstrapOptions{
 			Secret: &types.NamespacedName{
-				Namespace: os.Getenv(experimentv1alpha2.DefaultKatibNamespaceEnvName),
+				Namespace: os.Getenv(experimentsv1alpha2.DefaultKatibNamespaceEnvName),
 				Name:      katibControllerName,
 			},
 			Service: &webhook.Service{
-				Namespace: os.Getenv(experimentv1alpha2.DefaultKatibNamespaceEnvName),
+				Namespace: os.Getenv(experimentsv1alpha2.DefaultKatibNamespaceEnvName),
 				Name:      katibControllerName,
 				Selectors: map[string]string{
 					"app": katibControllerName,
@@ -179,7 +179,7 @@ type ReconcileExperiment struct {
 func (r *ReconcileExperiment) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the Experiment instance
 	logger := log.WithValues("Experiment", request.NamespacedName)
-	original := &experimentv1alpha2.Experiment{}
+	original := &experimentsv1alpha2.Experiment{}
 	requeue := false
 	err := r.Get(context.TODO(), request.NamespacedName, original)
 	if err != nil {
@@ -240,10 +240,10 @@ func (r *ReconcileExperiment) Reconcile(request reconcile.Request) (reconcile.Re
 	return reconcile.Result{Requeue: requeue}, nil
 }
 
-func (r *ReconcileExperiment) ReconcileExperiment(instance *experimentv1alpha2.Experiment) error {
+func (r *ReconcileExperiment) ReconcileExperiment(instance *experimentsv1alpha2.Experiment) error {
 
 	logger := log.WithValues("Experiment", types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()})
-	trials := &trialv1alpha2.TrialList{}
+	trials := &trialsv1alpha2.TrialList{}
 	labels := map[string]string{"experiment": instance.Name}
 	lo := &client.ListOptions{}
 	lo.MatchingLabels(labels).InNamespace(instance.Namespace)
@@ -265,7 +265,7 @@ func (r *ReconcileExperiment) ReconcileExperiment(instance *experimentv1alpha2.E
 	return nil
 }
 
-func (r *ReconcileExperiment) ReconcileTrials(instance *experimentv1alpha2.Experiment) error {
+func (r *ReconcileExperiment) ReconcileTrials(instance *experimentsv1alpha2.Experiment) error {
 
 	logger := log.WithValues("Experiment", types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()})
 
@@ -315,7 +315,7 @@ func (r *ReconcileExperiment) ReconcileTrials(instance *experimentv1alpha2.Exper
 
 }
 
-func (r *ReconcileExperiment) createTrials(instance *experimentv1alpha2.Experiment, addCount int) error {
+func (r *ReconcileExperiment) createTrials(instance *experimentsv1alpha2.Experiment, addCount int) error {
 
 	logger := log.WithValues("Experiment", types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()})
 	trials, err := r.GetSuggestions(instance, addCount)
@@ -332,7 +332,7 @@ func (r *ReconcileExperiment) createTrials(instance *experimentv1alpha2.Experime
 	return nil
 }
 
-func (r *ReconcileExperiment) deleteTrials(instance *experimentv1alpha2.Experiment, deleteCount int) error {
+func (r *ReconcileExperiment) deleteTrials(instance *experimentsv1alpha2.Experiment, deleteCount int) error {
 
 	return nil
 }

--- a/pkg/controller/v1alpha2/experiment/experiment_controller.go
+++ b/pkg/controller/v1alpha2/experiment/experiment_controller.go
@@ -66,17 +66,26 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 		Client: mgr.GetClient(),
 		scheme: mgr.GetScheme(),
 	}
+	imp := viper.GetString(consts.ConfigExperimentSuggestionName)
+	r.Suggestion = newSuggestion(imp)
+	return r
+}
+
+// newSuggestion returns the new Suggestion for the given config.
+func newSuggestion(implementation string) suggestion.Suggestion {
 	// If the flag is set in CLI, use the fake implementation.
-	imp := viper.GetString(consts.ConfigFakeExperimentSuggestion)
-	switch imp {
+	switch implementation {
 	case "fake":
 		log.Info("Using the fake suggestion implementation")
-		r.Suggestion = suggestionfake.New()
-	default:
+		return suggestionfake.New()
+	case "default":
 		log.Info("Using the default suggestion implementation")
-		r.Suggestion = suggestion.New()
+		return suggestion.New()
+	default:
+		log.Info("No valid name specified, using the default suggestion implementation",
+			"implementation", implementation)
+		return suggestion.New()
 	}
-	return r
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler

--- a/pkg/controller/v1alpha2/experiment/experiment_controller.go
+++ b/pkg/controller/v1alpha2/experiment/experiment_controller.go
@@ -63,14 +63,18 @@ func Add(mgr manager.Manager) error {
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	r := &ReconcileExperiment{
-		Client:     mgr.GetClient(),
-		scheme:     mgr.GetScheme(),
-		Suggestion: suggestion.New(),
+		Client: mgr.GetClient(),
+		scheme: mgr.GetScheme(),
 	}
 	// If the flag is set in CLI, use the fake implementation.
-	if viper.GetBool(consts.ConfigFakeExperimentSuggestion) {
+	imp := viper.GetString(consts.ConfigFakeExperimentSuggestion)
+	switch imp {
+	case "fake":
 		log.Info("Using the fake suggestion implementation")
 		r.Suggestion = suggestionfake.New()
+	default:
+		log.Info("Using the default suggestion implementation")
+		r.Suggestion = suggestion.New()
 	}
 	return r
 }

--- a/pkg/controller/v1alpha2/experiment/experiment_controller.go
+++ b/pkg/controller/v1alpha2/experiment/experiment_controller.go
@@ -72,9 +72,9 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 }
 
 // newSuggestion returns the new Suggestion for the given config.
-func newSuggestion(implementation string) suggestion.Suggestion {
-	// If the flag is set in CLI, use the fake implementation.
-	switch implementation {
+func newSuggestion(config string) suggestion.Suggestion {
+	// Use different implementation according to the configuration.
+	switch config {
 	case "fake":
 		log.Info("Using the fake suggestion implementation")
 		return suggestionfake.New()

--- a/pkg/controller/v1alpha2/experiment/suggestion/fake/fake.go
+++ b/pkg/controller/v1alpha2/experiment/suggestion/fake/fake.go
@@ -1,7 +1,7 @@
 package fake
 
 import (
-	experimentv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/experiment/v1alpha2"
+	experimentsv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/experiment/v1alpha2"
 	api_pb "github.com/kubeflow/katib/pkg/api/v1alpha2"
 	"github.com/kubeflow/katib/pkg/controller/v1alpha2/experiment/suggestion"
 )
@@ -13,6 +13,6 @@ func New() suggestion.Suggestion {
 	return &Fake{}
 }
 
-func (k *Fake) GetSuggestions(instance *experimentv1alpha2.Experiment, addCount int) ([]*api_pb.Trial, error) {
+func (k *Fake) GetSuggestions(instance *experimentsv1alpha2.Experiment, addCount int) ([]*api_pb.Trial, error) {
 	return nil, nil
 }

--- a/pkg/controller/v1alpha2/experiment/suggestion/fake/fake.go
+++ b/pkg/controller/v1alpha2/experiment/suggestion/fake/fake.go
@@ -1,0 +1,18 @@
+package fake
+
+import (
+	experimentv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/experiment/v1alpha2"
+	api_pb "github.com/kubeflow/katib/pkg/api/v1alpha2"
+	"github.com/kubeflow/katib/pkg/controller/v1alpha2/experiment/suggestion"
+)
+
+type Fake struct {
+}
+
+func New() suggestion.Suggestion {
+	return &Fake{}
+}
+
+func (k *Fake) GetSuggestions(instance *experimentv1alpha2.Experiment, addCount int) ([]*api_pb.Trial, error) {
+	return nil, nil
+}

--- a/pkg/controller/v1alpha2/experiment/suggestion/suggestion.go
+++ b/pkg/controller/v1alpha2/experiment/suggestion/suggestion.go
@@ -3,12 +3,12 @@ package suggestion
 import (
 	"fmt"
 
-	experimentv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/experiment/v1alpha2"
+	experimentsv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/experiment/v1alpha2"
 	api_pb "github.com/kubeflow/katib/pkg/api/v1alpha2"
 )
 
 type Suggestion interface {
-	GetSuggestions(instance *experimentv1alpha2.Experiment, addCount int) ([]*api_pb.Trial, error)
+	GetSuggestions(instance *experimentsv1alpha2.Experiment, addCount int) ([]*api_pb.Trial, error)
 }
 
 type General struct {
@@ -18,6 +18,6 @@ func New() Suggestion {
 	return &General{}
 }
 
-func (g *General) GetSuggestions(instance *experimentv1alpha2.Experiment, addCount int) ([]*api_pb.Trial, error) {
+func (g *General) GetSuggestions(instance *experimentsv1alpha2.Experiment, addCount int) ([]*api_pb.Trial, error) {
 	return nil, fmt.Errorf("Not implemented")
 }

--- a/pkg/controller/v1alpha2/experiment/suggestion/suggestion.go
+++ b/pkg/controller/v1alpha2/experiment/suggestion/suggestion.go
@@ -1,0 +1,23 @@
+package suggestion
+
+import (
+	"fmt"
+
+	experimentv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/experiment/v1alpha2"
+	api_pb "github.com/kubeflow/katib/pkg/api/v1alpha2"
+)
+
+type Suggestion interface {
+	GetSuggestions(instance *experimentv1alpha2.Experiment, addCount int) ([]*api_pb.Trial, error)
+}
+
+type General struct {
+}
+
+func New() Suggestion {
+	return &General{}
+}
+
+func (g *General) GetSuggestions(instance *experimentv1alpha2.Experiment, addCount int) ([]*api_pb.Trial, error) {
+	return nil, fmt.Errorf("Not implemented")
+}

--- a/pkg/controller/v1alpha2/experiment/util/api_util.go
+++ b/pkg/controller/v1alpha2/experiment/util/api_util.go
@@ -18,33 +18,28 @@ package util
 import (
 	"database/sql"
 
-	experimentsv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/experiment/v1alpha2"
 	commonv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/common/v1alpha2"
+	experimentv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/experiment/v1alpha2"
 	api_pb "github.com/kubeflow/katib/pkg/api/v1alpha2"
 )
 
-func CreateExperimentInDB(instance *experimentsv1alpha2.Experiment) error {
+func CreateExperimentInDB(instance *experimentv1alpha2.Experiment) error {
 	//TODO: Save experiment in to db
 	// experiment := GetExperimentConf(instance)
 
 	return nil
 }
 
-func UpdateExperimentStatusInDB(instance *experimentsv1alpha2.Experiment) error {
+func UpdateExperimentStatusInDB(instance *experimentv1alpha2.Experiment) error {
 
 	return nil
 }
 
-func GetExperimentFromDB(instance *experimentsv1alpha2.Experiment) (*api_pb.GetExperimentReply, error) {
+func GetExperimentFromDB(instance *experimentv1alpha2.Experiment) (*api_pb.GetExperimentReply, error) {
 	return nil, sql.ErrNoRows
 }
 
-func GetSuggestions(instance *experimentsv1alpha2.Experiment, addCount int) ([]*api_pb.Trial, error) {
-
-	return nil, nil
-}
-
-func GetExperimentConf(instance *experimentsv1alpha2.Experiment) *api_pb.Experiment {
+func GetExperimentConf(instance *experimentv1alpha2.Experiment) *api_pb.Experiment {
 	experiment := &api_pb.Experiment{
 		ExperimentSpec: &api_pb.ExperimentSpec{
 			Objective: &api_pb.ObjectiveSpec{
@@ -100,15 +95,15 @@ func GetExperimentConf(instance *experimentsv1alpha2.Experiment) *api_pb.Experim
 			parameter.FeasibleSpace.Step = p.FeasibleSpace.Step
 
 			switch p.ParameterType {
-			case experimentsv1alpha2.ParameterTypeCategorical:
+			case experimentv1alpha2.ParameterTypeCategorical:
 				parameter.ParameterType = api_pb.ParameterType_CATEGORICAL
-			case experimentsv1alpha2.ParameterTypeDiscrete:
+			case experimentv1alpha2.ParameterTypeDiscrete:
 				parameter.ParameterType = api_pb.ParameterType_DISCRETE
-			case experimentsv1alpha2.ParameterTypeDouble:
+			case experimentv1alpha2.ParameterTypeDouble:
 				parameter.ParameterType = api_pb.ParameterType_DOUBLE
-			case experimentsv1alpha2.ParameterTypeInt:
+			case experimentv1alpha2.ParameterTypeInt:
 				parameter.ParameterType = api_pb.ParameterType_INT
-			case experimentsv1alpha2.ParameterTypeUnknown:
+			case experimentv1alpha2.ParameterTypeUnknown:
 				parameter.ParameterType = api_pb.ParameterType_UNKNOWN_TYPE
 			}
 			experiment.ExperimentSpec.ParameterSpecs.Parameters = append(experiment.ExperimentSpec.ParameterSpecs.Parameters, parameter)
@@ -156,15 +151,15 @@ func GetExperimentConf(instance *experimentsv1alpha2.Experiment) *api_pb.Experim
 				parameter.FeasibleSpace.Step = p.FeasibleSpace.Step
 
 				switch p.ParameterType {
-				case experimentsv1alpha2.ParameterTypeCategorical:
+				case experimentv1alpha2.ParameterTypeCategorical:
 					parameter.ParameterType = api_pb.ParameterType_CATEGORICAL
-				case experimentsv1alpha2.ParameterTypeDiscrete:
+				case experimentv1alpha2.ParameterTypeDiscrete:
 					parameter.ParameterType = api_pb.ParameterType_DISCRETE
-				case experimentsv1alpha2.ParameterTypeDouble:
+				case experimentv1alpha2.ParameterTypeDouble:
 					parameter.ParameterType = api_pb.ParameterType_DOUBLE
-				case experimentsv1alpha2.ParameterTypeInt:
+				case experimentv1alpha2.ParameterTypeInt:
 					parameter.ParameterType = api_pb.ParameterType_INT
-				case experimentsv1alpha2.ParameterTypeUnknown:
+				case experimentv1alpha2.ParameterTypeUnknown:
 					parameter.ParameterType = api_pb.ParameterType_UNKNOWN_TYPE
 				}
 				operation.ParameterSpecs.Parameters = append(operation.ParameterSpecs.Parameters, parameter)

--- a/pkg/controller/v1alpha2/experiment/util/api_util.go
+++ b/pkg/controller/v1alpha2/experiment/util/api_util.go
@@ -19,27 +19,27 @@ import (
 	"database/sql"
 
 	commonv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/common/v1alpha2"
-	experimentv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/experiment/v1alpha2"
+	experimentsv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/experiment/v1alpha2"
 	api_pb "github.com/kubeflow/katib/pkg/api/v1alpha2"
 )
 
-func CreateExperimentInDB(instance *experimentv1alpha2.Experiment) error {
+func CreateExperimentInDB(instance *experimentsv1alpha2.Experiment) error {
 	//TODO: Save experiment in to db
 	// experiment := GetExperimentConf(instance)
 
 	return nil
 }
 
-func UpdateExperimentStatusInDB(instance *experimentv1alpha2.Experiment) error {
+func UpdateExperimentStatusInDB(instance *experimentsv1alpha2.Experiment) error {
 
 	return nil
 }
 
-func GetExperimentFromDB(instance *experimentv1alpha2.Experiment) (*api_pb.GetExperimentReply, error) {
+func GetExperimentFromDB(instance *experimentsv1alpha2.Experiment) (*api_pb.GetExperimentReply, error) {
 	return nil, sql.ErrNoRows
 }
 
-func GetExperimentConf(instance *experimentv1alpha2.Experiment) *api_pb.Experiment {
+func GetExperimentConf(instance *experimentsv1alpha2.Experiment) *api_pb.Experiment {
 	experiment := &api_pb.Experiment{
 		ExperimentSpec: &api_pb.ExperimentSpec{
 			Objective: &api_pb.ObjectiveSpec{
@@ -95,15 +95,15 @@ func GetExperimentConf(instance *experimentv1alpha2.Experiment) *api_pb.Experime
 			parameter.FeasibleSpace.Step = p.FeasibleSpace.Step
 
 			switch p.ParameterType {
-			case experimentv1alpha2.ParameterTypeCategorical:
+			case experimentsv1alpha2.ParameterTypeCategorical:
 				parameter.ParameterType = api_pb.ParameterType_CATEGORICAL
-			case experimentv1alpha2.ParameterTypeDiscrete:
+			case experimentsv1alpha2.ParameterTypeDiscrete:
 				parameter.ParameterType = api_pb.ParameterType_DISCRETE
-			case experimentv1alpha2.ParameterTypeDouble:
+			case experimentsv1alpha2.ParameterTypeDouble:
 				parameter.ParameterType = api_pb.ParameterType_DOUBLE
-			case experimentv1alpha2.ParameterTypeInt:
+			case experimentsv1alpha2.ParameterTypeInt:
 				parameter.ParameterType = api_pb.ParameterType_INT
-			case experimentv1alpha2.ParameterTypeUnknown:
+			case experimentsv1alpha2.ParameterTypeUnknown:
 				parameter.ParameterType = api_pb.ParameterType_UNKNOWN_TYPE
 			}
 			experiment.ExperimentSpec.ParameterSpecs.Parameters = append(experiment.ExperimentSpec.ParameterSpecs.Parameters, parameter)
@@ -151,15 +151,15 @@ func GetExperimentConf(instance *experimentv1alpha2.Experiment) *api_pb.Experime
 				parameter.FeasibleSpace.Step = p.FeasibleSpace.Step
 
 				switch p.ParameterType {
-				case experimentv1alpha2.ParameterTypeCategorical:
+				case experimentsv1alpha2.ParameterTypeCategorical:
 					parameter.ParameterType = api_pb.ParameterType_CATEGORICAL
-				case experimentv1alpha2.ParameterTypeDiscrete:
+				case experimentsv1alpha2.ParameterTypeDiscrete:
 					parameter.ParameterType = api_pb.ParameterType_DISCRETE
-				case experimentv1alpha2.ParameterTypeDouble:
+				case experimentsv1alpha2.ParameterTypeDouble:
 					parameter.ParameterType = api_pb.ParameterType_DOUBLE
-				case experimentv1alpha2.ParameterTypeInt:
+				case experimentsv1alpha2.ParameterTypeInt:
 					parameter.ParameterType = api_pb.ParameterType_INT
-				case experimentv1alpha2.ParameterTypeUnknown:
+				case experimentsv1alpha2.ParameterTypeUnknown:
 					parameter.ParameterType = api_pb.ParameterType_UNKNOWN_TYPE
 				}
 				operation.ParameterSpecs.Parameters = append(operation.ParameterSpecs.Parameters, parameter)

--- a/pkg/util/v1alpha2/katibclient/katib_client.go
+++ b/pkg/util/v1alpha2/katibclient/katib_client.go
@@ -20,7 +20,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	experimentv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/experiment/v1alpha2"
+	experimentsv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/experiment/v1alpha2"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,9 +42,9 @@ func NewClient(options client.Options) (*KatibClient, error) {
 	}, nil
 }
 
-func (k *KatibClient) GetExperimentList(namespace ...string) (*experimentv1alpha2.ExperimentList, error) {
+func (k *KatibClient) GetExperimentList(namespace ...string) (*experimentsv1alpha2.ExperimentList, error) {
 	ns := getNamespace(namespace...)
-	expList := &experimentv1alpha2.ExperimentList{}
+	expList := &experimentsv1alpha2.ExperimentList{}
 	listOpt := client.InNamespace(ns)
 
 	if err := k.client.List(context.Background(), listOpt, expList); err != nil {
@@ -54,7 +54,7 @@ func (k *KatibClient) GetExperimentList(namespace ...string) (*experimentv1alpha
 
 }
 
-func (k *KatibClient) CreateExperiment(experiment *experimentv1alpha2.Experiment, namespace ...string) error {
+func (k *KatibClient) CreateExperiment(experiment *experimentsv1alpha2.Experiment, namespace ...string) error {
 
 	if err := k.client.Create(context.Background(), experiment); err != nil {
 		return err
@@ -76,7 +76,7 @@ func (k *KatibClient) GetTrialTemplates(namespace ...string) (map[string]string,
 	ns := getNamespace(namespace...)
 	trialTemplates := &apiv1.ConfigMap{}
 
-	if err := k.client.Get(context.Background(), types.NamespacedName{Name: experimentv1alpha2.DefaultTrialConfigMapName, Namespace: ns}, trialTemplates); err != nil {
+	if err := k.client.Get(context.Background(), types.NamespacedName{Name: experimentsv1alpha2.DefaultTrialConfigMapName, Namespace: ns}, trialTemplates); err != nil {
 		return nil, err
 	}
 	return trialTemplates.Data, nil
@@ -87,7 +87,7 @@ func (k *KatibClient) UpdateTrialTemplates(newTrialTemplates map[string]string, 
 	ns := getNamespace(namespace...)
 	trialTemplates := &apiv1.ConfigMap{}
 
-	if err := k.client.Get(context.Background(), types.NamespacedName{Name: experimentv1alpha2.DefaultTrialConfigMapName, Namespace: ns}, trialTemplates); err != nil {
+	if err := k.client.Get(context.Background(), types.NamespacedName{Name: experimentsv1alpha2.DefaultTrialConfigMapName, Namespace: ns}, trialTemplates); err != nil {
 		return err
 	}
 	trialTemplates.Data = newTrialTemplates
@@ -103,7 +103,7 @@ func (k *KatibClient) GetMetricsCollectorTemplates(namespace ...string) (map[str
 	ns := getNamespace(namespace...)
 	metricsCollectorTemplates := &apiv1.ConfigMap{}
 
-	if err := k.client.Get(context.Background(), types.NamespacedName{Name: experimentv1alpha2.DefaultMetricsCollectorConfigMapName, Namespace: ns}, metricsCollectorTemplates); err != nil {
+	if err := k.client.Get(context.Background(), types.NamespacedName{Name: experimentsv1alpha2.DefaultMetricsCollectorConfigMapName, Namespace: ns}, metricsCollectorTemplates); err != nil {
 		return nil, err
 	}
 	return metricsCollectorTemplates.Data, nil
@@ -115,7 +115,7 @@ func (k *KatibClient) UpdateMetricsCollectorTemplates(newMCTemplates map[string]
 	ns := getNamespace(namespace...)
 	metricsCollectorTemplates := &apiv1.ConfigMap{}
 
-	if err := k.client.Get(context.Background(), types.NamespacedName{Name: experimentv1alpha2.DefaultMetricsCollectorConfigMapName, Namespace: ns}, metricsCollectorTemplates); err != nil {
+	if err := k.client.Get(context.Background(), types.NamespacedName{Name: experimentsv1alpha2.DefaultMetricsCollectorConfigMapName, Namespace: ns}, metricsCollectorTemplates); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
There are some benefits to define an interface instead of using util.GetSuggestions function:

- Easy to test and maintain. We can write unit test cases for the interface.
- Easy to integrate. We can mock the suggestion when testing the experiment controller, or use a fake controller to run the experiment without affecting the real logic.

This PR:

- added a CLI argument to control if we use fake implementation in the controller. If not, now we will always return an error becuase we do not implement suggestion logic now.

```
  -fake-experiment-suggestion
    	Use the fake suggestion in experiment controller
````

- added a interface about suggestion.

Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/502)
<!-- Reviewable:end -->
