### PR TITLE
Update status conditions during reconcile error

### DIFF
--- a/pkg/controller.v1alpha3/suggestion/suggestion_controller.go
+++ b/pkg/controller.v1alpha3/suggestion/suggestion_controller.go
@@ -149,6 +149,11 @@ func (r *ReconcileSuggestion) Reconcile(request reconcile.Request) (reconcile.Re
 		if err != nil {
 			r.recorder.Eventf(instance, corev1.EventTypeWarning,
 				consts.ReconcileErrorReason, err.Error())
+
+			// Try updating just the status condition when possible
+			// Status conditions might need to be  updated even in error
+			// Ignore all other status fields else it will be inconsistent during retry
+			_ = r.updateStatusCondition(instance, oldS)
 			logger.Error(err, "Reconcile Suggestion error")
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller.v1alpha3/suggestion/suggestion_controller_status.go
+++ b/pkg/controller.v1alpha3/suggestion/suggestion_controller_status.go
@@ -25,3 +25,15 @@ func (r *ReconcileSuggestion) updateStatus(s *suggestionsv1alpha3.Suggestion, ol
 	}
 	return nil
 }
+
+func (r *ReconcileSuggestion) updateStatusCondition(s *suggestionsv1alpha3.Suggestion, oldS *suggestionsv1alpha3.Suggestion) error {
+	if !equality.Semantic.DeepEqual(s.Status.Conditions, oldS.Status.Conditions) {
+		newConditions := s.Status.Conditions
+		s.Status = oldS.Status
+		s.Status.Conditions = newConditions
+		if err := r.Status().Update(context.TODO(), s); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Update Status conditions during reconcile error because status conditions might be updated. Rest all status fields should be ignored

Fixes: #804 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/831)
<!-- Reviewable:end -->
