### PR TITLE
fix: Check if the deletion time is nil or zero

### DIFF
--- a/pkg/api/operators/apis/experiment/v1alpha2/util.go
+++ b/pkg/api/operators/apis/experiment/v1alpha2/util.go
@@ -143,7 +143,7 @@ func (exp *Experiment) MarkExperimentStatusFailed(reason, message string) {
 }
 
 func (exp *Experiment) NeedUpdateFinalizers() (bool, []string) {
-	deleted := exp.GetDeletionTimestamp() != nil
+	deleted := exp.ObjectMeta.DeletionTimestamp.IsZero()
 	pendingFinalizers := exp.GetFinalizers()
 	contained := false
 	for _, elem := range pendingFinalizers {


### PR DESCRIPTION
Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR is to avoid the potential bug of finalizers. The object cannot be deleted without the PR.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/567)
<!-- Reviewable:end -->
