### PR TITLE
Add a gauge metric for current experiments

### DIFF
--- a/pkg/controller.v1alpha3/experiment/experiment_controller.go
+++ b/pkg/controller.v1alpha3/experiment/experiment_controller.go
@@ -73,6 +73,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 
 	r.Generator = manifest.New(r.Client)
 	r.updateStatusHandler = r.updateStatus
+	r.collector = util.NewExpsCollector(mgr.GetCache())
 	return r
 }
 
@@ -159,6 +160,8 @@ type ReconcileExperiment struct {
 	manifest.Generator
 	// updateStatusHandler is defined for test purpose.
 	updateStatusHandler updateStatusFunc
+	// collector is a wrapper for experiment metrics.
+	collector *util.ExperimentsCollector
 }
 
 // Reconcile reads that state of the cluster for a Experiment object and makes changes based on the state read
@@ -235,7 +238,7 @@ func (r *ReconcileExperiment) ReconcileExperiment(instance *experimentsv1alpha3.
 		return err
 	}
 	if len(trials.Items) > 0 {
-		if err := util.UpdateExperimentStatus(instance, trials); err != nil {
+		if err := util.UpdateExperimentStatus(r.collector, instance, trials); err != nil {
 			logger.Error(err, "Update experiment status error")
 			return err
 		}

--- a/pkg/controller.v1alpha3/experiment/experiment_controller_test.go
+++ b/pkg/controller.v1alpha3/experiment/experiment_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/kubeflow/katib/pkg/controller.v1alpha3/experiment/util"
 	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -169,6 +170,7 @@ spec:
 		scheme:     mgr.GetScheme(),
 		Suggestion: suggestion,
 		Generator:  generator,
+		collector:  util.NewExpsCollector(mgr.GetCache()),
 	}
 	r.updateStatusHandler = func(instance *experimentsv1alpha3.Experiment) error {
 		if !instance.IsCreated() {

--- a/pkg/controller.v1alpha3/experiment/experiment_util.go
+++ b/pkg/controller.v1alpha3/experiment/experiment_util.go
@@ -14,7 +14,6 @@ import (
 	experimentsv1alpha3 "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1alpha3"
 	suggestionsv1alpha3 "github.com/kubeflow/katib/pkg/apis/controller/suggestions/v1alpha3"
 	trialsv1alpha3 "github.com/kubeflow/katib/pkg/apis/controller/trials/v1alpha3"
-	utilv1alpha3 "github.com/kubeflow/katib/pkg/controller.v1alpha3/experiment/util"
 	"github.com/kubeflow/katib/pkg/controller.v1alpha3/util"
 )
 
@@ -102,9 +101,9 @@ func (r *ReconcileExperiment) updateFinalizers(instance *experimentsv1alpha3.Exp
 		return reconcile.Result{}, err
 	} else {
 		if !instance.ObjectMeta.DeletionTimestamp.IsZero() {
-			utilv1alpha3.IncreaseExperimentsDeletedCount()
+			r.collector.IncreaseExperimentsDeletedCount(instance.Namespace)
 		} else {
-			utilv1alpha3.IncreaseExperimentsCreatedCount()
+			r.collector.IncreaseExperimentsCreatedCount(instance.Namespace)
 		}
 		// Need to requeue because finalizer update does not change metadata.generation
 		return reconcile.Result{Requeue: true}, err

--- a/pkg/controller.v1alpha3/experiment/util/prometheus_metrics.go
+++ b/pkg/controller.v1alpha3/experiment/util/prometheus_metrics.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"context"
+
 	"github.com/kubeflow/katib/pkg/apis/controller/experiments/v1alpha3"
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -104,8 +105,8 @@ func (c *ExperimentsCollector) IncreaseExperimentsFailedCount(ns string) {
 func (c *ExperimentsCollector) collect() {
 	var (
 		conditionType v1alpha3.ExperimentConditionType
-		status string
-		err error
+		status        string
+		err           error
 	)
 	expLists := &v1alpha3.ExperimentList{}
 	if err = c.store.List(context.TODO(), nil, expLists); err != nil {

--- a/pkg/controller.v1alpha3/experiment/util/status_util.go
+++ b/pkg/controller.v1alpha3/experiment/util/status_util.go
@@ -34,12 +34,12 @@ const (
 	ExperimentKilledReason    = "ExperimentKilled"
 )
 
-func UpdateExperimentStatus(instance *experimentsv1alpha3.Experiment, trials *trialsv1alpha3.TrialList) error {
+func UpdateExperimentStatus(collector *ExperimentsCollector, instance *experimentsv1alpha3.Experiment, trials *trialsv1alpha3.TrialList) error {
 
 	isObjectiveGoalReached := updateTrialsSummary(instance, trials)
 
 	if !instance.IsCompleted() {
-		UpdateExperimentStatusCondition(instance, isObjectiveGoalReached, false)
+		UpdateExperimentStatusCondition(collector, instance, isObjectiveGoalReached, false)
 	}
 	return nil
 
@@ -135,7 +135,7 @@ func getObjectiveMetricValue(trial trialsv1alpha3.Trial, objectiveMetricName str
 	return nil
 }
 
-func UpdateExperimentStatusCondition(instance *experimentsv1alpha3.Experiment, isObjectiveGoalReached bool, getSuggestionDone bool) {
+func UpdateExperimentStatusCondition(collector *ExperimentsCollector, instance *experimentsv1alpha3.Experiment, isObjectiveGoalReached bool, getSuggestionDone bool) {
 
 	completedTrialsCount := instance.Status.TrialsSucceeded + instance.Status.TrialsFailed + instance.Status.TrialsKilled
 	failedTrialsCount := instance.Status.TrialsFailed
@@ -145,7 +145,7 @@ func UpdateExperimentStatusCondition(instance *experimentsv1alpha3.Experiment, i
 		msg := "Experiment has succeeded because Objective goal has reached"
 		instance.MarkExperimentStatusSucceeded(ExperimentSucceededReason, msg)
 		instance.Status.CompletionTime = &now
-		IncreaseExperimentsSucceededCount()
+		collector.IncreaseExperimentsSucceededCount(instance.Namespace)
 		return
 	}
 
@@ -153,7 +153,7 @@ func UpdateExperimentStatusCondition(instance *experimentsv1alpha3.Experiment, i
 		msg := "Experiment has succeeded because max trial count has reached"
 		instance.MarkExperimentStatusSucceeded(ExperimentSucceededReason, msg)
 		instance.Status.CompletionTime = &now
-		IncreaseExperimentsSucceededCount()
+		collector.IncreaseExperimentsSucceededCount(instance.Namespace)
 		return
 	}
 
@@ -161,7 +161,7 @@ func UpdateExperimentStatusCondition(instance *experimentsv1alpha3.Experiment, i
 		msg := "Experiment has succeeded because suggestion service has reached the end"
 		instance.MarkExperimentStatusSucceeded(ExperimentSucceededReason, msg)
 		instance.Status.CompletionTime = &now
-		IncreaseExperimentsSucceededCount()
+		collector.IncreaseExperimentsSucceededCount(instance.Namespace)
 		return
 	}
 
@@ -169,7 +169,7 @@ func UpdateExperimentStatusCondition(instance *experimentsv1alpha3.Experiment, i
 		msg := "Experiment has failed because max failed count has reached"
 		instance.MarkExperimentStatusFailed(ExperimentFailedReason, msg)
 		instance.Status.CompletionTime = &now
-		IncreaseExperimentsFailedCount()
+		collector.IncreaseExperimentsFailedCount(instance.Namespace)
 		return
 	}
 


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

1. Add a gauge metric `katib_experiments_current` to track the current experiments in the cluster and their status.
2. Add a namespace label in previous counter metrics.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/954)
<!-- Reviewable:end -->
