### PR TITLE
feat: Add a flag to support removing GRPC probe at runtime

### DIFF
--- a/cmd/katib-controller/v1alpha3/main.go
+++ b/cmd/katib-controller/v1alpha3/main.go
@@ -43,6 +43,7 @@ func main() {
 	var certLocalFS bool
 	var injectSecurityContext bool
 	var serviceName string
+	var enableGRPCProbeInSuggestion bool
 
 	flag.StringVar(&experimentSuggestionName, "experiment-suggestion-name",
 		"default", "The implementation of suggestion interface in experiment controller (default|fake)")
@@ -51,6 +52,7 @@ func main() {
 	flag.BoolVar(&certLocalFS, "cert-localfs", false, "Store the webhook cert in local file system")
 	flag.BoolVar(&injectSecurityContext, "webhook-inject-securitycontext", false, "Inject the securityContext of container[0] in the sidecar")
 	flag.StringVar(&serviceName, "webhook-service-name", "katib-controller", "The service name which will be used in webhook")
+	flag.BoolVar(&enableGRPCProbeInSuggestion, "enable-grpc-probe-in-suggestion", true, "enable grpc probe in suggestions")
 
 	flag.Parse()
 
@@ -58,6 +60,7 @@ func main() {
 	viper.Set(consts.ConfigExperimentSuggestionName, experimentSuggestionName)
 	viper.Set(consts.ConfigCertLocalFS, certLocalFS)
 	viper.Set(consts.ConfigInjectSecurityContext, injectSecurityContext)
+	viper.Set(consts.ConfigEnableGRPCProbeInSuggestion, enableGRPCProbeInSuggestion)
 
 	log.Info("Config:",
 		consts.ConfigExperimentSuggestionName,
@@ -70,6 +73,8 @@ func main() {
 		metricsAddr,
 		consts.ConfigInjectSecurityContext,
 		viper.GetBool(consts.ConfigInjectSecurityContext),
+		consts.ConfigEnableGRPCProbeInSuggestion,
+		viper.GetBool(consts.ConfigEnableGRPCProbeInSuggestion),
 	)
 
 	// Get a config to talk to the apiserver

--- a/pkg/controller.v1alpha3/consts/const.go
+++ b/pkg/controller.v1alpha3/consts/const.go
@@ -13,6 +13,9 @@ const (
 	// if we should inject the security context into the metrics collector
 	// sidecar.
 	ConfigInjectSecurityContext = "inject-security-context"
+	// ConfigEnableGRPCProbeInSuggestion is the config name which indicates
+	// if we should set GRPC probe in suggestion deployments.
+	ConfigEnableGRPCProbeInSuggestion = "enable-grpc-probe-in-suggestion"
 
 	// LabelExperimentName is the label of experiment name.
 	LabelExperimentName = "experiment"


### PR DESCRIPTION
Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

It is to add a flag to decide if we should enable the GRPC probe.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/1020)
<!-- Reviewable:end -->
