### PR TITLE
Use latest katib images to deploy katib

### DIFF
--- a/manifests/v1alpha1/studyjobcontroller/metricsControllerConfigMap.yaml
+++ b/manifests/v1alpha1/studyjobcontroller/metricsControllerConfigMap.yaml
@@ -23,7 +23,7 @@ data:
               serviceAccountName: metrics-collector
               containers:
               - name: {{.WorkerID}}
-                image: katib/metrics-collector
+                image: gcr.io/kubeflow-images-public/katib/v1alpha1/metrics-collector
                 command: ["./metricscollector"]
                 args:
                 - "-s"

--- a/manifests/v1alpha1/studyjobcontroller/studyjobcontroller.yaml
+++ b/manifests/v1alpha1/studyjobcontroller/studyjobcontroller.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: studyjob-controller
       containers:
       - name: studyjob-controller
-        image: katib/studyjob-controller
+        image: gcr.io/kubeflow-images-public/katib/v1alpha1/studyjob-controller
         imagePullPolicy: Always
         ports:
         - containerPort: 443

--- a/manifests/v1alpha1/vizier/core-rest/deployment.yaml
+++ b/manifests/v1alpha1/vizier/core-rest/deployment.yaml
@@ -17,16 +17,9 @@ spec:
     spec:
       containers:
       - name: vizier-core-rest
-        image: katib/vizier-core-rest
+        image: gcr.io/kubeflow-images-public/katib/v1alpha1/vizier-core-rest
         command:
           - './vizier-manager-rest'
         ports:
         - name: api
           containerPort: 80
-#        resources:
-#          requests:
-#            cpu: 500m
-#            memory: 500M
-#          limits:
-#            cpu: 500m
-#            memory: 500M

--- a/manifests/v1alpha1/vizier/core/deployment.yaml
+++ b/manifests/v1alpha1/vizier/core/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: vizier-core
-        image: katib/vizier-core
+        image: gcr.io/kubeflow-images-public/katib/v1alpha1/vizier-core
         env:
           - name: MYSQL_ROOT_PASSWORD
             valueFrom:
@@ -37,10 +37,3 @@ spec:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:6789"]
           initialDelaySeconds: 10
-#        resources:
-#          requests:
-#            cpu: 500m
-#            memory: 500M
-#          limits:
-#            cpu: 500m
-#            memory: 500M

--- a/manifests/v1alpha1/vizier/earlystopping/medianstopping/deployment.yaml
+++ b/manifests/v1alpha1/vizier/earlystopping/medianstopping/deployment.yaml
@@ -17,14 +17,7 @@ spec:
     spec:
       containers:
       - name: vizier-earlystopping-medianstopping
-        image: katib/earlystopping-medianstopping
+        image: gcr.io/kubeflow-images-public/katib/v1alpha1/earlystopping-medianstopping
         ports:
         - name: api
           containerPort: 6789
-#        resources:
-#          requests:
-#            cpu: 500m
-#            memory: 500M
-#          limits:
-#            cpu: 500m
-#            memory: 500M

--- a/manifests/v1alpha1/vizier/suggestion/bayesianoptimization/deployment.yaml
+++ b/manifests/v1alpha1/vizier/suggestion/bayesianoptimization/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: vizier-suggestion-bayesianoptimization
-        image: katib/suggestion-bayesianoptimization
+        image: gcr.io/kubeflow-images-public/katib/v1alpha1/suggestion-bayesianoptimization
         ports:
         - name: api
           containerPort: 6789

--- a/manifests/v1alpha1/vizier/suggestion/grid/deployment.yaml
+++ b/manifests/v1alpha1/vizier/suggestion/grid/deployment.yaml
@@ -17,14 +17,7 @@ spec:
     spec:
       containers:
       - name: vizier-suggestion-grid
-        image: katib/suggestion-grid
+        image: gcr.io/kubeflow-images-public/katib/v1alpha1/suggestion-grid
         ports:
         - name: api
           containerPort: 6789
-#        resources:
-#          requests:
-#            cpu: 500m
-#            memory: 500M
-#          limits:
-#            cpu: 500m
-#            memory: 500M

--- a/manifests/v1alpha1/vizier/suggestion/hyperband/deployment.yaml
+++ b/manifests/v1alpha1/vizier/suggestion/hyperband/deployment.yaml
@@ -17,14 +17,7 @@ spec:
     spec:
       containers:
       - name: vizier-suggestion-hyperband
-        image: katib/suggestion-hyperband
+        image: gcr.io/kubeflow-images-public/katib/v1alpha1/suggestion-hyperband
         ports:
         - name: api
           containerPort: 6789
-#        resources:
-#          requests:
-#            cpu: 500m
-#            memory: 500M
-#          limits:
-#            cpu: 500m
-#            memory: 500M

--- a/manifests/v1alpha1/vizier/suggestion/nasenvelopenet/deployment.yaml
+++ b/manifests/v1alpha1/vizier/suggestion/nasenvelopenet/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: vizier-suggestion-nasenvelopenet
-        image: katib/suggestion-nasenvelopenet
+        image: gcr.io/kubeflow-images-public/katib/v1alpha1/suggestion-nasenvelopenet
         ports:
         - name: api
           containerPort: 6789

--- a/manifests/v1alpha1/vizier/suggestion/nasrl/deployment.yaml
+++ b/manifests/v1alpha1/vizier/suggestion/nasrl/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: vizier-suggestion-nasrl
-        image: katib/suggestion-nasrl
+        image: gcr.io/kubeflow-images-public/katib/v1alpha1/suggestion-nasrl
         ports:
         - name: api
           containerPort: 6789

--- a/manifests/v1alpha1/vizier/suggestion/random/deployment.yaml
+++ b/manifests/v1alpha1/vizier/suggestion/random/deployment.yaml
@@ -17,14 +17,7 @@ spec:
     spec:
       containers:
       - name: vizier-suggestion-random
-        image: katib/suggestion-random
+        image: gcr.io/kubeflow-images-public/katib/v1alpha1/suggestion-random
         ports:
         - name: api
           containerPort: 6789
-#        resources:
-#          requests:
-#            cpu: 500m
-#            memory: 500M
-#          limits:
-#            cpu: 500m
-#            memory: 500M

--- a/manifests/v1alpha1/vizier/ui/deployment.yaml
+++ b/manifests/v1alpha1/vizier/ui/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: katib-ui
-        image: katib/katib-ui
+        image: gcr.io/kubeflow-images-public/katib/v1alpha1/katib-ui
         command:
           - './katib-ui'
         ports:

--- a/manifests/v1alpha2/katib-controller/katib-controller.yaml
+++ b/manifests/v1alpha2/katib-controller/katib-controller.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: katib-controller
       containers:
       - name: katib-controller
-        image: katib/v1alpha2/katib-controller
+        image: gcr.io/kubeflow-images-public/katib/v1alpha2/katib-controller
         imagePullPolicy: IfNotPresent
         command: ["./katib-controller"]
         ports:

--- a/manifests/v1alpha2/katib-controller/metricsControllerConfigMap.yaml
+++ b/manifests/v1alpha2/katib-controller/metricsControllerConfigMap.yaml
@@ -23,7 +23,7 @@ data:
               serviceAccountName: metrics-collector
               containers:
               - name: {{.Trial}}
-                image: katib/v1alpha2/metrics-collector
+                image: gcr.io/kubeflow-images-public/katib/v1alpha2/metrics-collector
                 imagePullPolicy: IfNotPresent
                 command: ["./metricscollector"]
                 args:

--- a/manifests/v1alpha2/manager-rest/deployment.yaml
+++ b/manifests/v1alpha2/manager-rest/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: katib-manager-rest
-        image: katib/v1alpha2/katib-manager-rest
+        image: gcr.io/kubeflow-images-public/katib/v1alpha2/katib-manager-rest
         imagePullPolicy: IfNotPresent
         command:
           - './katib-manager-rest'

--- a/manifests/v1alpha2/manager/deployment.yaml
+++ b/manifests/v1alpha2/manager/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: katib-manager
-        image: katib/v1alpha2/katib-manager
+        image: gcr.io/kubeflow-images-public/katib/v1alpha2/katib-manager
         imagePullPolicy: IfNotPresent
         env:
           - name: MYSQL_ROOT_PASSWORD

--- a/manifests/v1alpha2/suggestion/bayesianoptimization/deployment.yaml
+++ b/manifests/v1alpha2/suggestion/bayesianoptimization/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: katib-suggestion-bayesianoptimization
-        image: katib/v1alpha2/suggestion-bayesianoptimization
+        image: gcr.io/kubeflow-images-public/katib/v1alpha2/suggestion-bayesianoptimization
         imagePullPolicy: IfNotPresent
         ports:
         - name: api

--- a/manifests/v1alpha2/suggestion/grid/deployment.yaml
+++ b/manifests/v1alpha2/suggestion/grid/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: katib-suggestion-grid
-        image: katib/v1alpha2/suggestion-grid
+        image: gcr.io/kubeflow-images-public/katib/v1alpha2/suggestion-grid
         imagePullPolicy: IfNotPresent
         ports:
         - name: api

--- a/manifests/v1alpha2/suggestion/hyperband/deployment.yaml
+++ b/manifests/v1alpha2/suggestion/hyperband/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: katib-suggestion-hyperband
-        image: katib/v1alpha2/suggestion-hyperband
+        image: gcr.io/kubeflow-images-public/katib/v1alpha2/suggestion-hyperband
         imagePullPolicy: IfNotPresent
         ports:
         - name: api

--- a/manifests/v1alpha2/suggestion/nasrl/deployment.yaml
+++ b/manifests/v1alpha2/suggestion/nasrl/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: katib-suggestion-nasrl
-        image: katib/v1alpha2/suggestion-nasrl
+        image: gcr.io/kubeflow-images-public/katib/v1alpha2/suggestion-nasrl
         ports:
         - name: api
           containerPort: 6789

--- a/manifests/v1alpha2/suggestion/random/deployment.yaml
+++ b/manifests/v1alpha2/suggestion/random/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: katib-suggestion-random
-        image: katib/v1alpha2/suggestion-random
+        image: gcr.io/kubeflow-images-public/katib/v1alpha2/suggestion-random
         imagePullPolicy: IfNotPresent
         ports:
         - name: api

--- a/manifests/v1alpha2/ui/deployment.yaml
+++ b/manifests/v1alpha2/ui/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: katib-ui
-        image: katib/v1alpha2/katib-ui
+        image: gcr.io/kubeflow-images-public/katib/v1alpha2/katib-ui
         imagePullPolicy: IfNotPresent
         command:
           - './katib-ui'

--- a/test/scripts/v1alpha1/run-tests.sh
+++ b/test/scripts/v1alpha1/run-tests.sh
@@ -63,19 +63,19 @@ echo "REGISTRY ${REGISTRY}"
 echo "REPO_NAME ${REPO_NAME}"
 echo "VERSION ${VERSION}"
 
-sed -i -e "s@image: katib\/vizier-core@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/vizier-core:${VERSION}@" manifests/v1alpha1/vizier/core/deployment.yaml
-sed -i -e "s@image: katib\/vizier-core-rest@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/vizier-core-rest:${VERSION}@" manifests/v1alpha1/vizier/core-rest/deployment.yaml
-sed -i -e "s@image: katib\/katib-ui@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/katib-ui:${VERSION}@" manifests/v1alpha1/vizier/ui/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha1\/vizier-core@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/vizier-core:${VERSION}@" manifests/v1alpha1/vizier/core/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha1\/vizier-core-rest@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/vizier-core-rest:${VERSION}@" manifests/v1alpha1/vizier/core-rest/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha1\/katib-ui@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/katib-ui:${VERSION}@" manifests/v1alpha1/vizier/ui/deployment.yaml
 sed -i -e "s@type: NodePort@type: ClusterIP@" -e "/nodePort: 30678/d" manifests/v1alpha1/vizier/core/service.yaml
-sed -i -e "s@image: katib\/studyjob-controller@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/studyjob-controller:${VERSION}@" manifests/v1alpha1/studyjobcontroller/studyjobcontroller.yaml
-sed -i -e "s@image: katib\/suggestion-random@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/suggestion-random:${VERSION}@" manifests/v1alpha1/vizier/suggestion/random/deployment.yaml
-sed -i -e "s@image: katib\/suggestion-grid@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/suggestion-grid:${VERSION}@" manifests/v1alpha1/vizier/suggestion/grid/deployment.yaml
-sed -i -e "s@image: katib\/suggestion-hyperband@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/suggestion-hyperband:${VERSION}@" manifests/v1alpha1/vizier/suggestion/hyperband/deployment.yaml
-sed -i -e "s@image: katib\/suggestion-bayesianoptimization@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/suggestion-bayesianoptimization:${VERSION}@" manifests/v1alpha1/vizier/suggestion/bayesianoptimization/deployment.yaml
-sed -i -e "s@image: katib\/suggestion-nasrl@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/suggestion-nasrl:${VERSION}@" manifests/v1alpha1/vizier/suggestion/nasrl/deployment.yaml
-sed -i -e "s@image: katib\/suggestion-nasenvelopenet@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/suggestion-nasenvelopenet:${VERSION}@" manifests/v1alpha1/vizier/suggestion/nasenvelopenet/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha1\/studyjob-controller@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/studyjob-controller:${VERSION}@" manifests/v1alpha1/studyjobcontroller/studyjobcontroller.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha1\/suggestion-random@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/suggestion-random:${VERSION}@" manifests/v1alpha1/vizier/suggestion/random/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha1\/suggestion-grid@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/suggestion-grid:${VERSION}@" manifests/v1alpha1/vizier/suggestion/grid/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha1\/suggestion-hyperband@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/suggestion-hyperband:${VERSION}@" manifests/v1alpha1/vizier/suggestion/hyperband/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha1\/suggestion-bayesianoptimization@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/suggestion-bayesianoptimization:${VERSION}@" manifests/v1alpha1/vizier/suggestion/bayesianoptimization/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha1\/suggestion-nasrl@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/suggestion-nasrl:${VERSION}@" manifests/v1alpha1/vizier/suggestion/nasrl/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha1\/suggestion-nasenvelopenet@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/suggestion-nasenvelopenet:${VERSION}@" manifests/v1alpha1/vizier/suggestion/nasenvelopenet/deployment.yaml
 
-sed -i -e "s@image: katib\/earlystopping-medianstopping@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/earlystopping-medianstopping:${VERSION}@" manifests/v1alpha1/vizier/earlystopping/medianstopping/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha1\/earlystopping-medianstopping@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha1\/earlystopping-medianstopping:${VERSION}@" manifests/v1alpha1/vizier/earlystopping/medianstopping/deployment.yaml
 sed -i -e '/volumeMounts:/,$d' manifests/v1alpha1/vizier/db/deployment.yaml
 
 cat manifests/v1alpha1/vizier/core/deployment.yaml

--- a/test/scripts/v1alpha2/run-tests.sh
+++ b/test/scripts/v1alpha2/run-tests.sh
@@ -65,16 +65,16 @@ echo "REGISTRY ${REGISTRY}"
 echo "REPO_NAME ${REPO_NAME}"
 echo "VERSION ${VERSION}"
 
-sed -i -e "s@image: katib\/v1alpha2\/katib-controller@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/katib-controller:${VERSION}@" manifests/v1alpha2/katib-controller/katib-controller.yaml
-sed -i -e "s@image: katib\/v1alpha2\/metrics-collector@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/metrics-collector:${VERSION}@" manifests/v1alpha2/katib-controller/metricsControllerConfigMap.yaml
-sed -i -e "s@image: katib\/v1alpha2\/katib-manager@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/katib-manager:${VERSION}@" manifests/v1alpha2/manager/deployment.yaml
-sed -i -e "s@image: katib\/v1alpha2\/katib-manager-rest@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/katib-manager-rest:${VERSION}@" manifests/v1alpha2/manager-rest/deployment.yaml
-sed -i -e "s@image: katib\/v1alpha2\/katib-ui@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/katib-ui:${VERSION}@" manifests/v1alpha2/ui/deployment.yaml
-sed -i -e "s@image: katib\/v1alpha2\/suggestion-random@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/suggestion-random:${VERSION}@" manifests/v1alpha2/suggestion/random/deployment.yaml
-sed -i -e "s@image: katib\/v1alpha2\/suggestion-bayesianoptimization@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/suggestion-bayesianoptimization:${VERSION}@" manifests/v1alpha2/suggestion/bayesianoptimization/deployment.yaml
-sed -i -e "s@image: katib\/v1alpha2\/suggestion-nasrl@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/suggestion-nasrl:${VERSION}@" manifests/v1alpha2/suggestion/nasrl/deployment.yaml
-sed -i -e "s@image: katib\/v1alpha2\/suggestion-grid@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/suggestion-grid:${VERSION}@" manifests/v1alpha2/suggestion/grid/deployment.yaml
-sed -i -e "s@image: katib\/v1alpha2\/suggestion-hyperband@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/suggestion-hyperband:${VERSION}@" manifests/v1alpha2/suggestion/hyperband/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha2\/katib-controller@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/katib-controller:${VERSION}@" manifests/v1alpha2/katib-controller/katib-controller.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha2\/metrics-collector@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/metrics-collector:${VERSION}@" manifests/v1alpha2/katib-controller/metricsControllerConfigMap.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha2\/katib-manager@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/katib-manager:${VERSION}@" manifests/v1alpha2/manager/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha2\/katib-manager-rest@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/katib-manager-rest:${VERSION}@" manifests/v1alpha2/manager-rest/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha2\/katib-ui@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/katib-ui:${VERSION}@" manifests/v1alpha2/ui/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha2\/suggestion-random@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/suggestion-random:${VERSION}@" manifests/v1alpha2/suggestion/random/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha2\/suggestion-bayesianoptimization@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/suggestion-bayesianoptimization:${VERSION}@" manifests/v1alpha2/suggestion/bayesianoptimization/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha2\/suggestion-nasrl@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/suggestion-nasrl:${VERSION}@" manifests/v1alpha2/suggestion/nasrl/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha2\/suggestion-grid@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/suggestion-grid:${VERSION}@" manifests/v1alpha2/suggestion/grid/deployment.yaml
+sed -i -e "s@image: gcr.io\/kubeflow-images-public\/katib\/v1alpha2\/suggestion-hyperband@image: ${REGISTRY}\/${REPO_NAME}\/v1alpha2\/suggestion-hyperband:${VERSION}@" manifests/v1alpha2/suggestion/hyperband/deployment.yaml
 
 ./scripts/v1alpha2/deploy.sh
 


### PR DESCRIPTION
After this patch, user can install katib individually (not install kubeflow) with latest images by `deploy.sh`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/682)
<!-- Reviewable:end -->
