### PR TITLE
feat: Add event when the reconcile is failed

### DIFF
--- a/pkg/controller.v1alpha3/trial/trial_controller.go
+++ b/pkg/controller.v1alpha3/trial/trial_controller.go
@@ -185,7 +185,8 @@ func (r *ReconcileTrial) Reconcile(request reconcile.Request) (reconcile.Result,
 		if err != nil {
 			logger.Error(err, "Reconcile trial error")
 			r.recorder.Eventf(instance,
-				corev1.EventTypeWarning, ReconcileFailedReason, err.Error())
+				corev1.EventTypeWarning, ReconcileFailedReason,
+				"Failed to reconcile: %v", err)
 			return reconcile.Result{}, err
 		}
 	}

--- a/pkg/controller.v1alpha3/trial/trial_controller.go
+++ b/pkg/controller.v1alpha3/trial/trial_controller.go
@@ -184,6 +184,8 @@ func (r *ReconcileTrial) Reconcile(request reconcile.Request) (reconcile.Result,
 		err := r.reconcileTrial(instance)
 		if err != nil {
 			logger.Error(err, "Reconcile trial error")
+			r.recorder.Eventf(instance,
+				corev1.EventTypeWarning, ReconcileFailedReason, err.Error())
 			return reconcile.Result{}, err
 		}
 	}

--- a/pkg/controller.v1alpha3/trial/trial_controller_consts.go
+++ b/pkg/controller.v1alpha3/trial/trial_controller_consts.go
@@ -17,4 +17,5 @@ const (
 	JobSucceededReason          = "JobSucceeded"
 	JobMetricsUnavailableReason = "MetricsUnavailable"
 	JobFailedReason             = "JobFailed"
+	ReconcileFailedReason       = "ReconcileFailed"
 )


### PR DESCRIPTION
Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

When the reconcile has errors, we cannot get it from trial event. It is hard to debug. Thus I suggest sending an Event to trial if the reconcile is failed. It will not have the performance issue since the events are only kept for 1 hour by default.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/879)
<!-- Reviewable:end -->
