### PR TITLE
Fix TPE Suggestion

### DIFF
--- a/cmd/suggestion/hyperopt/v1alpha3/requirements.txt
+++ b/cmd/suggestion/hyperopt/v1alpha3/requirements.txt
@@ -7,4 +7,4 @@ scipy>=0.19.1
 forestci==0.3
 protobuf==3.9.1
 googleapis-common-protos==1.6.0
-hyperopt==0.1.2
+hyperopt==0.2.3

--- a/pkg/suggestion/v1alpha3/hyperopt/base_hyperopt_service.py
+++ b/pkg/suggestion/v1alpha3/hyperopt/base_hyperopt_service.py
@@ -7,12 +7,15 @@ from pkg.suggestion.v1alpha3.internal.trial import *
 
 logger = logging.getLogger("BaseHyperoptService")
 
+TPE_ALGORITHM_NAME = "tpe"
+RANDOM_ALGORITHM_NAME = "random"
+
 class BaseHyperoptService(object):
-    def __init__(self, algorithm_name="tpe", random_state=None):
-        self.random_state = random_state
-        if algorithm_name == 'tpe':
+    def __init__(self, algorithm_name=TPE_ALGORITHM_NAME, random_state=None, search_space=None):
+        self.algorithm_name = algorithm_name
+        if self.algorithm_name == TPE_ALGORITHM_NAME:
             self.hyperopt_algorithm = hyperopt.tpe.suggest
-        elif algorithm_name == 'random':
+        elif self.algorithm_name == RANDOM_ALGORITHM_NAME:
             self.hyperopt_algorithm = hyperopt.rand.suggest
         # elif algorithm_name == 'hyperopt-anneal':
         #     self.hyperopt_algorithm = hyperopt.anneal.suggest_batch
@@ -21,13 +24,16 @@ class BaseHyperoptService(object):
         else:
             raise Exception('"Failed to create the algortihm: {}'.format(algorithm_name))
 
-    def getSuggestions(self, search_space, trials, request_number):
-        """
-        Get the new suggested trials with the given algorithm.
-        """
+        self.search_space = search_space
+        # New hyperopt variables
+        self.hyperopt_rstate = np.random.RandomState(random_state)
+        self.create_hyperopt_domain()
+        self.create_fmin()
+
+    def create_hyperopt_domain(self):
         # Construct search space, example: {"x": hyperopt.hp.uniform('x', -10, 10), "x2": hyperopt.hp.uniform('x2', -10, 10)}
         hyperopt_search_space = {}
-        for param in search_space.params:
+        for param in self.search_space.params:
             if param.type == INTEGER:
                 hyperopt_search_space[param.name] = hyperopt.hp.quniform(
                     param.name,
@@ -38,102 +44,163 @@ class BaseHyperoptService(object):
                     param.name,
                     float(param.min),
                     float(param.max))
-            elif param.type == CATEGORICAL \
-                    or param.type == DISCRETE:
+            elif param.type == CATEGORICAL or param.type == DISCRETE:
                 hyperopt_search_space[param.name] = hyperopt.hp.choice(
                     param.name, param.list)
-         # New hyperopt variables
-        hyperopt_rstate = np.random.RandomState(self.random_state)
-        hyperopt_domain = hyperopt.Domain(
+
+        self.hyperopt_domain = hyperopt.Domain(
             None, hyperopt_search_space, pass_expr_memo_ctrl=None)
 
+    def create_fmin(self):
+        self.fmin = hyperopt.FMinIter(
+            self.hyperopt_algorithm,
+            self.hyperopt_domain,
+            trials=hyperopt.Trials(),
+            max_evals=-1,
+            rstate=self.hyperopt_rstate,
+            verbose=False)
+
+        self.fmin.catch_eval_exceptions = False
+
+
+    def getSuggestions(self, trials, request_number):
+        """
+        Get the new suggested trials with the given algorithm.
+        """
+
+        recorded_trials_names = self.fmin.trials.specs
+
+        # Produce new ids for Trials
+        hyperopt_trial_new_ids = self.fmin.trials.new_trial_ids(request_number)
+
+        tid_index = 0
         hyperopt_trial_specs = []
         hyperopt_trial_results = []
-        # Example: # Example: [{'tid': 0, 'idxs': {'l1_normalization': [0], 'learning_rate': [0], 'hidden2': [0], 'optimizer': [0]}, 'cmd': ('domain_attachment', 'FMinIter_Domain'), 'vals': {'l1_normalization': [0.1], 'learning_rate': [0.1], 'hidden2': [1], 'optimizer': [1]}, 'workdir': None}]
         hyperopt_trial_miscs = []
-        hyperopt_trial_new_ids = []
-
-        # Update hyperopt for trained trials with completed advisor trials
-        completed_hyperopt_trials = hyperopt.Trials()
+        # Update hyperopt FMin with new completed trials
         for trial in trials:
-             # Example: {'l1_normalization': [0], 'learning_rate': [0], 'hidden2': [0], 'optimizer': [0]}
-            hyperopt_trial_miscs_idxs = {}
-            # Example: {'l1_normalization': [0.1], 'learning_rate': [0.1], 'hidden2': [1], 'optimizer': [1]}
-            hyperopt_trial_miscs_vals = {}
-            new_id = trial.name
-            hyperopt_trial_new_ids.append(new_id)
-            hyperopt_trial_misc = dict(
-                tid=new_id, cmd=hyperopt_domain.cmd, workdir=hyperopt_domain.workdir)
-            for param in search_space.params:
-                parameter_value = None
-                for assignment in trial.assignments:
-                    if assignment.name == param.name:
-                        parameter_value = assignment.value
-                        break
-                if param.type == INTEGER:
-                    hyperopt_trial_miscs_idxs[param.name] = [new_id]
-                    hyperopt_trial_miscs_vals[param.name] = [
-                        parameter_value]
-                elif param.type == DOUBLE:
-                    hyperopt_trial_miscs_idxs[param.name] = [new_id]
-                    hyperopt_trial_miscs_vals[param.name] = [
-                        parameter_value]
-                elif param.type == DISCRETE or param.type == CATEGORICAL:
-                    index_of_value_in_list = param.list.index(parameter_value)
-                    hyperopt_trial_miscs_idxs[param.name] = [trial.name]
-                    hyperopt_trial_miscs_vals[param.name] = [
-                        index_of_value_in_list
-                    ]
+            if {"trial-name":trial.name} not in recorded_trials_names:
+                # New id for the new Trial
+                new_id = hyperopt_trial_new_ids[tid_index]
+                tid_index+=1
+                hyperopt_trial_miscs_idxs = {}
+                # Example: {'l1_normalization': [0.1], 'learning_rate': [0.1], 'hidden2': [1], 'optimizer': [1]}
+                hyperopt_trial_miscs_vals = {}
 
-            hyperopt_trial_specs.append(None)
+                # Insert Trial assignment to the misc
+                hyperopt_trial_misc = dict(
+                    tid=new_id, cmd=self.hyperopt_domain.cmd, workdir=self.hyperopt_domain.workdir)
+                for param in self.search_space.params:
+                    parameter_value = None
+                    for assignment in trial.assignments:
+                        if assignment.name == param.name:
+                            parameter_value = assignment.value
+                            break
+                    if param.type == INTEGER:
+                        hyperopt_trial_miscs_idxs[param.name] = [new_id]
+                        hyperopt_trial_miscs_vals[param.name] = [int(parameter_value)]
+                    elif param.type == DOUBLE:
+                        hyperopt_trial_miscs_idxs[param.name] = [new_id]
+                        hyperopt_trial_miscs_vals[param.name] = [float(parameter_value)]
+                    elif param.type == DISCRETE or param.type == CATEGORICAL:
+                        index_of_value_in_list = param.list.index(parameter_value)
+                        hyperopt_trial_miscs_idxs[param.name] = [new_id]
+                        hyperopt_trial_miscs_vals[param.name] = [index_of_value_in_list]
 
-            hyperopt_trial_misc["idxs"] = hyperopt_trial_miscs_idxs
-            hyperopt_trial_misc["vals"] = hyperopt_trial_miscs_vals
-            hyperopt_trial_miscs.append(hyperopt_trial_misc)
 
-            # TODO: Use negative objective value for loss or not
-            objective_for_hyperopt = float(trial.target_metric.value)
-            if search_space.goal == MAX_GOAL:
-                # Now hyperopt only supports fmin and we need to reverse objective value for maximization
-                objective_for_hyperopt = -1 * objective_for_hyperopt
-            hyperopt_trial_result = {
-                "loss": objective_for_hyperopt,
-                "status": hyperopt.STATUS_OK
-            }
-            hyperopt_trial_results.append(hyperopt_trial_result)
+                hyperopt_trial_misc["idxs"] = hyperopt_trial_miscs_idxs
+                hyperopt_trial_misc["vals"] = hyperopt_trial_miscs_vals
+                hyperopt_trial_miscs.append(hyperopt_trial_misc)
+
+                # Insert Trial name to the spec
+                hyperopt_trial_spec = {
+                    "trial-name": trial.name
+                }
+                hyperopt_trial_specs.append(hyperopt_trial_spec)
+
+                # Insert Trial result to the result
+                # TODO: Use negative objective value for loss or not
+                # TODO: Do we need to analyse additional_metrics?
+                objective_for_hyperopt = float(trial.target_metric.value)
+                if self.search_space.goal == MAX_GOAL:
+                    # Now hyperopt only supports fmin and we need to reverse objective value for maximization
+                    objective_for_hyperopt = -1 * objective_for_hyperopt
+                hyperopt_trial_result = {
+                    "loss": objective_for_hyperopt,
+                    "status": hyperopt.STATUS_OK
+                }
+                hyperopt_trial_results.append(hyperopt_trial_result)
+
         if len(trials) > 0:
-            # Example: {'refresh_time': datetime.datetime(2018, 9, 18, 12, 6, 41, 922000), 'book_time': datetime.datetime(2018, 9, 18, 12, 6, 41, 922000), 'misc': {'tid': 0, 'idxs': {'x2': [0], 'x': [0]}, 'cmd': ('domain_attachment', 'FMinIter_Domain'), 'vals': {'x2': [-8.137088361136204], 'x': [-4.849028446711832]}, 'workdir': None}, 'state': 2, 'tid': 0, 'exp_key': None, 'version': 0, 'result': {'status': 'ok', 'loss': 14.849028446711833}, 'owner': None, 'spec': None}
-            hyperopt_trials = completed_hyperopt_trials.new_trial_docs(
-                hyperopt_trial_new_ids, hyperopt_trial_specs, hyperopt_trial_results, hyperopt_trial_miscs)
-            for current_hyperopt_trials in hyperopt_trials:
-                current_hyperopt_trials["state"] = hyperopt.JOB_STATE_DONE
 
-            completed_hyperopt_trials.insert_trial_docs(hyperopt_trials)
-            completed_hyperopt_trials.refresh()
+            # Create new Trial doc
+            hyperopt_trials = hyperopt.Trials().new_trial_docs(
+                tids=hyperopt_trial_new_ids,
+                specs=hyperopt_trial_specs,
+                results=hyperopt_trial_results,
+                miscs=hyperopt_trial_miscs)
 
-        rval = hyperopt.FMinIter(
-            self.hyperopt_algorithm,
-            hyperopt_domain,
-            completed_hyperopt_trials,
-            max_evals=-1,
-            rstate=hyperopt_rstate,
-            verbose=0)
-        rval.catch_eval_exceptions = False
+            for i, _ in enumerate(hyperopt_trials):
+                hyperopt_trials[i]["state"] = hyperopt.JOB_STATE_DONE
 
-        new_ids = rval.trials.new_trial_ids(request_number)
+            # Insert new set of Trial to FMin object
+            # Example: of inserting doc with tunning lr
+            #   [{
+            #       'state':2,
+            #       'tid':5,
+            #       'spec':{
+            #          'trial-name':'tpe-example-48xl8whg'
+            #       },
+            #       'result':{
+            #          'loss':-0.1135,
+            #          'status':'ok'
+            #       },
+            #       'misc':{
+            #          'tid':5,
+            #          'cmd':('domain_attachment','FMinIter_Domain'),
+            #          'workdir':None,
+            #          'idxs':{
+            #             '--lr':[5]
+            #          },
+            #          'vals':{
+            #             '--lr':[0.025351232898626827]
+            #          }
+            #       },
+            #       'exp_key':None,
+            #       'owner':None,
+            #       'version':0,
+            #       'book_time':None,
+            #       'refresh_time':None
+            #   }]
+            self.fmin.trials.insert_trial_docs(hyperopt_trials)
+            self.fmin.trials.refresh()
 
-        rval.trials.refresh()
+            # Produce another new ids to make new Suggestion if we inserted Trials before
+            hyperopt_trial_new_ids = self.fmin.trials.new_trial_ids(request_number)
 
-        random_state = rval.rstate.randint(2**31 - 1)
-        new_trials = self.hyperopt_algorithm(
-            new_ids, rval.domain, completed_hyperopt_trials, random_state)
-        rval.trials.refresh()
+        random_state = self.fmin.rstate.randint(2**31 - 1)
+        if self.algorithm_name == RANDOM_ALGORITHM_NAME:
+            new_trials = self.hyperopt_algorithm(
+                new_ids=hyperopt_trial_new_ids,
+                domain=self.fmin.domain,
+                trials=self.fmin.trials,
+                seed=random_state)
+        elif self.algorithm_name == TPE_ALGORITHM_NAME:
+            # n_startup_jobs indicates for how many Trials we run random suggestion
+            # This must be request_number value
+            # After this tpe suggestion starts analyse Trial info
+            new_trials = self.hyperopt_algorithm(
+                new_ids=hyperopt_trial_new_ids,
+                domain=self.fmin.domain,
+                trials=self.fmin.trials,
+                seed=random_state,
+                n_startup_jobs=request_number)
 
         # Construct return advisor trials from new hyperopt trials
         list_of_assignments = []
         for i in range(request_number):
             vals = new_trials[i]['misc']['vals']
-            list_of_assignments.append(BaseHyperoptService.convert(search_space, vals))
+            list_of_assignments.append(BaseHyperoptService.convert(self.search_space, vals))
         return list_of_assignments
 
     @staticmethod

--- a/pkg/suggestion/v1alpha3/hyperopt/base_hyperopt_service.py
+++ b/pkg/suggestion/v1alpha3/hyperopt/base_hyperopt_service.py
@@ -196,6 +196,7 @@ class BaseHyperoptService(object):
                     trials=self.fmin.trials,
                     seed=random_state,
                     n_startup_jobs=request_number)
+                self.is_first_run = False
             else:
                 new_trials = []
                 for i in range(request_number):
@@ -212,7 +213,6 @@ class BaseHyperoptService(object):
         for i in range(request_number):
             vals = new_trials[i]['misc']['vals']
             list_of_assignments.append(BaseHyperoptService.convert(self.search_space, vals))
-        self.is_first_run = False
         return list_of_assignments
 
     @staticmethod

--- a/pkg/suggestion/v1alpha3/hyperopt_service.py
+++ b/pkg/suggestion/v1alpha3/hyperopt_service.py
@@ -24,6 +24,7 @@ class HyperoptService(api_pb2_grpc.SuggestionServicer, HealthServicer):
         """
         name, config = OptimizerConfiguration.convertAlgorithmSpec(
             request.experiment.spec.algorithm)
+
         if self.is_first_run:
             search_space = HyperParameterSearchSpace.convert(request.experiment)
             self.base_service = BaseHyperoptService(

--- a/pkg/suggestion/v1alpha3/hyperopt_service.py
+++ b/pkg/suggestion/v1alpha3/hyperopt_service.py
@@ -11,20 +11,29 @@ from pkg.suggestion.v1alpha3.base_health_service import HealthServicer
 logger = logging.getLogger("HyperoptRandomService")
 
 
-class HyperoptService(
-        api_pb2_grpc.SuggestionServicer, HealthServicer):
+class HyperoptService(api_pb2_grpc.SuggestionServicer, HealthServicer):
+
+    def __init__(self):
+        super(HyperoptService, self).__init__()
+        self.base_service = None
+        self.is_first_run = True
+
     def GetSuggestions(self, request, context):
         """
         Main function to provide suggestion.
         """
         name, config = OptimizerConfiguration.convertAlgorithmSpec(
             request.experiment.spec.algorithm)
-        base_serice = BaseHyperoptService(
-            algorithm_name=name, random_state=config.random_state)
-        search_space = HyperParameterSearchSpace.convert(request.experiment)
+        if self.is_first_run:
+            search_space = HyperParameterSearchSpace.convert(request.experiment)
+            self.base_service = BaseHyperoptService(
+                algorithm_name=name,
+                random_state=config.random_state,
+                search_space=search_space)
+            self.is_first_run = False
+
         trials = Trial.convert(request.trials)
-        new_assignments = base_serice.getSuggestions(
-            search_space, trials, request.request_number)
+        new_assignments = self.base_service.getSuggestions(trials, request.request_number)
         return api_pb2.GetSuggestionsReply(
             parameter_assignments=Assignment.generate(new_assignments)
         )
@@ -36,8 +45,8 @@ class OptimizerConfiguration(object):
 
     @staticmethod
     def convertAlgorithmSpec(algorithm_spec):
-        optmizer = OptimizerConfiguration()
+        optimizer = OptimizerConfiguration()
         for s in algorithm_spec.algorithm_setting:
             if s.name == "random_state":
-                optmizer.random_state = int(s.value)
-        return algorithm_spec.algorithm_name, optmizer
+                optimizer.random_state = int(s.value)
+        return algorithm_spec.algorithm_name, optimizer


### PR DESCRIPTION
This PR fixes some problems in hyperopt Suggestion.

1. I tested `tpe` Algorithm on large-amount of Trials. After 20 Succeeded Trial I always got this error:
```
INFO:hyperopt.tpe:tpe_transform took 0.001436 seconds
INFO:hyperopt.tpe:TPE using 20/20 trials with best loss -0.955490
ERROR:grpc._server:Exception calling application: '>' not supported between instances of 'int' and 'str'
Traceback (most recent call last):
File "/usr/local/lib/python3.6/site-packages/grpc/_server.py", line 434, in _call_behavior
response_or_iterator = behavior(argument, context)
File "/usr/src/app/github.com/kubeflow/katib/pkg/suggestion/v1alpha3/hyperopt_service.py", line 27, in GetSuggestions
search_space, trials, request.request_number)
File "/usr/src/app/github.com/kubeflow/katib/pkg/suggestion/v1alpha3/hyperopt/base_hyperopt_service.py", line 129, in getSuggestions
new_ids, rval.domain, completed_hyperopt_trials, random_state)
File "/usr/local/lib/python3.6/site-packages/hyperopt/tpe.py", line 876, in suggest
fake_id_0 = max(max(tids), new_id) + 2
TypeError: '>' not supported between instances of 'int' and 'str'
```
I investigated hyperopt and found that here: https://github.com/hyperopt/hyperopt/blob/master/hyperopt/tpe.py#L906, we run just a simple random suggestion for `n_startup_jobs` times, and only after 20 Trials we start to run `tpe`. I changed this number to `request_number`. Only in the first `GetSuggestion` call we must run random algorithm.

2. To solve above error, I change structure of Doc. **I believe, we can't use Trial name as `tid` in the Doc**.  For `tid` I use id generated by `self.fmin` object. As well, I save Trial name to the spec section.

3. I insert only new Trials in the Doc. I check which Trials have been already inserted in `recorded_trials_names`.

4. To generate new ids every `GetSuggestions` call, I create `FMinIter` instance in the first call. And I update information about succeeded Trials in `self.fmin` object.

5. To follow this PR https://github.com/kubeflow/katib/pull/1057, Search Space is transformed to Domain only in the first `GetSuggestions` call.

6. When we analyse information from Succeeded Trials we must cast values to `int` or `float` or they will be `strings` and we will have errors in `tpe.suggest`

7. After first `GetSuggestion` call, `tpe.suggest` will generate only one Trial. I create a loop to run this method, in case that we need to create more than 1 Trial during Experiment.

I tested `tpe` and `random` on 150 Trial Experiment, I didn't get any errors.

Please take a look.

/assign @gaocegege @johnugeorge

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/1063)
<!-- Reviewable:end -->
