### PR TITLE
Fix typo in getKabitJob function name

### DIFF
--- a/pkg/webhook/v1alpha3/pod/inject_webhook.go
+++ b/pkg/webhook/v1alpha3/pod/inject_webhook.go
@@ -104,7 +104,7 @@ func NewSidecarInjector(c client.Client, ms string) *sidecarInjector {
 }
 
 func (s *sidecarInjector) MutationRequired(pod *v1.Pod, ns string) (bool, error) {
-	jobKind, jobName, err := getKabitJob(pod)
+	jobKind, jobName, err := getKatibJob(pod)
 	if err != nil {
 		return false, nil
 	}
@@ -131,7 +131,7 @@ func (s *sidecarInjector) MutationRequired(pod *v1.Pod, ns string) (bool, error)
 func (s *sidecarInjector) Mutate(pod *v1.Pod, namespace string) (*v1.Pod, error) {
 	mutatedPod := pod.DeepCopy()
 
-	kind, trialName, _ := getKabitJob(pod)
+	kind, trialName, _ := getKatibJob(pod)
 	trial := &trialsv1alpha3.Trial{}
 	if err := s.client.Get(context.TODO(), apitypes.NamespacedName{Name: trialName, Namespace: namespace}, trial); err != nil {
 		return nil, err

--- a/pkg/webhook/v1alpha3/pod/utils.go
+++ b/pkg/webhook/v1alpha3/pod/utils.go
@@ -32,7 +32,7 @@ import (
 	jobv1alpha3 "github.com/kubeflow/katib/pkg/job/v1alpha3"
 )
 
-func getKabitJob(pod *v1.Pod) (string, string, error) {
+func getKatibJob(pod *v1.Pod) (string, string, error) {
 	for _, gvk := range jobv1alpha3.GetSupportedJobList() {
 		owners := pod.GetOwnerReferences()
 		for _, owner := range owners {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR fixes a potential typo in a function name (`getKabitJob` vs. `getKatibJob`) - unless it was intended for some reason.

Might not be a high priority, but I noticed it when I tried to search for `getKatibJob` and got 0 results back.

**Which issue(s) this PR fixes** 

Not really an issue, more a nit-picker personality trait

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

No image change

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/965)
<!-- Reviewable:end -->
