### PR TITLE
Update mysql version mysql:8.0.15

### DIFF
--- a/manifests/v1alpha3/db/deployment.yaml
+++ b/manifests/v1alpha3/db/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: katib-db
-        image: mysql:8
+        image: mysql:8.0.15
         args:
         - --datadir
         - /var/lib/mysql/datadir


### PR DESCRIPTION
New version of mysql installation fails.  I make a test on  mysql:8.0.16 mysql:8.0.17 mysql:8.0.18. All Failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/988)
<!-- Reviewable:end -->
