### PR TITLE
Populate Parameter assignments in trials

### DIFF
--- a/pkg/controller.v1alpha3/experiment/experiment_util.go
+++ b/pkg/controller.v1alpha3/experiment/experiment_util.go
@@ -33,6 +33,7 @@ func (r *ReconcileExperiment) createTrialInstance(expInstance *experimentsv1alph
 	trial.Spec.Objective = expInstance.Spec.Objective
 
 	hps := trialAssignment.ParameterAssignments
+	trial.Spec.ParameterAssignments = trialAssignment.ParameterAssignments
 	runSpec, err := r.GetRunSpecWithHyperParameters(expInstance, expInstance.GetName(), trial.Name, trial.Namespace, hps)
 	if err != nil {
 		logger.Error(err, "Fail to get RunSpec from experiment", expInstance.Name)


### PR DESCRIPTION
Best Parameter assignment is not populated in Experiment as trial spec was not updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/751)
<!-- Reviewable:end -->
