### PR TITLE
Mini fix for v1alpha1 metricsCollector

### DIFF
--- a/pkg/manager/v1alpha1/metricscollector/metricscollector.go
+++ b/pkg/manager/v1alpha1/metricscollector/metricscollector.go
@@ -47,7 +47,10 @@ func (d *MetricsCollector) CollectWorkerLog(wID string, wkind string, objectiveV
 	} else {
 		labelMap["job-name"] = wID
 	}
-	pl, _ := d.clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: labels.Set(labelMap).String(), IncludeUninitialized: true})
+	pl, err := d.clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: labels.Set(labelMap).String(), IncludeUninitialized: true})
+	if err != nil {
+		return nil, err
+	}
 	if len(pl.Items) == 0 {
 		return nil, errors.New(fmt.Sprintf("No Pods are found in Job %v", wID))
 	}


### PR DESCRIPTION
When I configure wrong metrics-collector role for `list` pods in namespace `kubeflow` by mistake, metricsCollectors always goes to `Error` with message `F0528 09:59:09.429051       1 main.go:81] Failed to collect logs: No Pods are found in Job v2cc12862537d2e9`, which is really confusing user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/600)
<!-- Reviewable:end -->
