### PR TITLE
fix: Do not use webhook in UT

### DIFF
--- a/pkg/controller/v1alpha2/experiment/experiment_controller.go
+++ b/pkg/controller/v1alpha2/experiment/experiment_controller.go
@@ -104,8 +104,23 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	if err = addWatch(mgr, c); err != nil {
+		log.Error(err, "Trial watch failed")
+		return err
+	}
+	if err = addWebhook(mgr); err != nil {
+		log.Error(err, "Failed to create webhook")
+		return err
+	}
+
+	log.Info("Experiment controller created")
+	return nil
+}
+
+// addWatch adds a new Controller to mgr with r as the reconcile.Reconciler
+func addWatch(mgr manager.Manager, c controller.Controller) error {
 	// Watch for changes to Experiment
-	err = c.Watch(&source.Kind{Type: &experimentsv1alpha2.Experiment{}}, &handler.EnqueueRequestForObject{})
+	err := c.Watch(&source.Kind{Type: &experimentsv1alpha2.Experiment{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		log.Error(err, "Experiment watch failed")
 		return err
@@ -123,12 +138,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		log.Error(err, "Trial watch failed")
 		return err
 	}
-	if err = addWebhook(mgr); err != nil {
-		log.Error(err, "Failed to create webhook")
-		return err
-	}
-
-	log.Info("Experiment controller created")
 	return nil
 }
 

--- a/pkg/controller/v1alpha2/experiment/experiment_controller_suite_test.go
+++ b/pkg/controller/v1alpha2/experiment/experiment_controller_suite_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -80,4 +81,22 @@ func StartTestManager(mgr manager.Manager, g *gomega.GomegaWithT) (chan struct{}
 		g.Expect(mgr.Start(stop)).NotTo(gomega.HaveOccurred())
 	}()
 	return stop, wg
+}
+
+// addForTestPurpose adds a new Controller to mgr with r as the reconcile.Reconciler.
+func addForTestPurpose(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("test-experiment-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		log.Error(err, "Failed to create experiment controller for test purpose.")
+		return err
+	}
+
+	if err = addWatch(mgr, c); err != nil {
+		log.Error(err, "Trial watch failed")
+		return err
+	}
+
+	log.Info("Experiment controller created")
+	return nil
 }

--- a/pkg/controller/v1alpha2/experiment/experiment_controller_test.go
+++ b/pkg/controller/v1alpha2/experiment/experiment_controller_test.go
@@ -79,7 +79,7 @@ func TestCreateExperiment(t *testing.T) {
 			return nil
 		},
 	})
-	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
+	g.Expect(addForTestPurpose(mgr, recFn)).NotTo(gomega.HaveOccurred())
 
 	stopMgr, mgrStopped := StartTestManager(mgr, g)
 
@@ -211,7 +211,7 @@ spec:
 	}
 
 	recFn := SetupTestReconcile(r)
-	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
+	g.Expect(addForTestPurpose(mgr, recFn)).NotTo(gomega.HaveOccurred())
 
 	stopMgr, mgrStopped := StartTestManager(mgr, g)
 


### PR DESCRIPTION
Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Unit test will use the same real API server for all test cases. And there are some uncertain problems during experiment test. Ref #604 

This PR is to avoid adding webhooks to avoid it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/657)
<!-- Reviewable:end -->
