### PR TITLE
Change Image Tags to the latest in e2e tests

### DIFF
--- a/test/scripts/v1alpha1/run-tests.sh
+++ b/test/scripts/v1alpha1/run-tests.sh
@@ -27,7 +27,8 @@ ZONE="${GCP_ZONE}"
 PROJECT="${GCP_PROJECT}"
 NAMESPACE="${DEPLOY_NAMESPACE}"
 REGISTRY="${GCP_REGISTRY}"
-VERSION=$(git describe --tags --always --dirty)
+# VERSION=$(git describe --tags --always --dirty)
+VERSION="latest"
 GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
 
 echo "Activating service-account"

--- a/test/scripts/v1alpha2/run-tests.sh
+++ b/test/scripts/v1alpha2/run-tests.sh
@@ -26,7 +26,8 @@ ZONE="${GCP_ZONE}"
 PROJECT="${GCP_PROJECT}"
 NAMESPACE="${DEPLOY_NAMESPACE}"
 REGISTRY="${GCP_REGISTRY}"
-VERSION=$(git describe --tags --always --dirty)
+# VERSION=$(git describe --tags --always --dirty)
+VERSION="latest"
 GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
 
 echo "Activating service-account"


### PR DESCRIPTION
I think, we can use the latest tag in e2e tests.
Here: https://github.com/kubeflow/katib/blob/master/test/scripts/v1alpha2/build-katib-controller.sh#L41, while we are building images, we assign latest tag to the images.

It is not necessary to take version from `git describe --tags --always --dirty`.
/assign @johnugeorge @hougangliu @richardsliu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/686)
<!-- Reviewable:end -->
