### PR TITLE
MetricsCollector pod injection for katib job

### DIFF
--- a/pkg/webhook/v1alpha2/pod/const.go
+++ b/pkg/webhook/v1alpha2/pod/const.go
@@ -27,7 +27,7 @@ const (
 )
 
 var JobRoleMap = map[string][]string{
-	"TFJob":      []string{JobRoleLabel, TFJobRoleLabel},
-	"PyTorchJob": []string{JobRoleLabel, PyTorchJobRoleLabel},
-	"Job":        []string{},
+	"TFJob":      {JobRoleLabel, TFJobRoleLabel},
+	"PyTorchJob": {JobRoleLabel, PyTorchJobRoleLabel},
+	"Job":        {},
 }

--- a/pkg/webhook/v1alpha2/pod/const.go
+++ b/pkg/webhook/v1alpha2/pod/const.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+const (
+	// JobNameLabel represents the label key for the job name, the value is job name
+	JobNameLabel = "job-name"
+	// JobRoleLabel represents the label key for the job role, e.g. the value is master
+	JobRoleLabel        = "job-role"
+	TFJobRoleLabel      = "tf-job-role"
+	PyTorchJobRoleLabel = "pytorch-job-role"
+	MasterRole          = "master"
+)
+
+var JobRoleMap = map[string][]string{
+	"TFJob":      []string{JobRoleLabel, TFJobRoleLabel},
+	"PyTorchJob": []string{JobRoleLabel, PyTorchJobRoleLabel},
+	"Job":        []string{},
+}

--- a/pkg/webhook/v1alpha2/pod/inject_webhook.go
+++ b/pkg/webhook/v1alpha2/pod/inject_webhook.go
@@ -18,7 +18,6 @@ package pod
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -36,17 +35,6 @@ import (
 	katibmanagerv1alpha2 "github.com/kubeflow/katib/pkg/common/v1alpha2"
 )
 
-const (
-	// JobNameLabel represents the label key for the job name, the value is job name
-	JobNameLabel = "job-name"
-	// JobRoleLabel represents the label key for the job role, e.g. the value is master
-	JobRoleLabel = "job-role"
-	MasterRole   = "master"
-	// ControllerNameLabel represents the label key for the controller name, e.g. tf-operator and pytorch-operator
-	ControllerNameLabel = "controller-name"
-)
-
-// For debug
 var log = logf.Log.WithName("injector-webhook")
 
 // sidecarInjector that inject metrics collect sidecar into master pod
@@ -108,15 +96,15 @@ func NewSidecarInjector(c client.Client, ms string) *sidecarInjector {
 }
 
 func (s *sidecarInjector) MutationRequired(pod *v1.Pod, ns string) (bool, error) {
-	value, err := s.GetLabel(pod, JobRoleLabel)
-	if err != nil || value != MasterRole {
-		return false, nil
-	}
-
-	trialName, err := s.GetLabel(pod, JobNameLabel)
+	jobKind, jobName, err := getKabitJob(pod)
 	if err != nil {
 		return false, nil
 	}
+	if !isMasterRole(pod, jobKind) {
+		return false, nil
+	}
+
+	trialName := jobName
 	trial := &trialsv1alpha2.Trial{}
 	err = s.client.Get(context.TODO(), apitypes.NamespacedName{Name: trialName, Namespace: ns}, trial)
 	if err != nil {
@@ -130,43 +118,12 @@ func (s *sidecarInjector) MutationRequired(pod *v1.Pod, ns string) (bool, error)
 	return true, nil
 }
 
-func (s *sidecarInjector) GetLabel(pod *v1.Pod, targetLabel string) (string, error) {
-	labels := pod.Labels
-	for k, v := range labels {
-		if k == targetLabel {
-			return v, nil
-		}
-	}
-	return "", errors.New("Label " + targetLabel + " not found.")
-}
-
-func GetJobKind(controllerName string) string {
-	if controllerName == "tf-operator" {
-		return "TFJob"
-	} else if controllerName == "pytorch-operator" {
-		return "PyTorchJob"
-	}
-	return "Unknown"
-}
-
 func (s *sidecarInjector) Mutate(pod *v1.Pod, namespace string) (*v1.Pod, error) {
 	mutatedPod := pod.DeepCopy()
 
-	// Get job Kind from label controller-name.
-	kind := "TODO_Kind"
-	controllerName, err := s.GetLabel(pod, ControllerNameLabel)
-	if err == nil {
-		kind = GetJobKind(controllerName)
-	}
-
-	// Get the trial info from client
-	trialName, err := s.GetLabel(pod, JobNameLabel)
-	if err != nil {
-		return nil, err
-	}
+	kind, trialName, _ := getKabitJob(pod)
 	trial := &trialsv1alpha2.Trial{}
-	err = s.client.Get(context.TODO(), apitypes.NamespacedName{Name: trialName, Namespace: namespace}, trial)
-	if err != nil {
+	if err := s.client.Get(context.TODO(), apitypes.NamespacedName{Name: trialName, Namespace: namespace}, trial); err != nil {
 		return nil, err
 	}
 
@@ -195,5 +152,6 @@ func (s *sidecarInjector) Mutate(pod *v1.Pod, namespace string) (*v1.Pod, error)
 	mutatedPod.Spec.Containers = append(mutatedPod.Spec.Containers, injectContainer)
 	mutatedPod.Spec.ServiceAccountName = pod.Spec.ServiceAccountName
 
+	log.Info("Inject metrics collector sidecar container", "Pod", pod.Name, "Trial", trialName, "Experiment", experimentName)
 	return mutatedPod, nil
 }

--- a/pkg/webhook/v1alpha2/pod/utils.go
+++ b/pkg/webhook/v1alpha2/pod/utils.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"errors"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	commonv1alpha2 "github.com/kubeflow/katib/pkg/common/v1alpha2"
+)
+
+func getKabitJob(pod *v1.Pod) (string, string, error) {
+	for _, gvk := range commonv1alpha2.GetSupportedJobList() {
+		owners := pod.GetOwnerReferences()
+		for _, owner := range owners {
+			if isMatchGVK(owner, gvk) {
+				return owner.Kind, owner.Name, nil
+			}
+		}
+	}
+	return "", "", errors.New("The Pod doesn't belong to Katib Job")
+}
+
+func isMatchGVK(owner metav1.OwnerReference, gvk schema.GroupVersionKind) bool {
+	if owner.Kind != gvk.Kind {
+		return false
+	}
+	gv := gvk.Group + "/" + gvk.Version
+	if gv != owner.APIVersion {
+		return false
+	}
+	return true
+}
+
+func isMasterRole(pod *v1.Pod, jobKind string) bool {
+	if labels, ok := JobRoleMap[jobKind]; ok {
+		if len(labels) == 0 {
+			return true
+		}
+		for _, label := range labels {
+			if v, err := getLabel(pod, label); err == nil {
+				if v == MasterRole {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func getLabel(pod *v1.Pod, targetLabel string) (string, error) {
+	labels := pod.Labels
+	for k, v := range labels {
+		if k == targetLabel {
+			return v, nil
+		}
+	}
+	return "", errors.New("Label " + targetLabel + " not found.")
+}


### PR DESCRIPTION
1. support kubernetes`Job` pod metrics collector injection, not just Pytorch and tfjob worker kind
2. Tfjob/pytorch job labels backward compatibility

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/738)
<!-- Reviewable:end -->
