### PR TITLE
Fix: Empty Trial templates in Katib UI

### DIFF
--- a/pkg/ui/v1alpha3/frontend/src/components/NAS/Create/Params/Trial.jsx
+++ b/pkg/ui/v1alpha3/frontend/src/components/NAS/Create/Params/Trial.jsx
@@ -40,7 +40,13 @@ const styles = theme => ({
     },
 })
 
+
 class TrialSpecParam extends React.Component {
+
+    componentDidMount() {
+        this.props.fetchTrialTemplates(this.props.trialNamespace);
+        this.props.changeTrialNamespace(this.props.trialNamespace);
+    }
 
     onTrialNamespaceChange = (event) => {
         this.props.fetchTrialTemplates(event.target.value);

--- a/pkg/ui/v1alpha3/frontend/src/components/Templates/Trial.jsx
+++ b/pkg/ui/v1alpha3/frontend/src/components/Templates/Trial.jsx
@@ -19,7 +19,13 @@ const styles = theme => ({
 });
 
 class Trial extends React.Component {
-    
+
+    componentDidMount() {
+        // TODO: Add possibility to change namespace in Trial Manifest form
+        // Right now we get templates only from kubeflow namespace
+        this.props.fetchTrialTemplates("");
+    }
+
     openAddDialog = () => {
         this.props.openDialog("add");
     }

--- a/pkg/ui/v1alpha3/frontend/src/reducers/nasCreate.js
+++ b/pkg/ui/v1alpha3/frontend/src/reducers/nasCreate.js
@@ -345,6 +345,7 @@ const initialState = {
     ],
     allParameterTypes: ["int", "double", "categorical"],
     trial: 'nasRLTrialTemplate.yaml',
+    trialNamespace: "kubeflow",
     currentYaml: '',
     snackText: '',
     snackOpen: false,


### PR DESCRIPTION
In this PR:
1. Fixed empty page while clicking on Trial Manifests in the Menu
2. Fetch Trial templates when opening submit by parameters in NAS page.

I did it in v1alpha3 version, should I make changes in v1alpha2 also @johnugeorge @gaocegege ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/938)
<!-- Reviewable:end -->
