### PR TITLE
Enable arm64 architecture support for katib images and fix grpc health probe multiarch error.

### DIFF
--- a/cmd/katib-controller/v1alpha2/Dockerfile
+++ b/cmd/katib-controller/v1alpha2/Dockerfile
@@ -8,6 +8,8 @@ WORKDIR /go/src/github.com/kubeflow/katib/cmd/katib-controller
 # Build
 RUN if [ "$(uname -m)" = "ppc64le" ]; then \
         CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -a -o katib-controller  ./v1alpha2; \
+    elif [ "$(uname -m)" = "aarch64" ]; then \
+        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o katib-controller  ./v1alpha2; \
     else \
         CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o katib-controller  ./v1alpha2; \
     fi

--- a/cmd/katib-controller/v1alpha3/Dockerfile
+++ b/cmd/katib-controller/v1alpha3/Dockerfile
@@ -8,6 +8,8 @@ WORKDIR /go/src/github.com/kubeflow/katib/cmd/katib-controller
 # Build
 RUN if [ "$(uname -m)" = "ppc64le" ]; then \
         CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -a -o katib-controller  ./v1alpha3; \
+    elif [ "$(uname -m)" = "aarch64" ]; then \
+        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o katib-controller  ./v1alpha3; \
     else \
         CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o katib-controller  ./v1alpha3; \
     fi

--- a/cmd/manager-rest/v1alpha2/Dockerfile
+++ b/cmd/manager-rest/v1alpha2/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:alpine AS build-env
 # The GOPATH in the image is /go.
 ADD . /go/src/github.com/kubeflow/katib
 WORKDIR /go/src/github.com/kubeflow/katib/cmd/manager-rest
-RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
         apk --update add gcc musl-dev  && \
         go build -o katib-manager-rest ./v1alpha2; \
     else \

--- a/cmd/manager/v1alpha2/Dockerfile
+++ b/cmd/manager/v1alpha2/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:alpine AS build-env
 # The GOPATH in the image is /go.
 ADD . /go/src/github.com/kubeflow/katib
 WORKDIR /go/src/github.com/kubeflow/katib/cmd/manager
-RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
         apk --update add git gcc musl-dev && \
         go build -o katib-manager ./v1alpha2  && \
         go get github.com/grpc-ecosystem/grpc-health-probe && \

--- a/cmd/manager/v1alpha3/Dockerfile
+++ b/cmd/manager/v1alpha3/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:alpine AS build-env
 # The GOPATH in the image is /go.
 ADD . /go/src/github.com/kubeflow/katib
 WORKDIR /go/src/github.com/kubeflow/katib/cmd/manager
-RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
         apk --update add git gcc musl-dev && \
         go build -o katib-manager ./v1alpha3; \
     else \

--- a/cmd/metricscollector/v1alpha2/Dockerfile
+++ b/cmd/metricscollector/v1alpha2/Dockerfile
@@ -9,6 +9,8 @@ WORKDIR /go/src/github.com/kubeflow/katib/cmd/metricscollector
 # Build
 RUN if [ "$(uname -m)" = "ppc64le" ]; then \
         CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -a -o metricscollector ./v1alpha2; \
+    elif [ "$(uname -m)" = "aarch64" ]; then \
+        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o metricscollector ./v1alpha2; \
     else \
         CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o metricscollector ./v1alpha2; \
     fi

--- a/cmd/metricscollector/v1alpha3/file-metricscollector/Dockerfile
+++ b/cmd/metricscollector/v1alpha3/file-metricscollector/Dockerfile
@@ -9,6 +9,8 @@ WORKDIR /go/src/github.com/kubeflow/katib/cmd/metricscollector/v1alpha3/file-met
 # Build
 RUN if [ "$(uname -m)" = "ppc64le" ]; then \
         CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -a -o file-metricscollector ./; \
+    elif [ "$(uname -m)" = "aarch64" ]; then \
+        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -o file-metricscollector ./; \
     else \
         CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o file-metricscollector ./; \
     fi

--- a/cmd/metricscollector/v1alpha3/tfevent-metricscollector/Dockerfile.aarch64
+++ b/cmd/metricscollector/v1alpha3/tfevent-metricscollector/Dockerfile.aarch64
@@ -1,0 +1,28 @@
+FROM ubuntu:18.04
+
+RUN apt-get update \
+    && apt-get -y install software-properties-common \
+        autoconf \
+        automake \
+        build-essential \
+        cmake \
+        pkg-config \
+        wget \
+        python-pip \
+        libhdf5-dev \
+        libhdf5-serial-dev \
+        hdf5-tools\
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://github.com/lhelontra/tensorflow-on-arm/releases/download/v1.11.0/tensorflow-1.11.0-cp27-none-linux_aarch64.whl \
+    && pip install tensorflow-1.11.0-cp27-none-linux_aarch64.whl \
+    && rm tensorflow-1.11.0-cp27-none-linux_aarch64.whl \
+    && rm -rf .cache
+
+RUN pip install rfc3339 grpcio googleapis-common-protos jupyter
+ADD . /usr/src/app/github.com/kubeflow/katib
+WORKDIR /usr/src/app/github.com/kubeflow/katib/cmd/metricscollector/v1alpha3/tfevent-metricscollector/
+RUN pip install --no-cache-dir -r requirements.txt
+ENV PYTHONPATH /usr/src/app/github.com/kubeflow/katib:/usr/src/app/github.com/kubeflow/katib/pkg/apis/manager/v1alpha3/python:/usr/src/app/github.com/kubeflow/katib/pkg/metricscollector/v1alpha3/tfevent-metricscollector/:/usr/src/app/github.com/kubeflow/katib/pkg/metricscollector/v1alpha3/common/
+ENTRYPOINT ["python", "main.py"]

--- a/cmd/suggestion/bayesianoptimization/v1alpha2/Dockerfile
+++ b/cmd/suggestion/bayesianoptimization/v1alpha2/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3
+FROM python:3.6
 
 ADD . /usr/src/app/github.com/kubeflow/katib
 WORKDIR /usr/src/app/github.com/kubeflow/katib/cmd/suggestion/bayesianoptimization/v1alpha2
-RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
        apt-get update && apt-get -y install libblas-dev liblapack-dev libatlas-base-dev gfortran && \
        pip install cython; \
     fi

--- a/cmd/suggestion/chocolate/v1alpha3/Dockerfile
+++ b/cmd/suggestion/chocolate/v1alpha3/Dockerfile
@@ -1,13 +1,15 @@
 FROM python:3.6
 
-RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
         apt-get -y update && \
         apt-get -y install gfortran libopenblas-dev liblapack-dev && \
-        pip install cython; \
+        pip install cython 'numpy>=1.13.3'; \
     fi
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     if [ "$(uname -m)" = "ppc64le" ]; then \
 	wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-ppc64le; \
+    elif [ "$(uname -m)" = "aarch64" ]; then \
+        wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-arm64; \
     else \
 	wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64; \
     fi && \

--- a/cmd/suggestion/grid/v1alpha2/Dockerfile
+++ b/cmd/suggestion/grid/v1alpha2/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3
+FROM python:3.6
 
 ADD . /usr/src/app/github.com/kubeflow/katib
 WORKDIR /usr/src/app/github.com/kubeflow/katib/cmd/suggestion/grid/v1alpha2
-RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
         apt-get -y update && \
         apt-get -y install gfortran libopenblas-dev liblapack-dev && \
         pip install cython; \

--- a/cmd/suggestion/hyperband/v1alpha2/Dockerfile
+++ b/cmd/suggestion/hyperband/v1alpha2/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3
+FROM python:3.6
 
 ADD . /usr/src/app/github.com/kubeflow/katib
 WORKDIR /usr/src/app/github.com/kubeflow/katib/cmd/suggestion/hyperband/v1alpha2
-RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
         apt-get -y update && \
         apt-get -y install gfortran libopenblas-dev liblapack-dev && \
         pip install cython; \

--- a/cmd/suggestion/hyperband/v1alpha3/Dockerfile
+++ b/cmd/suggestion/hyperband/v1alpha3/Dockerfile
@@ -1,17 +1,21 @@
 FROM python:3.6
 
-RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
         apt-get -y update && \
         apt-get -y install gfortran libopenblas-dev liblapack-dev && \
         pip install cython; \
     fi
+
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     if [ "$(uname -m)" = "ppc64le" ]; then \
 	wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-ppc64le; \
+    elif [ "$(uname -m)" = "aarch64" ]; then \
+        wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-arm64; \
     else \
 	wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64; \
     fi && \
     chmod +x /bin/grpc_health_probe
+
 ADD . /usr/src/app/github.com/kubeflow/katib
 WORKDIR /usr/src/app/github.com/kubeflow/katib/cmd/suggestion/hyperband/v1alpha3
 RUN pip install --no-cache-dir -r requirements.txt

--- a/cmd/suggestion/hyperopt/v1alpha3/Dockerfile
+++ b/cmd/suggestion/hyperopt/v1alpha3/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6
 
-RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
         apt-get -y update && \
         apt-get -y install gfortran libopenblas-dev liblapack-dev && \
         pip install cython; \
@@ -9,6 +9,8 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     if [ "$(uname -m)" = "ppc64le" ]; then \
 	wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-ppc64le; \
+    elif [ "$(uname -m)" = "aarch64" ]; then \
+        wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-arm64; \
     else \
 	wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64; \
     fi && \

--- a/cmd/suggestion/nasrl/v1alpha2/Dockerfile.aarch64
+++ b/cmd/suggestion/nasrl/v1alpha2/Dockerfile.aarch64
@@ -1,0 +1,92 @@
+FROM ubuntu:18.04
+
+#install bazel
+RUN apt-get update \
+    && apt-get install -y software-properties-common \
+	build-essential \
+	curl \
+	openjdk-8-jdk \
+	openjdk-8-jre-headless \
+	pkg-config \
+	zip \
+	g++ \
+	wget \
+	git \
+	zlib1g-dev \
+	unzip \
+	python3.6 \
+	python3-pip \
+	python3.6-dev \
+	python3-setuptools \
+	libhdf5-serial-dev \
+	libcurl3-dev \
+	libfreetype6-dev \
+	libzmq3-dev \
+	rsync \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+#set default python as python3
+RUN ln -s /usr/bin/python3.6 /usr/bin/python && ln -s /usr/bin/pip3 /usr/bin/pip
+
+ENV BAZEL_VERSION=0.18.1
+
+RUN mkdir -p /bazel \
+    && cd /bazel \
+    && curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-dist.zip \
+    && unzip bazel-$BAZEL_VERSION-dist.zip \
+    && ./compile.sh \
+    && cp output/bazel /usr/local/bin \
+    && rm -rf /bazel
+
+#build and install tensorflow
+RUN pip install -U cython six 'numpy==1.16.4' wheel mock 'future>=0.17.1' \
+    && pip install keras_applications==1.0.6 --no-deps \
+    && pip install keras_preprocessing==1.0.5 --no-deps \
+    && pip install tensorflow_estimator --no-deps
+
+ENV TF_ROOT=/tensorflow
+ENV PYTHON_BIN_PATH=/usr/bin/python3
+ENV PYTHON_LIB_PATH="$($PYTHON_BIN_PATH -c 'import site; print(site.getsitepackages()[0])')"
+ENV PYTHONPATH=${TF_ROOT}/lib
+ENV PYTHON_ARG=${TF_ROOT}/lib
+ENV TF_NEED_GCP=0
+ENV TF_NEED_CUDA=0
+ENV TF_NEED_HDFS=0
+ENV TF_NEED_OPENCL=0
+ENV TF_NEED_JEMALLOC=0
+ENV TF_ENABLE_XLA=0
+ENV TF_NEED_VERBS=0
+ENV TF_NEED_MKL=0
+ENV TF_DOWNLOAD_MKL=0
+ENV TF_NEED_AWS=0
+ENV TF_NEED_MPI=0
+ENV TF_NEED_GDR=0
+ENV TF_NEED_S3=0
+ENV TF_NEED_OPENCL_SYCL=0
+ENV TF_SET_ANDROID_WORKSPACE=0
+ENV TF_NEED_COMPUTECPP=0
+ENV CC_OPT_FLAGS="-march=native"
+ENV TF_SET_ANDROID_WORKSPACE=0
+ENV TF_NEED_KAFKA=0
+ENV TF_NEED_TENSORRT=0
+ENV TF_NEED_AWS=0
+
+RUN git clone https://github.com/tensorflow/tensorflow.git \
+    && cd tensorflow \
+    && git checkout v1.12.0 \
+    && sed -i 's/ "-mfpu=neon",//' /tensorflow/tensorflow/contrib/lite/kernels/internal/BUILD \
+    && sed -i '0,/conditions:default": \[\],/s//conditions:default": glob(\["aws-cpp-sdk-core\/source\/platform\/linux-shared\/*\.cpp",\]),/' /tensorflow/third_party/aws.BUILD \
+    && ./configure \
+    && bazel build --config=opt //tensorflow/tools/pip_package:build_pip_package \
+    && bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg \
+    && pip install --upgrade --force-reinstall /tmp/tensorflow_pkg/tensorflow*.whl\
+    && rm -rf /tensorflow \
+    && rm -r /tmp/tensorflow_pkg/tensorflow*.whl
+
+ADD . /usr/src/app/github.com/kubeflow/katib
+WORKDIR /usr/src/app/github.com/kubeflow/katib/cmd/suggestion/nasrl/v1alpha2
+RUN pip install --no-cache-dir -r requirements.txt
+ENV PYTHONPATH /usr/src/app/github.com/kubeflow/katib:/usr/src/app/github.com/kubeflow/katib/pkg/apis/manager/v1alpha2/python
+
+ENTRYPOINT ["python", "-u", "main.py"]

--- a/cmd/suggestion/nasrl/v1alpha3/Dockerfile
+++ b/cmd/suggestion/nasrl/v1alpha3/Dockerfile
@@ -12,6 +12,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
 	wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64; \
     fi && \
     chmod +x /bin/grpc_health_probe
+
 ADD . /usr/src/app/github.com/kubeflow/katib
 WORKDIR /usr/src/app/github.com/kubeflow/katib/cmd/suggestion/nasrl/v1alpha3
 RUN pip install --no-cache-dir -r requirements.txt

--- a/cmd/suggestion/nasrl/v1alpha3/Dockerfile.aarch64
+++ b/cmd/suggestion/nasrl/v1alpha3/Dockerfile.aarch64
@@ -1,0 +1,51 @@
+FROM golang:alpine AS build-env
+# The GOPATH in the image is /go.
+ADD . /go/src/github.com/kubeflow/katib
+RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
+        apk --update add git gcc musl-dev && \
+        go get github.com/grpc-ecosystem/grpc-health-probe && \
+        mv $GOPATH/bin/grpc-health-probe /bin/grpc_health_probe && \
+        chmod +x /bin/grpc_health_probe; \
+    else \
+        GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
+            wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+            chmod +x /bin/grpc_health_probe; \
+    fi
+
+FROM python:3.7-slim-buster
+
+RUN apt-get update \
+    && apt-get -y install software-properties-common \
+	autoconf \
+	automake \
+	build-essential \
+	cmake \
+	libtool \
+	pkg-config \
+	wget \
+	gfortran \
+	libopenblas-dev \
+	liblapack-dev \
+	libhdf5-dev \
+	libhdf5-serial-dev \
+	hdf5-tools \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install cython numpy
+
+RUN wget https://github.com/lhelontra/tensorflow-on-arm/releases/download/v1.14.0-buster/tensorflow-1.14.0-cp37-none-linux_aarch64.whl \
+    && pip install tensorflow-1.14.0-cp37-none-linux_aarch64.whl \
+    && rm tensorflow-1.14.0-cp37-none-linux_aarch64.whl \
+    && rm -rf .cache
+
+RUN pip install 'grpcio==1.23.0' 'protobuf==3.9.1' 'googleapis-common-protos==1.6.0'
+
+COPY --from=build-env /bin/grpc_health_probe /bin/
+
+ADD . /usr/src/app/github.com/kubeflow/katib
+WORKDIR /usr/src/app/github.com/kubeflow/katib/cmd/suggestion/nasrl/v1alpha3
+
+ENV PYTHONPATH /usr/src/app/github.com/kubeflow/katib:/usr/src/app/github.com/kubeflow/katib/pkg/apis/manager/v1alpha3/python:/usr/src/app/github.com/kubeflow/katib/pkg/apis/manager/health/python
+
+ENTRYPOINT ["python", "main.py"]

--- a/cmd/suggestion/random/v1alpha2/Dockerfile
+++ b/cmd/suggestion/random/v1alpha2/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3
+FROM python:3.6
 
 ADD . /usr/src/app/github.com/kubeflow/katib
 WORKDIR /usr/src/app/github.com/kubeflow/katib/cmd/suggestion/random/v1alpha2
-RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
         apt-get -y update && \
         apt-get -y install gfortran libopenblas-dev liblapack-dev && \
         pip install cython; \

--- a/cmd/suggestion/skopt/v1alpha3/Dockerfile
+++ b/cmd/suggestion/skopt/v1alpha3/Dockerfile
@@ -1,17 +1,21 @@
 FROM python:3.6
 
-RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
         apt-get -y update && \
         apt-get -y install gfortran libopenblas-dev liblapack-dev && \
         pip install cython; \
     fi
+
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     if [ "$(uname -m)" = "ppc64le" ]; then \
 	wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-ppc64le; \
+    elif [ "$(uname -m)" = "aarch64" ]; then \
+        wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-arm64; \
     else \
 	wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64; \
     fi && \
     chmod +x /bin/grpc_health_probe
+
 ADD . /usr/src/app/github.com/kubeflow/katib
 WORKDIR /usr/src/app/github.com/kubeflow/katib/cmd/suggestion/skopt/v1alpha3
 RUN pip install --no-cache-dir -r requirements.txt

--- a/cmd/tfevent-metricscollector/v1alpha2/Dockerfile.aarch64
+++ b/cmd/tfevent-metricscollector/v1alpha2/Dockerfile.aarch64
@@ -1,0 +1,28 @@
+FROM ubuntu:18.04
+
+RUN apt-get update \
+    && apt-get -y install software-properties-common \
+	autoconf \
+	automake \
+	build-essential \
+	cmake \
+	pkg-config \
+	wget \
+	python-pip \
+	libhdf5-dev \
+	libhdf5-serial-dev \
+	hdf5-tools\
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://github.com/lhelontra/tensorflow-on-arm/releases/download/v1.11.0/tensorflow-1.11.0-cp27-none-linux_aarch64.whl \
+    && pip install tensorflow-1.11.0-cp27-none-linux_aarch64.whl \
+    && rm tensorflow-1.11.0-cp27-none-linux_aarch64.whl \
+    && rm -rf .cache
+
+RUN pip install rfc3339 grpcio googleapis-common-protos jupyter
+ADD . /usr/src/app/github.com/kubeflow/katib
+WORKDIR /usr/src/app/github.com/kubeflow/katib/cmd/tfevent-metricscollector/v1alpha2
+ENV PYTHONPATH /usr/src/app/github.com/kubeflow/katib:/usr/src/app/github.com/kubeflow/katib/pkg/apis/manager/v1alpha2/python:/usr/src/app/github.com/kubeflow/katib/pkg/util/v1alpha2/tfevent-metricscollector
+
+CMD ["bash","-c","jupyter notebook --ip 0.0.0.0 --no-browser --allow-root"]

--- a/cmd/ui/v1alpha2/Dockerfile
+++ b/cmd/ui/v1alpha2/Dockerfile
@@ -9,7 +9,7 @@ FROM golang:alpine AS go-build
 # The GOPATH in the image is /go.
 ADD . /go/src/github.com/kubeflow/katib
 WORKDIR /go/src/github.com/kubeflow/katib/cmd/ui
-RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
         apk --update add gcc musl-dev  && \
 	go build -o katib-ui ./v1alpha2; \
     else \

--- a/cmd/ui/v1alpha3/Dockerfile
+++ b/cmd/ui/v1alpha3/Dockerfile
@@ -9,7 +9,7 @@ FROM golang:alpine AS go-build
 # The GOPATH in the image is /go.
 ADD . /go/src/github.com/kubeflow/katib
 WORKDIR /go/src/github.com/kubeflow/katib/cmd/ui
-RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
         apk --update add gcc musl-dev  && \
 	go build -o katib-ui ./v1alpha3; \
     else \

--- a/scripts/v1alpha2/build.sh
+++ b/scripts/v1alpha2/build.sh
@@ -20,6 +20,7 @@ set -o pipefail
 
 PREFIX="katib"
 CMD_PREFIX="cmd"
+MACHINE_ARCH=`uname -m`
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/../..
 
@@ -35,11 +36,19 @@ echo "Building UI image..."
 docker build -t ${PREFIX}/v1alpha2/katib-ui -f ${CMD_PREFIX}/ui/v1alpha2/Dockerfile .
 
 echo "Building TF Event metrics collector image..."
-docker build -t ${PREFIX}/v1alpha2/tfevent-metrics-collector -f ${CMD_PREFIX}/tfevent-metricscollector/v1alpha2/Dockerfile .
+if [ $MACHINE_ARCH == "aarch64" ]; then
+	docker build -t ${PREFIX}/v1alpha2/tfevent-metrics-collector -f ${CMD_PREFIX}/tfevent-metricscollector/v1alpha2/Dockerfile.aarch64 .
+else
+	docker build -t ${PREFIX}/v1alpha2/tfevent-metrics-collector -f ${CMD_PREFIX}/tfevent-metricscollector/v1alpha2/Dockerfile .
+fi
 
 echo "Building suggestion images..."
 docker build -t ${PREFIX}/v1alpha2/suggestion-random -f ${CMD_PREFIX}/suggestion/random/v1alpha2/Dockerfile .
 docker build -t ${PREFIX}/v1alpha2/suggestion-bayesianoptimization -f ${CMD_PREFIX}/suggestion/bayesianoptimization/v1alpha2/Dockerfile .
 docker build -t ${PREFIX}/v1alpha2/suggestion-grid -f ${CMD_PREFIX}/suggestion/grid/v1alpha2/Dockerfile .
 docker build -t ${PREFIX}/v1alpha2/suggestion-hyperband -f ${CMD_PREFIX}/suggestion/hyperband/v1alpha2/Dockerfile .
-docker build -t ${PREFIX}/v1alpha2/suggestion-nasrl -f ${CMD_PREFIX}/suggestion/nasrl/v1alpha2/Dockerfile .
+if [ $MACHINE_ARCH == "aarch64" ]; then
+	docker build -t ${PREFIX}/v1alpha2/suggestion-nasrl -f ${CMD_PREFIX}/suggestion/nasrl/v1alpha2/Dockerfile.aarch64 .
+else
+	docker build -t ${PREFIX}/v1alpha2/suggestion-nasrl -f ${CMD_PREFIX}/suggestion/nasrl/v1alpha2/Dockerfile .
+fi

--- a/scripts/v1alpha3/build.sh
+++ b/scripts/v1alpha3/build.sh
@@ -22,6 +22,7 @@ REGISTRY="gcr.io/kubeflow-images-public"
 TAG="latest"
 PREFIX="katib/v1alpha3"
 CMD_PREFIX="cmd"
+MACHINE_ARCH=`uname -m`
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/../..
 
@@ -58,11 +59,19 @@ echo "Building file metrics collector image..."
 docker build -t ${REGISTRY}/${PREFIX}/file-metrics-collector:${TAG} -f ${CMD_PREFIX}/metricscollector/v1alpha3/file-metricscollector/Dockerfile .
 
 echo "Building TF Event metrics collector image..."
-docker build -t ${REGISTRY}/${PREFIX}/tfevent-metrics-collector:${TAG} -f ${CMD_PREFIX}/metricscollector/v1alpha3/tfevent-metricscollector/Dockerfile .
+if [ $MACHINE_ARCH == "aarch64" ]; then
+        docker build -t ${REGISTRY}/${PREFIX}/tfevent-metrics-collector:${TAG} -f ${CMD_PREFIX}/metricscollector/v1alpha3/tfevent-metricscollector/Dockerfile.aarch64 .
+else
+        docker build -t ${REGISTRY}/${PREFIX}/tfevent-metrics-collector:${TAG} -f ${CMD_PREFIX}/metricscollector/v1alpha3/tfevent-metricscollector/Dockerfile .
+fi
 
 echo "Building suggestion images..."
 docker build -t ${REGISTRY}/${PREFIX}/suggestion-hyperopt:${TAG} -f ${CMD_PREFIX}/suggestion/hyperopt/v1alpha3/Dockerfile .
 docker build -t ${REGISTRY}/${PREFIX}/suggestion-skopt:${TAG} -f ${CMD_PREFIX}/suggestion/skopt/v1alpha3/Dockerfile .
 docker build -t ${REGISTRY}/${PREFIX}/suggestion-chocolate:${TAG} -f ${CMD_PREFIX}/suggestion/chocolate/v1alpha3/Dockerfile .
-docker build -t ${REGISTRY}/${PREFIX}/suggestion-nasrl:${TAG} -f ${CMD_PREFIX}/suggestion/nasrl/v1alpha3/Dockerfile .
+if [ $MACHINE_ARCH == "aarch64" ]; then
+	docker build -t ${REGISTRY}/${PREFIX}/suggestion-nasrl:${TAG} -f ${CMD_PREFIX}/suggestion/nasrl/v1alpha3/Dockerfile.aarch64 .
+else
+	docker build -t ${REGISTRY}/${PREFIX}/suggestion-nasrl:${TAG} -f ${CMD_PREFIX}/suggestion/nasrl/v1alpha3/Dockerfile .
+fi
 docker build -t ${REGISTRY}/${PREFIX}/suggestion-hyperband:${TAG} -f ${CMD_PREFIX}/suggestion/hyperband/v1alpha3/Dockerfile .


### PR DESCRIPTION
- Changed Dockerfiles and build scripts to support images on arm64, tested on both x86_64 machine and arm64 machine.

- Followed by discussions with @gaocegege in #779 ([comment](https://github.com/kubeflow/katib/pull/779#discussion_r337413401)), fixed problems of only have x86_64 version binary of grpc_health_probe in original Dockerfiles.

Change-Id: I5ddee7e8fbe96b8e0a025e3f182b4a5192c45597
Signed-off-by: Henry Wang <<henry.wang@arm.com>>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/897)
<!-- Reviewable:end -->
