### PR TITLE
Get dbUser from Env or default('root')

### DIFF
--- a/pkg/db/v1alpha3/common/const.go
+++ b/pkg/db/v1alpha3/common/const.go
@@ -1,6 +1,8 @@
 package common
 
 const (
+	DBUserEnvName = "DB_USER"
+
 	DBNameEnvName = "DB_NAME"
 
 	MySqlDBNameEnvValue = "mysql"
@@ -11,6 +13,7 @@ const (
 	MySQLDBPortEnvName = "KATIB_MYSQL_PORT"
 	MySQLDatabase      = "KATIB_MYSQL_DATABASE"
 
+	DefaultMySQLUser     = "root"
 	DefaultMySQLDatabase = "katib"
 	DefaultMySQLHost     = "katib-db"
 	DefaultMySQLPort     = "3306"

--- a/pkg/db/v1alpha3/mysql/mysql.go
+++ b/pkg/db/v1alpha3/mysql/mysql.go
@@ -19,7 +19,8 @@ import (
 
 const (
 	dbDriver     = "mysql"
-	dbNameTmpl   = "root:%s@tcp(%s:%s)/%s?timeout=5s"
+	//dbNameTmpl   = "root:%s@tcp(%s:%s)/%s?timeout=5s"
+	dbNameTmpl   = "%s:%s@tcp(%s:%s)/%s?timeout=5s"
 	mysqlTimeFmt = "2006-01-02 15:04:05.999999"
 
 	connectInterval = 5 * time.Second
@@ -33,6 +34,8 @@ type dbConn struct {
 func getDbName() string {
 	dbPassEnvName := common.DBPasswordEnvName
 	dbPass := os.Getenv(dbPassEnvName)
+	dbUser := env.GetEnvOrDefault(
+		common.DBUserEnvName, common.DefaultMySQLUser)
 	dbHost := env.GetEnvOrDefault(
 		common.MySQLDBHostEnvName, common.DefaultMySQLHost)
 	dbPort := env.GetEnvOrDefault(
@@ -40,7 +43,7 @@ func getDbName() string {
 	dbName := env.GetEnvOrDefault(common.MySQLDatabase,
 		common.DefaultMySQLDatabase)
 
-	return fmt.Sprintf(dbNameTmpl, dbPass, dbHost, dbPort, dbName)
+	return fmt.Sprintf(dbNameTmpl, dbUser, dbPass, dbHost, dbPort, dbName)
 }
 
 func openSQLConn(driverName string, dataSourceName string, interval time.Duration,

--- a/pkg/db/v1alpha3/mysql/mysql.go
+++ b/pkg/db/v1alpha3/mysql/mysql.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	dbDriver     = "mysql"
+	dbDriver = "mysql"
 	//dbNameTmpl   = "root:%s@tcp(%s:%s)/%s?timeout=5s"
 	dbNameTmpl   = "%s:%s@tcp(%s:%s)/%s?timeout=5s"
 	mysqlTimeFmt = "2006-01-02 15:04:05.999999"


### PR DESCRIPTION
Fixes #984 
After this PR, 
* can dynamically configure the user name of mysql databases via environment variables
* can use external mysql instead of the mysql in pods

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/985)
<!-- Reviewable:end -->
