### PR TITLE
Fix katib-manager crash in kubeflow cluster

### DIFF
--- a/pkg/db/v1alpha3/common/const.go
+++ b/pkg/db/v1alpha3/common/const.go
@@ -7,8 +7,8 @@ const (
 
 	DBPasswordEnvName = "DB_PASSWORD"
 
-	MySQLDBHostEnvName = "MYSQL_HOST"
-	MySQLDBPortEnvName = "MYSQL_PORT"
+	MySQLDBHostEnvName = "KATIB_MYSQL_HOST"
+	MySQLDBPortEnvName = "KATIB_MYSQL_PORT"
 
 	DefaultMySQLHost = "katib-db"
 	DefaultMySQLPort = "3306"

--- a/pkg/db/v1alpha3/mysql/mysql.go
+++ b/pkg/db/v1alpha3/mysql/mysql.go
@@ -14,13 +14,12 @@ import (
 
 	v1alpha3 "github.com/kubeflow/katib/pkg/apis/manager/v1alpha3"
 	"github.com/kubeflow/katib/pkg/db/v1alpha3/common"
-	//"github.com/kubeflow/katib/pkg/util/v1alpha3/env"
+	"github.com/kubeflow/katib/pkg/util/v1alpha3/env"
 )
 
 const (
-	dbDriver   = "mysql"
-	dbNameTmpl = "root:%s@tcp(katib-db:3306)/katib?timeout=5s"
-	//dbNameTmpl   = "root:%s@tcp(%s:%s)/katib?timeout=5s"
+	dbDriver     = "mysql"
+	dbNameTmpl   = "root:%s@tcp(%s:%s)/katib?timeout=5s"
 	mysqlTimeFmt = "2006-01-02 15:04:05.999999"
 
 	connectInterval = 5 * time.Second
@@ -34,11 +33,12 @@ type dbConn struct {
 func getDbName() string {
 	dbPassEnvName := common.DBPasswordEnvName
 	dbPass := os.Getenv(dbPassEnvName)
-	//dbHost := env.GetEnvOrDefault(
-	//	common.MySQLDBHostEnvName, common.DefaultMySQLHost)
-	//dbPort := env.GetEnvOrDefault(
-	//	common.MySQLDBPortEnvName, common.DefaultMySQLPort)
-	return fmt.Sprintf(dbNameTmpl, dbPass)
+	dbHost := env.GetEnvOrDefault(
+		common.MySQLDBHostEnvName, common.DefaultMySQLHost)
+	dbPort := env.GetEnvOrDefault(
+		common.MySQLDBPortEnvName, common.DefaultMySQLPort)
+
+	return fmt.Sprintf(dbNameTmpl, dbPass, dbHost, dbPort)
 }
 
 func openSQLConn(driverName string, dataSourceName string, interval time.Duration,


### PR DESCRIPTION
In kubeflow cluster, there is a service named "mysql" from pipeline. so in each kubeflow POD, there is will ENV for mysql service like below, which will make `getDbName()` return in katib mysql DB invalid (owning to env `MYSQL_PORT`)
```
# env|grep MYSQL
MYSQL_PORT_3306_TCP_ADDR=10.0.251.111
MYSQL_PORT_3306_TCP_PORT=3306
MYSQL_SERVICE_HOST=10.0.251.111
MYSQL_PORT_3306_TCP_PROTO=tcp
MYSQL_HOST=katib-db.kubeflow
MYSQL_PORT=tcp://10.0.251.111:3306
MYSQL_SERVICE_PORT=3306
MYSQL_PORT_3306_TCP=tcp://10.0.251.111:3306
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/900)
<!-- Reviewable:end -->
