### PR TITLE
Adding Babylon Health as adopter

### DIFF
--- a/docs/community/adopters.md
+++ b/docs/community/adopters.md
@@ -8,3 +8,4 @@ please add yourself into the following list by a pull request.
 | [caicloud](https://caicloud.io/) |[@gaocegege](https://github.com/gaocegege) | Hyperparameter tuning in Caicloud Cloud-Native AI Platform |
 | [antfin](https://www.antfin.com/) |[@sperlingxx](https://github.com/sperlingxx) | Automatic training in AntFin internal AI Platform |
 | [cisco](https://cisco.com/) |[@ramdootp](https://github.com/ramdootp) | Hyperparameter tuning for conversational AI interface using Rasa |
+| [babylon health](https://www.babylonhealth.com/) |[@jeremievallee](https://github.com/jeremievallee) | Hyperparameter tuning for AIR internal AI Platform |


### PR DESCRIPTION
Adding [Babylon Health](https://www.babylonhealth.com/) as an adopter of Katib.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/1046)
<!-- Reviewable:end -->
