### PR TITLE
Add ghalton package to Chocolate Suggestion

### DIFF
--- a/cmd/suggestion/chocolate/v1alpha3/requirements.txt
+++ b/cmd/suggestion/chocolate/v1alpha3/requirements.txt
@@ -9,3 +9,4 @@ protobuf==3.9.1
 googleapis-common-protos==1.6.0
 SQLAlchemy==1.3.8
 git+https://github.com/AIworx-Labs/chocolate@master
+ghalton>=0.6


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1093.

For some reason, `git+https://github.com/AIworx-Labs/chocolate@master` command doesn't add `ghalton` package.

I tested quasirandom with this search space: https://github.com/kubeflow/katib/blob/master/examples/v1alpha3/grid-example.yaml. Experiment was succeeded.

/assign @gaocegege 
/cc @terrykong