### PR TITLE
Skip creating trials if add count is zero

### DIFF
--- a/pkg/controller/v1alpha2/experiment/experiment_controller.go
+++ b/pkg/controller/v1alpha2/experiment/experiment_controller.go
@@ -331,13 +331,15 @@ func (r *ReconcileExperiment) ReconcileTrials(instance *experimentsv1alpha2.Expe
 			addCount = 0
 		}
 
-		//create "addCount" number of trials
-		logger.Info("CreateTrials", "addCount", addCount)
-		if err := r.createTrials(instance, addCount); err != nil {
-			logger.Error(err, "Create trials error")
-			return err
+		//skip if no trials need to be created
+		if addCount > 0 {
+			//create "addCount" number of trials
+			logger.Info("CreateTrials", "addCount", addCount)
+			if err := r.createTrials(instance, addCount); err != nil {
+				logger.Error(err, "Create trials error")
+				return err
+			}
 		}
-
 	}
 
 	return nil


### PR DESCRIPTION
During reconcile, CreateTrials and GetSuggestion calls should be skipped if add count is zero.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/617)
<!-- Reviewable:end -->
