### PR TITLE
Adding error propagation for K8s client creation in KatibClient

### DIFF
--- a/pkg/util/v1alpha3/katibclient/katib_client.go
+++ b/pkg/util/v1alpha3/katibclient/katib_client.go
@@ -66,6 +66,9 @@ func NewClient(options client.Options) (Client, error) {
 	trialsv1alpha3.AddToScheme(scheme.Scheme)
 	suggestionsv1alpha3.AddToScheme(scheme.Scheme)
 	cl, err := client.New(cfg, options)
+	if err != nil {
+		return nil, err
+	}
 	return &KatibClient{
 		client: cl,
 	}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds error propagation for K8s client creation in `katib_client.NewClient()`

**Which issue(s) this PR fixes**
If the `Client` creation fails for some reason - the error is silently ignored and Katib UI backend starts normally. However, when a new experiment is submitted from the UI, it results in nil pointer dereference panic because the `Client` has not been initialized.

**Special notes for your reviewer**:
This PR doesn't change any image versions

**Release note**:
```release-note
Fixed nil pointer dereference in `KatibClient`
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/1053)
<!-- Reviewable:end -->
