### PR TITLE
Fix Scheme in Katib Client for v1alpha2

### DIFF
--- a/pkg/util/v1alpha2/katibclient/katib_client.go
+++ b/pkg/util/v1alpha2/katibclient/katib_client.go
@@ -23,6 +23,7 @@ import (
 	experimentsv1alpha2 "github.com/kubeflow/katib/pkg/api/operators/apis/experiment/v1alpha2"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
@@ -53,6 +54,7 @@ func NewClient(options client.Options) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	experimentsv1alpha2.AddToScheme(scheme.Scheme)
 	cl, err := client.New(cfg, options)
 	return &KatibClient{
 		client: cl,


### PR DESCRIPTION
To use Experiment CRD we need to add the Scheme to the Katib Client. 
Without this Scheme, we will have this error in Katib Client:

```
no kind is registered for the type v1alpha2.Experiment
no kind is registered for the type v1alpha2.ExperimentList
```
/assign @johnugeorge @richardsliu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/620)
<!-- Reviewable:end -->
