### PR TITLE
Check error in OpenSQLConnection

### DIFF
--- a/pkg/db/v1alpha1/interface.go
+++ b/pkg/db/v1alpha1/interface.go
@@ -111,9 +111,9 @@ func openSQLConn(driverName string, dataSourceName string, interval time.Duratio
 				if err = db.Ping(); err == nil {
 					return db, nil
 				}
-				klog.Infof("Ping to Katib db failed: %v", err)
+				klog.Errorf("Ping to Katib db failed: %v", err)
 			} else {
-				klog.Infof("Open sql connection failed: %v", err)
+				klog.Errorf("Open sql connection failed: %v", err)
 			}
 		case <-timeoutC:
 			return nil, fmt.Errorf("Timeout waiting for DB conn successfully opened.")

--- a/pkg/db/v1alpha1/interface.go
+++ b/pkg/db/v1alpha1/interface.go
@@ -111,6 +111,9 @@ func openSQLConn(driverName string, dataSourceName string, interval time.Duratio
 				if err = db.Ping(); err == nil {
 					return db, nil
 				}
+				klog.Infof("Ping to Katib db failed: %v", err)
+			} else {
+				klog.Infof("Open sql connection failed: %v", err)
 			}
 		case <-timeoutC:
 			return nil, fmt.Errorf("Timeout waiting for DB conn successfully opened.")

--- a/pkg/db/v1alpha2/interface.go
+++ b/pkg/db/v1alpha2/interface.go
@@ -95,6 +95,9 @@ func openSQLConn(driverName string, dataSourceName string, interval time.Duratio
 				if err = db.Ping(); err == nil {
 					return db, nil
 				}
+				klog.Infof("Ping to Katib db failed: %v", err)
+			} else {
+				klog.Infof("Open sql connection failed: %v", err)
 			}
 		case <-timeoutC:
 			return nil, fmt.Errorf("Timeout waiting for DB conn successfully opened.")

--- a/pkg/db/v1alpha2/interface.go
+++ b/pkg/db/v1alpha2/interface.go
@@ -95,9 +95,9 @@ func openSQLConn(driverName string, dataSourceName string, interval time.Duratio
 				if err = db.Ping(); err == nil {
 					return db, nil
 				}
-				klog.Infof("Ping to Katib db failed: %v", err)
+				klog.Errorf("Ping to Katib db failed: %v", err)
 			} else {
-				klog.Infof("Open sql connection failed: %v", err)
+				klog.Errorf("Open sql connection failed: %v", err)
 			}
 		case <-timeoutC:
 			return nil, fmt.Errorf("Timeout waiting for DB conn successfully opened.")


### PR DESCRIPTION
I faced with the same error as here: https://github.com/kubeflow/katib/issues/340.
Problem was with my Coredns in Kubernetes cluster. After I changed pod network from `Flannel` to `Calico`, it was fixed.
I didn't see any logs from the katib-manager and it was hard to found this problem. 
I think, we should print these error messages to the user, then it will be easier to find the problem.

/cc @gaocegege @johnugeorge @hougangliu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/588)
<!-- Reviewable:end -->
