### PR TITLE
[FileMetricsCollector]skip line without metrics keywords

### DIFF
--- a/pkg/metricscollector/v1alpha3/file-metricscollector/file-metricscollector.go
+++ b/pkg/metricscollector/v1alpha3/file-metricscollector/file-metricscollector.go
@@ -38,9 +38,18 @@ func (d *FileMetricsCollector) parseLogs(logs []string, metrics []string, filter
 	metricRegList := getFilterRegexpList(filters)
 
 	for _, logline := range logs {
-		if logline == "" {
+		// skip line which doesn't contain any metrics keywords, avoiding unnecessary pattern match
+		isObjLine := false
+		for _, m := range metrics {
+			if strings.Contains(logline, m) {
+				isObjLine = true
+				break
+			}
+		}
+		if !isObjLine {
 			continue
 		}
+
 		timestamp := time.Time{}.UTC().Format(time.RFC3339)
 		ls := strings.SplitN(logline, " ", 2)
 		if len(ls) != 2 {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR purpose a tiny refinement on FileMetricsCollector. When parsing logs, it is better to skip line which doesn't contain any metrics keywords, so as to avoid unnecessary string matches.
