### PR TITLE
Add categories for katib CRDs

### DIFF
--- a/manifests/v1alpha1/studyjobcontroller/crd.yaml
+++ b/manifests/v1alpha1/studyjobcontroller/crd.yaml
@@ -10,6 +10,10 @@ spec:
     kind: StudyJob
     singular: studyjob
     plural: studyjobs
+    categories:
+    - all
+    - kubeflow
+    - katib
   additionalPrinterColumns:
   - JSONPath: .status.condition
     name: Condition

--- a/manifests/v1alpha2/katib-controller/crd-experiment.yaml
+++ b/manifests/v1alpha2/katib-controller/crd-experiment.yaml
@@ -19,3 +19,7 @@ spec:
     kind: Experiment
     singular: experiment
     plural: experiments
+    categories:
+    - all
+    - kubeflow
+    - katib

--- a/manifests/v1alpha2/katib-controller/crd-trial.yaml
+++ b/manifests/v1alpha2/katib-controller/crd-trial.yaml
@@ -19,3 +19,7 @@ spec:
     kind: Trial
     singular: trial
     plural: trials
+    categories:
+    - all
+    - kubeflow
+    - katib


### PR DESCRIPTION
```
# kubectl get katib -n kubeflow-test
NAME                STATUS      AGE
random-experiment   Succeeded   23h

NAME                         STATUS      AGE
random-experiment-4x8q6r6d   Succeeded   23h
random-experiment-5bvj7rrz   Succeeded   23h

# kubectl get kubeflow -n kubeflow-test
NAME                STATUS      AGE
random-experiment   Succeeded   23h

NAME                         STATUS      AGE
random-experiment-4x8q6r6d   Succeeded   23h
random-experiment-5bvj7rrz   Succeeded   23h

# kubectl get experiments -n kubeflow-test
NAME                STATUS      AGE
random-experiment   Succeeded   23h

# kubectl get trials -n kubeflow-test
NAME                         STATUS      AGE
random-experiment-4x8q6r6d   Succeeded   23h
random-experiment-5bvj7rrz   Succeeded   23h
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/576)
<!-- Reviewable:end -->
