### PR TITLE
UI: Fix problem with equal time in different Trial metrics

### DIFF
--- a/pkg/ui/v1alpha3/hp.go
+++ b/pkg/ui/v1alpha3/hp.go
@@ -162,13 +162,16 @@ func (k *KatibUIHandler) FetchHPJobTrialInfo(w http.ResponseWriter, r *http.Requ
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	prevTime := ""
+	prevMetricTime := map[string]string{}
 	for _, m := range obsLogResp.ObservationLog.MetricLogs {
 		parsedTime, _ := time.Parse(time.RFC3339Nano, m.TimeStamp)
 		formatTime := parsedTime.Format("2006-01-02T15:04:05")
-		if formatTime != prevTime {
+		if _, found := prevMetricTime[m.Metric.Name]; !found {
+			prevMetricTime[m.Metric.Name] = ""
+		}
+		if formatTime != prevMetricTime[m.Metric.Name] {
 			resultText += m.Metric.Name + "," + formatTime + "," + m.Metric.Value + "\n"
-			prevTime = formatTime
+			prevMetricTime[m.Metric.Name] = formatTime
 		}
 	}
 


### PR DESCRIPTION
This PR fixes problem when different metrics have the same timestamp.
We should show all data from Observation Logs table in the Plot.

/assign @johnugeorge 
/cc @hougangliu @gaocegege

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/1047)
<!-- Reviewable:end -->
