### PR TITLE
Adding cascading delete of pods when jobs are deleted

### DIFF
--- a/pkg/controller/v1alpha2/trial/trial_controller.go
+++ b/pkg/controller/v1alpha2/trial/trial_controller.go
@@ -272,7 +272,7 @@ func (r *ReconcileTrial) reconcileJob(instance *trialsv1alpha2.Trial, desiredJob
 		}
 	} else {
 		if instance.IsCompleted() && !instance.Spec.RetainRun {
-			if err = r.Delete(context.TODO(), desiredJob); err != nil {
+			if err = r.Delete(context.TODO(), desiredJob, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
 				logger.Error(err, "Delete job error")
 				return nil, err
 			} else {
@@ -351,7 +351,7 @@ func (r *ReconcileTrial) reconcileMetricsCollector(instance *trialsv1alpha2.Tria
 		}
 	} else {
 		if instance.IsCompleted() && !instance.Spec.RetainMetricsCollector {
-			if err = r.Delete(context.TODO(), desiredMetricsCollector); err != nil {
+			if err = r.Delete(context.TODO(), desiredMetricsCollector, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
 				logger.Error(err, "Delete Metrics Collector error")
 				return nil, err
 			} else {


### PR DESCRIPTION
Pods have to be deleted when jobs are deleted.  Hence, DeletionPropogation strategy is set to Foreground.(https://github.com/kubernetes/kubernetes/blob/release-1.7/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go#L370)

Fixes: #597

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/632)
<!-- Reviewable:end -->
