### PR TITLE
Use port higher than 1024 to be able to run as a non-root user

### DIFF
--- a/cmd/katib-controller/v1alpha3/Dockerfile
+++ b/cmd/katib-controller/v1alpha3/Dockerfile
@@ -18,4 +18,5 @@ FROM alpine:3.7
 WORKDIR /app
 RUN apk update && apk add ca-certificates
 COPY --from=build-env /go/src/github.com/kubeflow/katib/cmd/katib-controller/katib-controller .
+USER 1000
 ENTRYPOINT ["./katib-controller"]

--- a/cmd/katib-controller/v1alpha3/main.go
+++ b/cmd/katib-controller/v1alpha3/main.go
@@ -39,10 +39,12 @@ func main() {
 
 	var experimentSuggestionName string
 	var metricsAddr string
+	var webhookPort int
 
 	flag.StringVar(&experimentSuggestionName, "experiment-suggestion-name",
 		"default", "The implementation of suggestion interface in experiment controller (default|fake)")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.IntVar(&webhookPort, "webhook-port", 8443, "The port number to be used for admission webhook server.")
 
 	flag.Parse()
 
@@ -83,7 +85,7 @@ func main() {
 	}
 
 	log.Info("Setting up webhooks")
-	if err := webhook.AddToManager(mgr); err != nil {
+	if err := webhook.AddToManager(mgr, int32(webhookPort)); err != nil {
 		log.Error(err, "unable to register webhooks to the manager")
 		os.Exit(1)
 	}

--- a/manifests/v1alpha3/katib-controller/katib-controller.yaml
+++ b/manifests/v1alpha3/katib-controller/katib-controller.yaml
@@ -23,8 +23,10 @@ spec:
         image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller
         imagePullPolicy: IfNotPresent
         command: ["./katib-controller"]
+        args:
+        - '--webhook-port=8443'
         ports:
-        - containerPort: 443
+        - containerPort: 8443
           name: webhook
           protocol: TCP
         - containerPort: 8080

--- a/manifests/v1alpha3/katib-controller/service.yaml
+++ b/manifests/v1alpha3/katib-controller/service.yaml
@@ -11,7 +11,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 8443
     name: webhook
   - name: metrics
     port: 8080

--- a/pkg/webhook/v1alpha3/webhook.go
+++ b/pkg/webhook/v1alpha3/webhook.go
@@ -35,7 +35,7 @@ const (
 	katibControllerName = "katib-controller"
 )
 
-func AddToManager(m manager.Manager) error {
+func AddToManager(m manager.Manager, port int32) error {
 	server, err := webhook.NewServer("katib-admission-server", m, webhook.ServerOptions{
 		CertDir: "/tmp/cert",
 		BootstrapOptions: &webhook.BootstrapOptions{
@@ -53,6 +53,7 @@ func AddToManager(m manager.Manager) error {
 			ValidatingWebhookConfigName: "katib-validating-webhook-config",
 			MutatingWebhookConfigName:   "katib-mutating-webhook-config",
 		},
+		Port: port,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR allows Katib Controller to run as a non-root user. This is important from security point of view and especially to enable Katib on enterprise distributions of Kubernetes like OpenShift.

This PR adds a parameter `--webhook-port` to allow configuring port > 1024 for admission webhooks and also changes the default port (`443`) to `8443`.

It also changes the `USER` in `Dockerfile` as it is not necessary to run as root with this change even on the vanilla Kubernetes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #959

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

No image changes

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/960)
<!-- Reviewable:end -->
