### PR TITLE
MetricController: Run only a single job per task

### DIFF
--- a/manifests/v1alpha1/studyjobcontroller/metricsControllerConfigMap.yaml
+++ b/manifests/v1alpha1/studyjobcontroller/metricsControllerConfigMap.yaml
@@ -14,6 +14,7 @@ data:
       schedule: "*/1 * * * *"
       successfulJobsHistoryLimit: 0
       failedJobsHistoryLimit: 1
+      concurrencyPolicy: Forbid
       jobTemplate:
         spec:
           backoffLimit: 0

--- a/manifests/v1alpha2/katib-controller/metricsControllerConfigMap.yaml
+++ b/manifests/v1alpha2/katib-controller/metricsControllerConfigMap.yaml
@@ -14,6 +14,7 @@ data:
       schedule: "*/1 * * * *"
       successfulJobsHistoryLimit: 0
       failedJobsHistoryLimit: 1
+      concurrencyPolicy: Forbid
       jobTemplate:
         spec:
           backoffLimit: 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This changes the `spec.concurrencyPolicy` of the metric collector 
cron-job from "Allow" (default) to "Forbid". The cronjob used to
create a new job even if the previous job had not succeeded. On
high-load clusters this could lead to a high number of jobs which
never finished. 

**Which issue(s) this PR fixes** *:
This fixes #659 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/660)
<!-- Reviewable:end -->
