### PR TITLE
Fix number of Trials problem in NAS RL Suggestion

### DIFF
--- a/pkg/suggestion/v1alpha3/NAS_Reinforcement_Learning/AlgorithmSettings.py
+++ b/pkg/suggestion/v1alpha3/NAS_Reinforcement_Learning/AlgorithmSettings.py
@@ -1,4 +1,4 @@
-def parseAlgorithmSettings(params_raw):
+def parseAlgorithmSettings(params_raw, logger):
     param_standard = {
         "lstm_num_cells":       ['value', int, [1, 'inf']],
         "lstm_num_layers":      ['value', int, [1, 'inf']],
@@ -31,26 +31,26 @@ def parseAlgorithmSettings(params_raw):
         "baseline_decay":       0.9999
     }
 
-    def checktype(param_name, param_value, check_mode, supposed_type, supposed_range=None):
+    def checktype(param_name, param_value, check_mode, supposed_type, supposed_range=None, logger=None):
         correct = True
 
         try:
             converted_value = supposed_type(param_value)
         except:
             correct = False
-            print("Parameter {} is of wrong type. Set back to default value {}"
+            logger.info("Parameter {} is of wrong type. Set back to default value {}"
                   .format(param_name, algorithm_settings[param_name]))
 
         if correct and check_mode == 'value':
             if not ((supposed_range[0] == '-inf' or converted_value >= supposed_range[0]) and
                     (supposed_range[1] == 'inf' or converted_value <= supposed_range[1])):
                 correct = False
-                print("Parameter {} out of range. Set back to default value {}"
+                logger.info("Parameter {} out of range. Set back to default value {}"
                       .format(param_name, algorithm_settings[param_name]))
         elif correct and check_mode == 'categorical':
             if converted_value not in supposed_range:
                 correct = False
-                print("Parameter {} out of range. Set back to default value {}"
+                logger.info("Parameter {} out of range. Set back to default value {}"
                       .format(param_name, algorithm_settings[param_name]))
 
         if correct:
@@ -63,8 +63,9 @@ def parseAlgorithmSettings(params_raw):
                       param.value,
                       param_standard[param.name][0],  # mode
                       param_standard[param.name][1],  # type
-                      param_standard[param.name][2])  # range
+                      param_standard[param.name][2],  # range
+                      logger)
         else:
-            print("Unknown Parameter name: {}".format(param.name))
+            logger.info("Unknown Parameter name: {}".format(param.name))
 
     return algorithm_settings

--- a/pkg/suggestion/v1alpha3/NAS_Reinforcement_Learning/Trainer.py
+++ b/pkg/suggestion/v1alpha3/NAS_Reinforcement_Learning/Trainer.py
@@ -40,7 +40,7 @@ def get_train_ops(loss,
         loss += l2_reg * l2_loss
 
     grads = tf.gradients(loss, tf_variables)
-    grad_norm = tf.global_norm(grads)
+    grad_norm = tf.linalg.global_norm(grads)
 
     grad_norms = {}
     for v, g in zip(tf_variables, grads):
@@ -99,7 +99,7 @@ def get_train_ops(loss,
         learning_rate = tf.cond(
             tf.greater_equal(T_curr, T_i), _update, _no_update)
     else:
-        learning_rate = tf.train.exponential_decay(
+        learning_rate = tf.compat.v1.train.exponential_decay(
             lr_init, tf.maximum(train_step - lr_dec_start, 0), lr_dec_every,
             lr_dec_rate, staircase=True)
         if lr_dec_min is not None:
@@ -110,12 +110,12 @@ def get_train_ops(loss,
                                 lambda: lr_warmup_val, lambda: learning_rate)
 
     if optim_algo == "momentum":
-        opt = tf.train.MomentumOptimizer(
+        opt = tf.compat.v1.train.MomentumOptimizer(
             learning_rate, 0.9, use_locking=True, use_nesterov=True)
     elif optim_algo == "sgd":
-        opt = tf.train.GradientDescentOptimizer(learning_rate, use_locking=True)
+        opt = tf.compat.v1.train.GradientDescentOptimizer(learning_rate, use_locking=True)
     elif optim_algo == "adam":
-        opt = tf.train.AdamOptimizer(learning_rate, beta1=0.0, epsilon=1e-3,
+        opt = tf.compat.v1.train.AdamOptimizer(learning_rate, beta1=0.0, epsilon=1e-3,
                                      use_locking=True)
     else:
         raise ValueError("Unknown optim_algo {}".format(optim_algo))
@@ -124,7 +124,7 @@ def get_train_ops(loss,
         assert num_aggregate is not None, "Need num_aggregate to sync."
         assert num_replicas is not None, "Need num_replicas to sync."
 
-        opt = tf.train.SyncReplicasOptimizer(
+        opt = tf.compat.v1.train.SyncReplicasOptimizer(
             opt,
             replicas_to_aggregate=num_aggregate,
             total_num_replicas=num_replicas,


### PR DESCRIPTION
I fixed bug in NAS RL Suggestion. 
`experiment.num_trials` should be updated every `GetSuggestions` call, since `request_number` value can be different during one experiment.
Also, I change deprecated TF functions to decrease warning in Suggestion logs and I added `logger` instead of `print` in AlgorithmSettings.

/cc @johnugeorge @gaocegege @hougangliu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/1009)
<!-- Reviewable:end -->
