### PR TITLE
Wait for GRPC server to be up

### DIFF
--- a/cmd/suggestion/hyperopt/v1alpha3/requirements.txt
+++ b/cmd/suggestion/hyperopt/v1alpha3/requirements.txt
@@ -1,10 +1,10 @@
-grpcio
-duecredit
+grpcio==1.23.0
+duecredit===0.7.0
 cloudpickle==0.5.6
 numpy>=1.13.3
 scikit-learn>=0.19.0
 scipy>=0.19.1
-forestci
-protobuf
-googleapis-common-protos
+forestci==0.3
+protobuf==3.9.1
+googleapis-common-protos==1.6.0
 hyperopt==0.1.2

--- a/pkg/controller.v1alpha3/suggestion/suggestionclient/suggestionclient.go
+++ b/pkg/controller.v1alpha3/suggestion/suggestionclient/suggestionclient.go
@@ -100,7 +100,9 @@ func (g *General) ValidateAlgorithmSettings(instance *suggestionsv1alpha3.Sugges
 	request := &suggestionapi.ValidateAlgorithmSettingsRequest{
 		Experiment: g.ConvertExperiment(e),
 	}
-	_, err = client.ValidateAlgorithmSettings(ctx, request)
+	// See https://github.com/grpc/grpc-go/issues/2636
+	// See https://github.com/grpc/grpc-go/pull/2503
+	_, err = client.ValidateAlgorithmSettings(ctx, request, grpc.WaitForReady(true))
 	statusCode, _ := status.FromError(err)
 
 	// validation error


### PR DESCRIPTION
grpc.WaitForReady(true) waits  for ready in GRPC calls. All packages are versioned for reproducibility

Related: https://github.com/grpc/grpc-go/issues/2636
Related: https://github.com/grpc/grpc-go/pull/2503

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/785)
<!-- Reviewable:end -->
