### PR TITLE
Support multiple metric logs in one line

### DIFF
--- a/examples/v1alpha3/file-metrics-collector/mnist.py
+++ b/examples/v1alpha3/file-metrics-collector/mnist.py
@@ -63,7 +63,7 @@ def test(args, model, device, test_loader, epoch):
             correct += pred.eq(target.view_as(pred)).sum().item()
 
     test_loss /= len(test_loader.dataset)
-    logging.info('\naccuracy={:.4f}\n'.format(float(correct) / len(test_loader.dataset)))
+    logging.info('\naccuracy = {:.4f};loss = {:.4f}\n'.format(float(correct) / len(test_loader.dataset), test_loss))
 
 
 def should_distribute():

--- a/examples/v1alpha3/file-metricscollector-example.yaml
+++ b/examples/v1alpha3/file-metricscollector-example.yaml
@@ -10,6 +10,8 @@ spec:
     type: maximize
     goal: 0.99
     objectiveMetricName: accuracy
+    additionalMetricNames:
+    - loss
   metricsCollectorSpec:
     source:
       fileSystemPath:


### PR DESCRIPTION
for now, in one line, only $metricsName=$value (without blank) can be parsed.
By this PR, blank can be tolerant before and after "="; Also in the same line, multiple metrics couple can be parsed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/925)
<!-- Reviewable:end -->
