### PR TITLE
Update Algorithm extra settings during experiment creation

### DIFF
--- a/pkg/common/v1alpha2/katib_manager_util.go
+++ b/pkg/common/v1alpha2/katib_manager_util.go
@@ -103,6 +103,17 @@ func UpdateExperimentStatus(request *api_pb.UpdateExperimentStatusRequest) (*api
 	return kc.UpdateExperimentStatus(ctx, request)
 }
 
+func UpdateAlgorithmExtraSettings(request *api_pb.UpdateAlgorithmExtraSettingsRequest) (*api_pb.UpdateAlgorithmExtraSettingsReply, error) {
+	ctx := context.Background()
+	kcc, err := getKatibManagerClientAndConn()
+	if err != nil {
+		return nil, err
+	}
+	defer closeKatibManagerConnection(kcc)
+	kc := kcc.KatibManagerClient
+	return kc.UpdateAlgorithmExtraSettings(ctx, request)
+}
+
 func RegisterTrial(request *api_pb.RegisterTrialRequest) (*api_pb.RegisterTrialReply, error) {
 	ctx := context.Background()
 	kcc, err := getKatibManagerClientAndConn()

--- a/pkg/controller/v1alpha2/experiment/managerclient/managerclient.go
+++ b/pkg/controller/v1alpha2/experiment/managerclient/managerclient.go
@@ -34,6 +34,17 @@ func (d *DefaultClient) CreateExperimentInDB(instance *experimentsv1alpha2.Exper
 	if _, err := commonv1alpha2.RegisterExperiment(request); err != nil {
 		return err
 	}
+	if len(experiment.Spec.Algorithm.AlgorithmSetting) > 0 {
+		req := &api_pb.UpdateAlgorithmExtraSettingsRequest{
+			ExperimentName:         experiment.Name,
+			ExtraAlgorithmSettings: experiment.Spec.Algorithm.AlgorithmSetting,
+		}
+
+		if _, err := commonv1alpha2.UpdateAlgorithmExtraSettings(req); err != nil {
+			return err
+		}
+
+	}
 	return nil
 }
 


### PR DESCRIPTION
If algorithm settings are present in the experiment, it has to be updated in algorithm extra settings via UpdateAlgorithmExtraSettings call. The suggestion algorithms look for algorithm settings using GetAlgorithmExtraSettings call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/630)
<!-- Reviewable:end -->
