### PR TITLE
feat: Do not inject sh -c when it exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ ehthumbs_vista.db
 
 ## Recycle Bin used on file shares
 $RECYCLE.BIN/
+
+/katib-controller
+/katib-manager

--- a/pkg/webhook/v1alpha3/pod/inject_webhook.go
+++ b/pkg/webhook/v1alpha3/pod/inject_webhook.go
@@ -307,6 +307,13 @@ func wrapWorkerContainer(
 		if err != nil {
 			return err
 		}
+		// If the first two commands are sh -c, we do not inject command.
+		if args[0] == "sh" || args[0] == "bash" {
+			if args[1] == "-c" {
+				command = args[0:2]
+				args = args[2:]
+			}
+		}
 		if mc.Collector.Kind == common.StdOutCollector {
 			redirectStr := fmt.Sprintf("1>%s 2>&1", metricsFile)
 			args = append(args, redirectStr)

--- a/pkg/webhook/v1alpha3/pod/inject_webhook_test.go
+++ b/pkg/webhook/v1alpha3/pod/inject_webhook_test.go
@@ -18,7 +18,127 @@ func TestWrapWorkerContainer(t *testing.T) {
 		MC            common.MetricsCollectorSpec
 		Expected      *v1.Pod
 		ExpectedError error
-	}{}
+		Name          string
+	}{
+		{
+			Pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "tensorflow",
+							Command: []string{
+								"python main.py",
+							},
+						},
+					},
+				},
+			},
+			Namespace:   "nohere",
+			JobKind:     "TFJob",
+			MetricsFile: "testfile",
+			PathKind:    common.FileKind,
+			MC: common.MetricsCollectorSpec{
+				Collector: &common.CollectorSpec{
+					Kind: common.StdOutCollector,
+				},
+			},
+			Expected: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "tensorflow",
+							Command: []string{
+								"sh", "-c",
+							},
+							Args: []string{
+								"python main.py 1>testfile 2>&1 && echo completed > $$$$.pid",
+							},
+						},
+					},
+				},
+			},
+			ExpectedError: nil,
+			Name:          "tensorflow container without sh -c",
+		},
+		{
+			Pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "test",
+							Command: []string{
+								"python main.py",
+							},
+						},
+					},
+				},
+			},
+			Namespace:   "nohere",
+			JobKind:     "TFJob",
+			MetricsFile: "testfile",
+			PathKind:    common.FileKind,
+			MC: common.MetricsCollectorSpec{
+				Collector: &common.CollectorSpec{
+					Kind: common.StdOutCollector,
+				},
+			},
+			Expected: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "test",
+							Command: []string{
+								"python main.py",
+							},
+						},
+					},
+				},
+			},
+			ExpectedError: nil,
+			Name:          "test container without sh -c",
+		},
+		{
+			Pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "tensorflow",
+							Command: []string{
+								"sh", "-c",
+								"python main.py",
+							},
+						},
+					},
+				},
+			},
+			Namespace:   "nohere",
+			JobKind:     "TFJob",
+			MetricsFile: "testfile",
+			PathKind:    common.FileKind,
+			MC: common.MetricsCollectorSpec{
+				Collector: &common.CollectorSpec{
+					Kind: common.StdOutCollector,
+				},
+			},
+			Expected: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "tensorflow",
+							Command: []string{
+								"sh", "-c",
+							},
+							Args: []string{
+								"python main.py 1>testfile 2>&1 && echo completed > $$$$.pid",
+							},
+						},
+					},
+				},
+			},
+			ExpectedError: nil,
+			Name:          "Tensorflow container with sh -c",
+		},
+	}
 
 	for _, c := range testCases {
 		err := wrapWorkerContainer(c.Pod, c.Namespace, c.JobKind, c.MetricsFile, c.PathKind, c.MC)
@@ -26,8 +146,9 @@ func TestWrapWorkerContainer(t *testing.T) {
 			t.Errorf("Expected error %v, got %v", c.ExpectedError, err)
 		}
 		if err == nil {
-			if !equality.Semantic.DeepEqual(c.Pod.Spec, c.Expected.Spec) {
-				t.Errorf("Expected pod %v, got %v", c.Pod.Spec, c.Expected.Spec)
+			if !equality.Semantic.DeepEqual(c.Pod.Spec.Containers, c.Expected.Spec.Containers) {
+				t.Errorf("Case %s: Expected pod %v, got %v",
+					c.Name, c.Expected.Spec.Containers, c.Pod.Spec.Containers)
 			}
 		}
 	}

--- a/pkg/webhook/v1alpha3/pod/inject_webhook_test.go
+++ b/pkg/webhook/v1alpha3/pod/inject_webhook_test.go
@@ -1,0 +1,34 @@
+package pod
+
+import (
+	"testing"
+
+	common "github.com/kubeflow/katib/pkg/apis/controller/common/v1alpha3"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+func TestWrapWorkerContainer(t *testing.T) {
+	testCases := []struct {
+		Pod           *v1.Pod
+		Namespace     string
+		JobKind       string
+		MetricsFile   string
+		PathKind      common.FileSystemKind
+		MC            common.MetricsCollectorSpec
+		Expected      *v1.Pod
+		ExpectedError error
+	}{}
+
+	for _, c := range testCases {
+		err := wrapWorkerContainer(c.Pod, c.Namespace, c.JobKind, c.MetricsFile, c.PathKind, c.MC)
+		if err != c.ExpectedError {
+			t.Errorf("Expected error %v, got %v", c.ExpectedError, err)
+		}
+		if err == nil {
+			if !equality.Semantic.DeepEqual(c.Pod.Spec, c.Expected.Spec) {
+				t.Errorf("Expected pod %v, got %v", c.Pod.Spec, c.Expected.Spec)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

We should not inject sh -c if the command already contains it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/1010)
<!-- Reviewable:end -->
