### PR TITLE
upgrade deployments API for k8s 1.16+

### DIFF
--- a/manifests/v1alpha2/db/deployment.yaml
+++ b/manifests/v1alpha2/db/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: katib-db
@@ -8,6 +8,10 @@ metadata:
     component: db
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: katib
+      component: db
   template:
     metadata:
       name: katib-db

--- a/manifests/v1alpha2/manager-rest/deployment.yaml
+++ b/manifests/v1alpha2/manager-rest/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: katib-manager-rest
@@ -8,6 +8,10 @@ metadata:
     component: manager-rest
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: katib
+      component: manager-rest
   template:
     metadata:
       name: katib-manager-rest

--- a/manifests/v1alpha2/manager/deployment.yaml
+++ b/manifests/v1alpha2/manager/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: katib-manager
@@ -8,6 +8,10 @@ metadata:
     component: manager
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: katib
+      component: manager
   template:
     metadata:
       name: katib-manager

--- a/manifests/v1alpha2/suggestion/bayesianoptimization/deployment.yaml
+++ b/manifests/v1alpha2/suggestion/bayesianoptimization/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: katib-suggestion-bayesianoptimization
@@ -8,6 +8,10 @@ metadata:
     component: suggestion-bayesianoptimization
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: katib
+      component: suggestion-bayesianoptimization
   template:
     metadata:
       name: katib-suggestion-bayesianoptimization

--- a/manifests/v1alpha2/suggestion/grid/deployment.yaml
+++ b/manifests/v1alpha2/suggestion/grid/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: katib-suggestion-grid
@@ -8,6 +8,10 @@ metadata:
     component: suggestion-grid
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: katib
+      component: suggestion-grid
   template:
     metadata:
       name: katib-suggestion-grid

--- a/manifests/v1alpha2/suggestion/hyperband/deployment.yaml
+++ b/manifests/v1alpha2/suggestion/hyperband/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: katib-suggestion-hyperband
@@ -8,6 +8,10 @@ metadata:
     component: suggestion-hyperband
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: katib
+      component: suggestion-hyperband
   template:
     metadata:
       name: katib-suggestion-hyperband

--- a/manifests/v1alpha2/suggestion/nasrl/deployment.yaml
+++ b/manifests/v1alpha2/suggestion/nasrl/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: katib-suggestion-nasrl
@@ -8,6 +8,10 @@ metadata:
     component: suggestion-nasrl
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: katib
+      component: suggestion-nasrl
   template:
     metadata:
       name: katib-suggestion-nasrl

--- a/manifests/v1alpha2/suggestion/random/deployment.yaml
+++ b/manifests/v1alpha2/suggestion/random/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: katib-suggestion-random
@@ -8,6 +8,10 @@ metadata:
     component: suggestion-random
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: katib
+      component: suggestion-random
   template:
     metadata:
       name: katib-suggestion-random

--- a/manifests/v1alpha2/ui/deployment.yaml
+++ b/manifests/v1alpha2/ui/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: katib-ui
@@ -8,6 +8,10 @@ metadata:
     component: ui
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: katib
+      component: ui
   template:
     metadata:
       name: katib-ui

--- a/manifests/v1alpha3/db/deployment.yaml
+++ b/manifests/v1alpha3/db/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: katib-db
@@ -8,6 +8,10 @@ metadata:
     component: db
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: katib
+      component: db
   template:
     metadata:
       name: katib-db

--- a/manifests/v1alpha3/manager/deployment.yaml
+++ b/manifests/v1alpha3/manager/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: katib-manager
@@ -8,6 +8,10 @@ metadata:
     component: manager
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: katib
+      component: manager
   template:
     metadata:
       name: katib-manager

--- a/manifests/v1alpha3/ui/deployment.yaml
+++ b/manifests/v1alpha3/ui/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: katib-ui
@@ -8,6 +8,10 @@ metadata:
     component: ui
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: katib
+      component: ui
   template:
     metadata:
       name: katib-ui


### PR DESCRIPTION
As k8s [deprecated](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) APIs In 1.16,  
the API of deployment "extensions/v1beta1" is deprecated,  so the deploy scripts are breaking now.

This pr aims to fix the break by using "apps/v1" deployment API instead. 
Also, the selector sections are added, otherwise a warning would throw
It works at my computer using k8s version 1.16.1。

But backward compatibility is not tested due to lack of machine resources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/948)
<!-- Reviewable:end -->
