### PR TITLE
fix: Ignore trials without metrics

### DIFF
--- a/pkg/suggestion/v1alpha3/internal/trial.py
+++ b/pkg/suggestion/v1alpha3/internal/trial.py
@@ -19,7 +19,9 @@ class Trial(object):
         res = []
         for trial in trials:
             if trial.status.condition == api.TrialStatus.TrialConditionType.SUCCEEDED:
-                res.append(Trial.convertTrial(trial))
+                new_trial = Trial.convertTrial(trial)
+                if new_trial != None:
+                    res.append(Trial.convertTrial(trial))
         return res
 
     @staticmethod
@@ -30,9 +32,12 @@ class Trial(object):
         metric_name = trial.spec.objective.objective_metric_name
         target_metric, additional_metrics = Metric.convert(
             trial.status.observation, metric_name)
-        trial = Trial(trial.name, assignments, target_metric,
+        # If the target_metric is none, ignore the trial.
+        if target_metric != None:
+            trial = Trial(trial.name, assignments, target_metric,
                       metric_name, additional_metrics)
-        return trial
+            return trial
+        return None
 
     def __str__(self):
         if self.name == None:
@@ -77,7 +82,7 @@ class Metric(object):
 
     @staticmethod
     def convert(observation, target):
-        metric = ""
+        metric = None
         additional_metrics = []
         for m in observation.metrics:
             if m.name == target:


### PR DESCRIPTION
Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Some metrics will be ignored if it is none.

```
ERROR:grpc._server:Exception calling application: 'str' object has no attribute 'value'
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/grpc/_server.py", line 434, in _call_behavior
    response_or_iterator = behavior(argument, context)
  File "/usr/src/app/github.com/kubeflow/katib/pkg/suggestion/v1alpha3/hyperopt_service.py", line 27, in GetSuggestions
    search_space, trials, request.request_number)
  File "/usr/src/app/github.com/kubeflow/katib/pkg/suggestion/v1alpha3/hyperopt/base_hyperopt_service.py", line 95, in getSuggestions
    objective_for_hyperopt = float(trial.target_metric.value)
AttributeError: 'str' object has no attribute 'value'
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/1028)
<!-- Reviewable:end -->
