### PR TITLE
Adding extra check for Katib core namespace env

### DIFF
--- a/pkg/api/operators/apis/experiment/v1alpha2/constants.go
+++ b/pkg/api/operators/apis/experiment/v1alpha2/constants.go
@@ -26,7 +26,7 @@ const (
 	DefaultKatibNamespaceEnvName = "KATIB_CORE_NAMESPACE"
 
 	//Default katib namespace
-	DefaultKatibNamespace = "kubeflow"
+	DefaultKatibNamespace = "default"
 
 	// Default value of Spec.TemplatePath
 	DefaultTrialTemplatePath = "defaultTrialTemplate.yaml"

--- a/pkg/api/operators/apis/experiment/v1alpha2/constants.go
+++ b/pkg/api/operators/apis/experiment/v1alpha2/constants.go
@@ -25,6 +25,9 @@ const (
 	// Default env name of katib namespace
 	DefaultKatibNamespaceEnvName = "KATIB_CORE_NAMESPACE"
 
+	//Default katib namespace
+	DefaultKatibNamespace = "kubeflow"
+
 	// Default value of Spec.TemplatePath
 	DefaultTrialTemplatePath = "defaultTrialTemplate.yaml"
 

--- a/pkg/api/operators/apis/experiment/v1alpha2/constants.go
+++ b/pkg/api/operators/apis/experiment/v1alpha2/constants.go
@@ -26,7 +26,7 @@ const (
 	DefaultKatibNamespaceEnvName = "KATIB_CORE_NAMESPACE"
 
 	//Default katib namespace
-	DefaultKatibNamespace = "default"
+	DefaultKatibNamespace = "kubeflow"
 
 	// Default value of Spec.TemplatePath
 	DefaultTrialTemplatePath = "defaultTrialTemplate.yaml"

--- a/pkg/controller/v1alpha2/experiment/experiment_controller.go
+++ b/pkg/controller/v1alpha2/experiment/experiment_controller.go
@@ -155,15 +155,19 @@ func addWebhook(mgr manager.Manager) error {
 	if err != nil {
 		return err
 	}
+	namespace := experimentsv1alpha2.DefaultKatibNamespace
+	if ns := os.Getenv(experimentsv1alpha2.DefaultKatibNamespaceEnvName); ns != "" {
+		namespace = ns
+	}
 	as, err := webhook.NewServer("experiment-admission-server", mgr, webhook.ServerOptions{
 		CertDir: "/tmp/cert",
 		BootstrapOptions: &webhook.BootstrapOptions{
 			Secret: &types.NamespacedName{
-				Namespace: os.Getenv(experimentsv1alpha2.DefaultKatibNamespaceEnvName),
+				Namespace: namespace,
 				Name:      katibControllerName,
 			},
 			Service: &webhook.Service{
-				Namespace: os.Getenv(experimentsv1alpha2.DefaultKatibNamespaceEnvName),
+				Namespace: namespace,
 				Name:      katibControllerName,
 				Selectors: map[string]string{
 					"app": katibControllerName,

--- a/pkg/controller/v1alpha2/experiment/experiment_controller_test.go
+++ b/pkg/controller/v1alpha2/experiment/experiment_controller_test.go
@@ -29,11 +29,11 @@ import (
 
 const (
 	experimentName = "foo"
-	namespace      = "default"
 
 	timeout = time.Second * 40
 )
 
+var namespace = experimentsv1alpha2.DefaultKatibNamespace
 var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: experimentName, Namespace: namespace}}
 var trialKey = types.NamespacedName{Name: "test", Namespace: namespace}
 


### PR DESCRIPTION
If DefaultKatibNamespaceEnvName is not set, it will use default namespace.  This will be used in unit tests where env is not set.
/hold
Fixes: #604 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/655)
<!-- Reviewable:end -->
