### PR TITLE
UI: Show best metrics in the Trial metrics information plot

### DIFF
--- a/pkg/mock/v1alpha3/util/katibclient/katibclient.go
+++ b/pkg/mock/v1alpha3/util/katibclient/katibclient.go
@@ -183,6 +183,26 @@ func (mr *MockClientMockRecorder) GetSuggestion(arg0 interface{}, arg1 ...interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSuggestion", reflect.TypeOf((*MockClient)(nil).GetSuggestion), varargs...)
 }
 
+// GetTrial mocks base method
+func (m *MockClient) GetTrial(arg0 string, arg1 ...string) (*v1alpha31.Trial, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetTrial", varargs...)
+	ret0, _ := ret[0].(*v1alpha31.Trial)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTrial indicates an expected call of GetTrial
+func (mr *MockClientMockRecorder) GetTrial(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrial", reflect.TypeOf((*MockClient)(nil).GetTrial), varargs...)
+}
+
 // GetTrialList mocks base method
 func (m *MockClient) GetTrialList(arg0 string, arg1 ...string) (*v1alpha31.TrialList, error) {
 	m.ctrl.T.Helper()

--- a/pkg/ui/v1alpha3/frontend/src/actions/hpMonitorActions.js
+++ b/pkg/ui/v1alpha3/frontend/src/actions/hpMonitorActions.js
@@ -45,9 +45,10 @@ export const FETCH_HP_JOB_TRIAL_INFO_REQUEST = "FETCH_HP_JOB_TRIAL_INFO_REQUEST"
 export const FETCH_HP_JOB_TRIAL_INFO_SUCCESS = "FETCH_HP_JOB_TRIAL_INFO_SUCCESS";
 export const FETCH_HP_JOB_TRIAL_INFO_FAILURE = "FETCH_HP_JOB_TRIAL_INFO_FAILURE";
 
-export const fetchHPJobTrialInfo = (trialName) => ({
+export const fetchHPJobTrialInfo = (trialName, namespace) => ({
     type: FETCH_HP_JOB_TRIAL_INFO_REQUEST,
-    trialName
+    trialName,
+    namespace
 })
 
 export const CLOSE_DIALOG_TRIAL = "CLOSE_DIALOG_TRIAL";

--- a/pkg/ui/v1alpha3/frontend/src/components/HP/Monitor/HPJobInfo.jsx
+++ b/pkg/ui/v1alpha3/frontend/src/components/HP/Monitor/HPJobInfo.jsx
@@ -73,7 +73,7 @@ class HPJobInfo extends React.Component {
                         </Button>
                     </div>
                     <HPJobPlot name={this.props.match.params.name} />
-                    <HPJobTable name={this.props.match.params.name} />
+                    <HPJobTable namespace={this.props.match.params.namespace} />
                     <ExperimentInfoDialog/>
                     <TrialInfoDialog />
                 </div>

--- a/pkg/ui/v1alpha3/frontend/src/components/HP/Monitor/HPJobTable.jsx
+++ b/pkg/ui/v1alpha3/frontend/src/components/HP/Monitor/HPJobTable.jsx
@@ -46,7 +46,7 @@ const styles = theme => ({
 class HPJobTable extends React.Component {
 
   fetchAndOpenDialogTrial = (trialName) => (event) => {
-    this.props.fetchHPJobTrialInfo(trialName);
+    this.props.fetchHPJobTrialInfo(trialName, this.props.namespace);
   }
 
   render () {

--- a/pkg/ui/v1alpha3/frontend/src/components/HP/Monitor/TrialInfoDialog.jsx
+++ b/pkg/ui/v1alpha3/frontend/src/components/HP/Monitor/TrialInfoDialog.jsx
@@ -63,7 +63,7 @@ const TrialInfoDialog = (props) => {
                 aria-describedby="alert-dialog-description"
                 maxWidth={"xl"}
             >
-            <DialogTitle id="alert-dialog-title" className = {classes.header}>{"Trial data"}</DialogTitle>
+            <DialogTitle id="alert-dialog-title" className = {classes.header}>{"Trial Name: "+props.trialName}</DialogTitle>
             <DialogContent>
                 <Plot 
                     data={dataToPlot}
@@ -87,6 +87,7 @@ const mapStateToProps = state => {
     return {
         open: state[module].dialogTrialOpen,
         trialData: state[module].trialData,
+        trialName: state[module].trialName
     }
 }
 

--- a/pkg/ui/v1alpha3/frontend/src/reducers/hpMonitor.js
+++ b/pkg/ui/v1alpha3/frontend/src/reducers/hpMonitor.js
@@ -23,6 +23,7 @@ const initialState = {
     dialogTrialOpen: false,
     dialogExperimentOpen: false,
     loading: false,
+    trialName: ''
 };
 
 const hpMonitorReducer = (state = initialState, action) => {
@@ -134,6 +135,7 @@ const hpMonitorReducer = (state = initialState, action) => {
                 ...state,
                 trialData: action.trialData,
                 dialogTrialOpen: true,
+                trialName: action.trialName
             }
         case actions.CLOSE_DIALOG_TRIAL:
             return {

--- a/pkg/ui/v1alpha3/frontend/src/sagas/index.js
+++ b/pkg/ui/v1alpha3/frontend/src/sagas/index.js
@@ -292,13 +292,15 @@ export const fetchHPJobTrialInfo = function* () {
         try {
             const result = yield call(
                 gofetchHPJobTrialInfo,
-                action.trialName
+                action.trialName,
+                action.namespace
             )
             if (result.status === 200) {
                 let data = result.data.split("\n").map((line, i) => line.split(','))
                 yield put({
                     type: hpMonitorActions.FETCH_HP_JOB_TRIAL_INFO_SUCCESS,
-                    trialData: data
+                    trialData: data,
+                    trialName: action.trialName
                 })
             } else {
                 yield put({
@@ -313,11 +315,11 @@ export const fetchHPJobTrialInfo = function* () {
     }
 }
 
-const gofetchHPJobTrialInfo = function* (trialName) {
+const gofetchHPJobTrialInfo = function* (trialName, namespace) {
     try {
         const result = yield call(
             axios.get,
-            `/katib/fetch_hp_job_trial_info/?trialName=${trialName}`,
+            `/katib/fetch_hp_job_trial_info/?trialName=${trialName}&namespace=${namespace}`,
         )
         return result
     } catch (err) {

--- a/pkg/ui/v1alpha3/hp.go
+++ b/pkg/ui/v1alpha3/hp.go
@@ -170,7 +170,7 @@ func (k *KatibUIHandler) FetchHPJobTrialInfo(w http.ResponseWriter, r *http.Requ
 
 	objectiveType := trial.Spec.Objective.Type
 
-	//resultArray - array of arrays, where [i][0] - metricName, [i][1] - metricTime, [i][2] - metriValue
+	// resultArray - array of arrays, where [i][0] - metricName, [i][1] - metricTime, [i][2] - metricValue
 	var resultArray [][]string
 	resultArray = append(resultArray, strings.Split("metricName,time,value", ","))
 	obsLogResp, err := c.GetObservationLog(

--- a/pkg/ui/v1alpha3/hp.go
+++ b/pkg/ui/v1alpha3/hp.go
@@ -153,13 +153,26 @@ func (k *KatibUIHandler) FetchHPJobInfo(w http.ResponseWriter, r *http.Request) 
 	w.Write(response)
 }
 
+// FetchHPJobTrialInfo returns all metrics for the HP Job Trial
 func (k *KatibUIHandler) FetchHPJobTrialInfo(w http.ResponseWriter, r *http.Request) {
 	//enableCors(&w)
 	trialName := r.URL.Query()["trialName"][0]
+	namespace := r.URL.Query()["namespace"][0]
 	conn, c := k.connectManager()
 	defer conn.Close()
 
-	resultText := "metricName,time,value\n"
+	trial, err := k.katibClient.GetTrial(trialName, namespace)
+
+	if err != nil {
+		log.Printf("GetTrial from HP job failed: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+
+	objectiveType := trial.Spec.Objective.Type
+
+	//resultArray - array of arrays, where [i][0] - metricName, [i][1] - metricTime, [i][2] - metriValue
+	var resultArray [][]string
+	resultArray = append(resultArray, strings.Split("metricName,time,value", ","))
 	obsLogResp, err := c.GetObservationLog(
 		context.Background(),
 		&api_pb_v1alpha3.GetObservationLogRequest{
@@ -173,17 +186,40 @@ func (k *KatibUIHandler) FetchHPJobTrialInfo(w http.ResponseWriter, r *http.Requ
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	prevMetricTime := map[string]string{}
+
+	// prevMetricTimeValue is the dict, where key = metric name,
+	// value = array, where [0] - Last metric time, [1] - Best metric value for this time
+	prevMetricTimeValue := make(map[string][]string)
 	for _, m := range obsLogResp.ObservationLog.MetricLogs {
-		parsedTime, _ := time.Parse(time.RFC3339Nano, m.TimeStamp)
-		formatTime := parsedTime.Format("2006-01-02T15:04:05")
-		if _, found := prevMetricTime[m.Metric.Name]; !found {
-			prevMetricTime[m.Metric.Name] = ""
+		parsedCurrentTime, _ := time.Parse(time.RFC3339Nano, m.TimeStamp)
+		formatCurrentTime := parsedCurrentTime.Format("2006-01-02T15:04:05")
+		if _, found := prevMetricTimeValue[m.Metric.Name]; !found {
+			prevMetricTimeValue[m.Metric.Name] = []string{"", ""}
+
 		}
-		if formatTime != prevMetricTime[m.Metric.Name] {
-			resultText += m.Metric.Name + "," + formatTime + "," + m.Metric.Value + "\n"
-			prevMetricTime[m.Metric.Name] = formatTime
+		if formatCurrentTime == prevMetricTimeValue[m.Metric.Name][0] &&
+			((objectiveType == commonv1alpha3.ObjectiveTypeMinimize &&
+				m.Metric.Value < prevMetricTimeValue[m.Metric.Name][1]) ||
+				(objectiveType == commonv1alpha3.ObjectiveTypeMaximize &&
+					m.Metric.Value > prevMetricTimeValue[m.Metric.Name][1])) {
+
+			prevMetricTimeValue[m.Metric.Name][1] = m.Metric.Value
+			for i := len(resultArray) - 1; i >= 0; i-- {
+				if resultArray[i][0] == m.Metric.Name {
+					resultArray[i][2] = m.Metric.Value
+					break
+				}
+			}
+		} else if formatCurrentTime != prevMetricTimeValue[m.Metric.Name][0] {
+			resultArray = append(resultArray, []string{m.Metric.Name, formatCurrentTime, m.Metric.Value})
+			prevMetricTimeValue[m.Metric.Name][0] = formatCurrentTime
+			prevMetricTimeValue[m.Metric.Name][1] = m.Metric.Value
 		}
+	}
+
+	var resultText string
+	for _, metric := range resultArray {
+		resultText += strings.Join(metric, ",") + "\n"
 	}
 
 	response, err := json.Marshal(resultText)

--- a/pkg/util/v1alpha3/katibclient/katib_client.go
+++ b/pkg/util/v1alpha3/katibclient/katib_client.go
@@ -40,6 +40,7 @@ type Client interface {
 	DeleteExperiment(experiment *experimentsv1alpha3.Experiment, namespace ...string) error
 	GetExperiment(name string, namespace ...string) (*experimentsv1alpha3.Experiment, error)
 	GetConfigMap(name string, namespace ...string) (map[string]string, error)
+	GetTrial(name string, namespace ...string) (*trialsv1alpha3.Trial, error)
 	GetTrialList(name string, namespace ...string) (*trialsv1alpha3.TrialList, error)
 	GetTrialTemplates(namespace ...string) (map[string]string, error)
 	GetSuggestion(name string, namespace ...string) (*suggestionsv1alpha3.Suggestion, error)
@@ -103,6 +104,18 @@ func (k *KatibClient) GetSuggestion(name string, namespace ...string) (
 		return nil, err
 	}
 	return suggestion, nil
+
+}
+
+// GetTrial returns the Trial for the given name and namespace
+func (k *KatibClient) GetTrial(name string, namespace ...string) (*trialsv1alpha3.Trial, error) {
+	ns := getNamespace(namespace...)
+	trial := &trialsv1alpha3.Trial{}
+
+	if err := k.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: ns}, trial); err != nil {
+		return nil, err
+	}
+	return trial, nil
 
 }
 


### PR DESCRIPTION
If metrics have the same time, we should show metrics with best objective value in the Trial metrics information plot, instead of latest.
This PR fixes this problem.
Also, I added Trial name to the metrics plot.

/assign @johnugeorge

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/1068)
<!-- Reviewable:end -->
