### PR TITLE
Set trial completion status only after metric collection

### DIFF
--- a/pkg/controller/v1alpha2/trial/trial_controller.go
+++ b/pkg/controller/v1alpha2/trial/trial_controller.go
@@ -87,7 +87,13 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to Cronjob
-	err = c.Watch(&source.Kind{Type: &batchv1beta.CronJob{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(
+		&source.Kind{Type: &batchv1beta.CronJob{}},
+		&handler.EnqueueRequestForOwner{
+			IsController: true,
+			OwnerType:    &trialsv1alpha2.Trial{},
+		})
+
 	if err != nil {
 		log.Error(err, "CronJob watch error")
 		return err

--- a/pkg/controller/v1alpha2/trial/trial_controller_util.go
+++ b/pkg/controller/v1alpha2/trial/trial_controller_util.go
@@ -109,6 +109,18 @@ func (r *ReconcileTrial) UpdateTrialStatusObservation(instance *trialsv1alpha2.T
 	return nil
 }
 
+func isTrialObservationAvailable(instance *trialsv1alpha2.Trial) bool {
+	objectiveMetricName := instance.Spec.Objective.ObjectiveMetricName
+	if instance.Status.Observation != nil && instance.Status.Observation.Metrics != nil {
+		for _, metric := range instance.Status.Observation.Metrics {
+			if metric.Name == objectiveMetricName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func getBestObjectiveMetricValue(metricLogs []*api_pb.MetricLog, objectiveType commonv1alpha2.ObjectiveType) *float64 {
 	metricLogSize := len(metricLogs)
 	if metricLogSize == 0 {


### PR DESCRIPTION
Fixes: #615 

Trial status is updated only if trial observation field is updated. (This will be set if metrics are collected)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/616)
<!-- Reviewable:end -->
