### PR TITLE
fix: Use as instead of , to support python 3 in tfevent metrics collector

### DIFF
--- a/cmd/metricscollector/v1alpha3/tfevent-metricscollector/main.py
+++ b/cmd/metricscollector/v1alpha3/tfevent-metricscollector/main.py
@@ -6,17 +6,22 @@ from pns import WaitOtherMainProcesses
 from tfevent_loader import MetricsCollector
 from logging import getLogger, StreamHandler, INFO
 
+timeout_in_seconds = 60
+
+
 def parse_options():
     parser = argparse.ArgumentParser(
-            description='TF-Event MetricsCollector',
-            add_help = True
-            )
-    parser.add_argument("-s", "--manager_server_addr", type = str, default = "katib-manager:6789")
-    parser.add_argument("-t", "--trial_name", type = str, default = "")
-    parser.add_argument("-path", "--dir_path", type = str, default = "/log")
-    parser.add_argument("-m", "--metric_names", type = str, default = "")
+        description='TF-Event MetricsCollector',
+        add_help=True
+    )
+    parser.add_argument("-s", "--manager_server_addr",
+                        type=str, default="katib-manager:6789")
+    parser.add_argument("-t", "--trial_name", type=str, default="")
+    parser.add_argument("-path", "--dir_path", type=str, default="/log")
+    parser.add_argument("-m", "--metric_names", type=str, default="")
     opt = parser.parse_args()
     return opt
+
 
 if __name__ == '__main__':
     logger = getLogger(__name__)
@@ -28,18 +33,21 @@ if __name__ == '__main__':
     opt = parse_options()
     manager_server = opt.manager_server_addr.split(':')
     if len(manager_server) != 2:
-        raise Exception("Invalid katib manager service address: %s" % opt.manager_server_addr)
-    
+        raise Exception("Invalid katib manager service address: %s" %
+                        opt.manager_server_addr)
+
     WaitOtherMainProcesses()
 
     mc = MetricsCollector(opt.metric_names.split(','))
     observation_log = mc.parse_file(opt.dir_path)
 
-    channel = grpc.beta.implementations.insecure_channel(manager_server[0], int(manager_server[1]))
+    channel = grpc.beta.implementations.insecure_channel(
+        manager_server[0], int(manager_server[1]))
 
     with api_pb2.beta_create_Manager_stub(channel) as client:
-        logger.info("In " + opt.trial_name + " " + str(len(observation_log.metric_logs)) + " metrics will be reported.")
+        logger.info("In " + opt.trial_name + " " +
+                    str(len(observation_log.metric_logs)) + " metrics will be reported.")
         client.ReportObservationLog(api_pb2.ReportObservationLogRequest(
             trial_name=opt.trial_name,
             observation_log=observation_log
-            ), 10)
+        ), timeout=timeout_in_seconds)

--- a/pkg/metricscollector/v1alpha3/tfevent-metricscollector/tfevent_loader.py
+++ b/pkg/metricscollector/v1alpha3/tfevent-metricscollector/tfevent_loader.py
@@ -58,8 +58,7 @@ class MetricsCollector:
             try:
                 self.logger.info(f + " will be parsed.")
                 mls = self.parser.parse_summary(f, self.metrics)
-            except Exception, e:
+            except Exception as e:
                 self.logger.warning("Unexpected error: "+ str(e))
                 continue
         return api_pb2.ObservationLog(metric_logs=mls)
- 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #877 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/881)
<!-- Reviewable:end -->
