### PR TITLE
Use port 8080 for Katib UI

### DIFF
--- a/cmd/ui/v1alpha3/Dockerfile
+++ b/cmd/ui/v1alpha3/Dockerfile
@@ -22,4 +22,6 @@ WORKDIR /app
 COPY --from=go-build /go/src/github.com/kubeflow/katib/cmd/ui/katib-ui /app/
 COPY --from=npm-build /frontend/build /app/build
 
+USER 1000
+
 ENTRYPOINT ["./katib-ui"]

--- a/manifests/v1alpha3/ui/deployment.yaml
+++ b/manifests/v1alpha3/ui/deployment.yaml
@@ -25,6 +25,8 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
           - './katib-ui'
+        args:
+          - '--port=8080'
         env:
         - name: KATIB_CORE_NAMESPACE
           valueFrom:
@@ -32,5 +34,5 @@ spec:
               fieldPath: metadata.namespace
         ports:
         - name: ui
-          containerPort: 80
+          containerPort: 8080
       serviceAccountName: katib-ui

--- a/manifests/v1alpha3/ui/service.yaml
+++ b/manifests/v1alpha3/ui/service.yaml
@@ -12,6 +12,7 @@ spec:
     - port: 80
       protocol: TCP
       name: ui
+      targetPort: 8080
   selector:
     app: katib
     component: ui


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR changes the port used by `katib-ui` from `80` (needs root privileges) to `8080` so that we can run `katib-ui` on OpenShift with default security context.

As `katib-ui` already supports port configuration it is really just about changing manifests, but I have also changed the `USER` in `Dockerfile` as running as unprivileged user is generally considered a good practice in containers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #966 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

There is not a  change of the image, but there is a change in the image, not sure if that fits under this note.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/967)
<!-- Reviewable:end -->
