### PR TITLE
Create Optimizer in BO Suggestion only for the first run

### DIFF
--- a/pkg/suggestion/v1alpha3/skopt/base_skopt_service.py
+++ b/pkg/suggestion/v1alpha3/skopt/base_skopt_service.py
@@ -63,7 +63,6 @@ class BaseSkoptService(object):
         logger.info("New GetSuggestions call\n")
         skopt_suggested = []
         loss_for_skopt = []
-        return_trial_list = []
         if len(trials) > self.succeeded_trials or self.succeeded_trials == 0:
             self.succeeded_trials = len(trials)
             logger.info("Succeeded Trials changed or first call: {}\n".format(self.succeeded_trials))
@@ -106,12 +105,14 @@ class BaseSkoptService(object):
         else:
             logger.info("Succeeded Trials didn't change: {}\n".format(self.succeeded_trials))
 
-        logger.info("Running Optimizer ask to query new parameters for {} Trials".format(request_number))
-        skopt_suggested = self.skopt_optimizer.ask(n_points=request_number)
-        logger.info("New suggested parameters for Trials: {}\n\n".format(skopt_suggested))
-        for suggested in skopt_suggested:
-            return_trial_list.append(BaseSkoptService.convert(self.search_space, suggested))
+        logger.info("Running Optimizer ask to query new parameters for {} Trials\n".format(request_number))
+        return_trial_list = []
 
+        for i in range(request_number):
+                    skopt_suggested = self.skopt_optimizer.ask()
+                    logger.info("New suggested parameters for Trial: {}".format(skopt_suggested))
+                    return_trial_list.append(
+                        BaseSkoptService.convert(self.search_space, skopt_suggested))
         return return_trial_list
 
     @staticmethod

--- a/pkg/suggestion/v1alpha3/skopt/base_skopt_service.py
+++ b/pkg/suggestion/v1alpha3/skopt/base_skopt_service.py
@@ -106,7 +106,7 @@ class BaseSkoptService(object):
         else:
             logger.info("Succeeded Trials didn't change: {}\n".format(self.succeeded_trials))
 
-        logger.info("Running Optimizer ask to query new parameters for {} Trials\n".format(request_number))
+        logger.info("Running Optimizer ask to query new parameters for Trials\n")
 
         return_trial_list = []
 
@@ -115,7 +115,8 @@ class BaseSkoptService(object):
             logger.info("New suggested parameters for Trial: {}".format(skopt_suggested))
             return_trial_list.append(
                 BaseSkoptService.convert(self.search_space, skopt_suggested))
-        logger.info("\n" * 3)
+
+        logger.info("GetSuggestions return {} new Trials\n\n".format(request_number))
         return return_trial_list
 
     @staticmethod

--- a/pkg/suggestion/v1alpha3/skopt/base_skopt_service.py
+++ b/pkg/suggestion/v1alpha3/skopt/base_skopt_service.py
@@ -107,13 +107,15 @@ class BaseSkoptService(object):
             logger.info("Succeeded Trials didn't change: {}\n".format(self.succeeded_trials))
 
         logger.info("Running Optimizer ask to query new parameters for {} Trials\n".format(request_number))
+
         return_trial_list = []
 
         for i in range(request_number):
-                    skopt_suggested = self.skopt_optimizer.ask()
-                    logger.info("New suggested parameters for Trial: {}".format(skopt_suggested))
-                    return_trial_list.append(
-                        BaseSkoptService.convert(self.search_space, skopt_suggested))
+            skopt_suggested = self.skopt_optimizer.ask()
+            logger.info("New suggested parameters for Trial: {}".format(skopt_suggested))
+            return_trial_list.append(
+                BaseSkoptService.convert(self.search_space, skopt_suggested))
+        logger.info("\n" * 3)
         return return_trial_list
 
     @staticmethod

--- a/pkg/suggestion/v1alpha3/skopt/base_skopt_service.py
+++ b/pkg/suggestion/v1alpha3/skopt/base_skopt_service.py
@@ -65,7 +65,8 @@ class BaseSkoptService(object):
         loss_for_skopt = []
         if len(trials) > self.succeeded_trials or self.succeeded_trials == 0:
             self.succeeded_trials = len(trials)
-            logger.info("Succeeded Trials changed or first call: {}\n".format(self.succeeded_trials))
+            if self.succeeded_trials != 0:
+                logger.info("Succeeded Trials changed: {}\n".format(self.succeeded_trials))
             for trial in trials:
                 trial_assignment = []
                 for param in self.search_space.params:

--- a/pkg/suggestion/v1alpha3/skopt/base_skopt_service.py
+++ b/pkg/suggestion/v1alpha3/skopt/base_skopt_service.py
@@ -66,7 +66,7 @@ class BaseSkoptService(object):
         return_trial_list = []
         if len(trials) > self.succeeded_trials or self.succeeded_trials == 0:
             self.succeeded_trials = len(trials)
-            logger.info("Succeeded Trials changed: {}\n".format(self.succeeded_trials))
+            logger.info("Succeeded Trials changed or first call: {}\n".format(self.succeeded_trials))
             for trial in trials:
                 trial_assignment = []
                 for param in self.search_space.params:

--- a/pkg/suggestion/v1alpha3/skopt/base_skopt_service.py
+++ b/pkg/suggestion/v1alpha3/skopt/base_skopt_service.py
@@ -29,6 +29,9 @@ class BaseSkoptService(object):
         self.search_space = search_space
         self.skopt_optimizer = None
         self.create_optimizer()
+        self.succeeded_trials = 0
+        # Dict of recorded trials where key = loss value, value = List of trial assignment list for this value
+        self.recorded_trials = {}
 
     def create_optimizer(self):
         skopt_search_space = []
@@ -59,36 +62,48 @@ class BaseSkoptService(object):
 
         skopt_suggested = []
         loss_for_skopt = []
-        for trial in trials:
-            trial_assignment = []
-            for param in self.search_space.params:
-                parameter_value = None
-                for assignment in trial.assignments:
-                    if assignment.name == param.name:
-                        parameter_value = assignment.value
-                        break
-                if param.type == INTEGER:
-                    trial_assignment.append(int(parameter_value))
-                elif param.type == DOUBLE:
-                    trial_assignment.append(float(parameter_value))
-                else:
-                    trial_assignment.append(parameter_value)
-            skopt_suggested.append(trial_assignment)
-
-            loss_value = float(trial.target_metric.value)
-            if self.search_space.goal == MAX_GOAL:
-                loss_value = -1 * loss_value
-            loss_for_skopt.append(loss_value)
-
-        if loss_for_skopt != [] and skopt_suggested != []:
-            self.skopt_optimizer.tell(skopt_suggested, loss_for_skopt)
-
         return_trial_list = []
+        if len(trials) > self.succeeded_trials or self.succeeded_trials == 0:
+            self.succeeded_trials = len(trials)
+            logger.info("Succeeded Trials: {}".format(self.succeeded_trials))
+            for trial in trials:
+                trial_assignment = []
+                for param in self.search_space.params:
+                    parameter_value = None
+                    for assignment in trial.assignments:
+                        if assignment.name == param.name:
+                            parameter_value = assignment.value
+                            break
+                    if param.type == INTEGER:
+                        trial_assignment.append(int(parameter_value))
+                    elif param.type == DOUBLE:
+                        trial_assignment.append(float(parameter_value))
+                    else:
+                        trial_assignment.append(parameter_value)
 
-        for i in range(request_number):
-            skopt_suggested = self.skopt_optimizer.ask()
-            return_trial_list.append(
-                BaseSkoptService.convert(self.search_space, skopt_suggested))
+                loss_value = float(trial.target_metric.value)
+                if self.search_space.goal == MAX_GOAL:
+                    loss_value = -1 * loss_value
+
+                # Update only for new values
+                if loss_value not in self.recorded_trials:
+                    self.recorded_trials[loss_value] = []
+                    self.recorded_trials[loss_value].append(trial_assignment)
+                    skopt_suggested.append(trial_assignment)
+                    loss_for_skopt.append(loss_value)
+                elif trial_assignment not in self.recorded_trials[loss_value]:
+                    self.recorded_trials[loss_value].append(trial_assignment)
+                    skopt_suggested.append(trial_assignment)
+                    loss_for_skopt.append(loss_value)
+
+            if loss_for_skopt != [] and skopt_suggested != []:
+                self.skopt_optimizer.tell(skopt_suggested, loss_for_skopt)
+
+            for i in range(request_number):
+                skopt_suggested = self.skopt_optimizer.ask()
+                return_trial_list.append(
+                    BaseSkoptService.convert(self.search_space, skopt_suggested))
+
         return return_trial_list
 
     @staticmethod
@@ -102,4 +117,7 @@ class BaseSkoptService(object):
                 assignments.append(Assignment(param.name, skopt_suggested[i]))
             elif param.type == CATEGORICAL or param.type == DISCRETE:
                 assignments.append(Assignment(param.name, skopt_suggested[i]))
+        for a in assignments:
+            logger.info("Generate new Trial with Assignment")
+            logger.info(a)
         return assignments

--- a/pkg/suggestion/v1alpha3/skopt_service.py
+++ b/pkg/suggestion/v1alpha3/skopt_service.py
@@ -27,8 +27,8 @@ class SkoptService(api_pb2_grpc.SuggestionServicer, HealthServicer):
         if algorithm_name != "bayesianoptimization":
             raise Exception("Failed to create the algortihm: {}".format(algorithm_name))
 
-        search_space = HyperParameterSearchSpace.convert(request.experiment)
         if self.is_first_run:
+            search_space = HyperParameterSearchSpace.convert(request.experiment)
             self.base_service = BaseSkoptService(
                 base_estimator=config.base_estimator,
                 n_initial_points=config.n_initial_points,


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1039.

In this PR I added `is_first_run` flag.
We must create `Optimizer` instance using `search_space` only for the first `GetSuggestions` call.

/assign @gaocegege @johnugeorge

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/1057)
<!-- Reviewable:end -->
