### PR TITLE
Change undeploy script

### DIFF
--- a/scripts/v1alpha1/undeploy.sh
+++ b/scripts/v1alpha1/undeploy.sh
@@ -29,8 +29,8 @@ done
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/../..
 
 cd ${SCRIPT_ROOT}
-kubectl delete -f manifests/v1alpha1/pv
 kubectl delete -f manifests/v1alpha1/vizier/db
+kubectl delete -f manifests/v1alpha1/pv
 kubectl delete -f manifests/v1alpha1/vizier/core
 kubectl delete -f manifests/v1alpha1/vizier/core-rest
 kubectl delete -f manifests/v1alpha1/vizier/ui

--- a/scripts/v1alpha2/undeploy.sh
+++ b/scripts/v1alpha2/undeploy.sh
@@ -32,8 +32,8 @@ cd ${SCRIPT_ROOT}
 kubectl delete -f manifests/v1alpha2/katib-controller
 kubectl delete -f manifests/v1alpha2/katib/manager
 kubectl delete -f manifests/v1alpha2/katib/manager-rest
-kubectl delete -f manifests/v1alpha2/katib/pv
 kubectl delete -f manifests/v1alpha2/katib/db
+kubectl delete -f manifests/v1alpha2/katib/pv
 kubectl delete -f manifests/v1alpha2/katib/suggestion/random
 kubectl delete -f manifests/v1alpha2
 cd - > /dev/null


### PR DESCRIPTION
I think, we should move deletion for PV under Katib-db.
Persistent Volume can't be deleted before db.
It will stuck in deletion step, because it used by Katib-db.

/assign @gyliu513 @hougangliu 
/cc @gaocegege @johnugeorge

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/587)
<!-- Reviewable:end -->
