### PR TITLE
Add missing GRPC health probe for arm64 to db-manager

### DIFF
--- a/cmd/db-manager/v1alpha3/Dockerfile
+++ b/cmd/db-manager/v1alpha3/Dockerfile
@@ -11,6 +11,8 @@ RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     if [ "$(uname -m)" = "ppc64le" ]; then \
 	wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-ppc64le; \
+    elif [ "$(uname -m)" = "aarch64" ]; then \
+	wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-arm64; \
     else \
 	wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64; \
     fi && \


### PR DESCRIPTION
In my previous PR #897 for the aarch64 platform support for katib Dockerfiles, the version of db-manager was v1alpha2, which has been deprecated now. 

This PR adds the missing GRPC health probe binary to v1alpha3 aarch64 images.

Signed-off-by: Henry Wang <<henry.wang@arm.com>>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/1059)
<!-- Reviewable:end -->
