### PR TITLE
Enable to add Service Account Name in Katib config

### DIFF
--- a/pkg/controller.v1alpha3/consts/const.go
+++ b/pkg/controller.v1alpha3/consts/const.go
@@ -73,6 +73,8 @@ const (
 	DefaultDiskRequest = "500Mi"
 	// LabelSuggestionImagePullPolicy is the name of suggestion image pull policy in configmap.
 	LabelSuggestionImagePullPolicy = "imagePullPolicy"
+	// LabelSuggestionServiceAccountName is the name of suggestion service account in configmap.
+	LabelSuggestionServiceAccountName = "serviceAccountName"
 	// DefaultImagePullPolicy is the default value for image pull policy.
 	DefaultImagePullPolicy = "IfNotPresent"
 	// LabelMetricsCollectorSidecar is the name of metrics collector config in configmap.

--- a/pkg/util/v1alpha3/katibconfig/config.go
+++ b/pkg/util/v1alpha3/katibconfig/config.go
@@ -15,9 +15,10 @@ import (
 )
 
 type suggestionConfigJSON struct {
-	Image           string                      `json:"image"`
-	ImagePullPolicy corev1.PullPolicy           `json:"imagePullPolicy"`
-	Resource        corev1.ResourceRequirements `json:"resources"`
+	Image              string                      `json:"image"`
+	ImagePullPolicy    corev1.PullPolicy           `json:"imagePullPolicy"`
+	Resource           corev1.ResourceRequirements `json:"resources"`
+	ServiceAccountName string                      `json: "serviceAccountName"`
 }
 
 type metricsCollectorConfigJSON struct {
@@ -58,6 +59,12 @@ func GetSuggestionConfigData(algorithmName string, client client.Client) (map[st
 				suggestionConfigData[consts.LabelSuggestionImagePullPolicy] = string(imagePullPolicy)
 			} else {
 				suggestionConfigData[consts.LabelSuggestionImagePullPolicy] = consts.DefaultImagePullPolicy
+			}
+
+			// Get Service Account Name
+			serviceAccountName := suggestionConfig.ServiceAccountName
+			if strings.TrimSpace(serviceAccountName) != "" {
+				suggestionConfigData[consts.LabelSuggestionServiceAccountName] = serviceAccountName
 			}
 
 			// Set default values for CPU, Memory and Disk

--- a/pkg/util/v1alpha3/katibconfig/config.go
+++ b/pkg/util/v1alpha3/katibconfig/config.go
@@ -18,7 +18,7 @@ type suggestionConfigJSON struct {
 	Image              string                      `json:"image"`
 	ImagePullPolicy    corev1.PullPolicy           `json:"imagePullPolicy"`
 	Resource           corev1.ResourceRequirements `json:"resources"`
-	ServiceAccountName string                      `json: "serviceAccountName"`
+	ServiceAccountName string                      `json:"serviceAccountName"`
 }
 
 type metricsCollectorConfigJSON struct {


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1079.

I added functionality to add Service Account Name using Katib config.

We can add Validation part, for example here: https://github.com/kubeflow/katib/blob/master/pkg/webhook/v1alpha3/experiment/validation_webhook.go#L88, to Validate Katib config.

For example, users can't submit Experiment with Service Account, if they don't have appropriate Service Account in Experiment Namespace. I don't know if it useful or not for us.

What do you think @gaocegege @johnugeorge @hougangliu ?

/cc @nrchakradhar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/katib/1092)
<!-- Reviewable:end -->
