### PR TITLE
Reducing the Prow workflow name length 

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -44,7 +44,7 @@ workflows:
   # The postsubmit run publishes the docker images to gcr.io/kubeflow-images-public      
   - app_dir: kubeflow/katib/test/workflows
     component: workflows-v1alpha1
-    name: e2e-v1alpha1-release
+    name: e2e-v1alpha1
     job_types:      
       - postsubmit
     include_dirs:
@@ -123,7 +123,7 @@ workflows:
       registry: "gcr.io/kubeflow-ci"
   - app_dir: kubeflow/katib/test/workflows
     component: workflows-v1alpha2
-    name: e2e-v1alpha2-release
+    name: e2e-v1alpha2
     job_types:
       - postsubmit
     include_dirs:


### PR DESCRIPTION
Postsubmit jobs fail currently because workflow pods name length exceeds 63 characters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/562)
<!-- Reviewable:end -->
