### PR TITLE
Fix custom Katib DB Manager env variables

### DIFF
--- a/pkg/common/v1alpha3/katib_manager_util.go
+++ b/pkg/common/v1alpha3/katib_manager_util.go
@@ -31,12 +31,15 @@ type katibDBManagerClientAndConn struct {
 
 // GetDBManagerAddr returns address of Katib DB Manager
 func GetDBManagerAddr() string {
+	dbManagerNS := consts.DefaultKatibDBManagerServiceNamespace
+	dbManagerIP := consts.DefaultKatibDBManagerServiceIP
+	dbManagerPort := consts.DefaultKatibDBManagerServicePort
 
-	if len(consts.DefaultKatibDBManagerNamespace) != 0 {
-		return consts.DefaultKatibDBManagerIP + "." + consts.DefaultKatibDBManagerNamespace + ":" + consts.DefaultKatibDBManagerPort
+	if len(dbManagerNS) != 0 {
+		return dbManagerIP + "." + dbManagerNS + ":" + dbManagerPort
 	}
 
-	return consts.DefaultKatibDBManagerIP + ":" + consts.DefaultKatibDBManagerPort
+	return dbManagerIP + ":" + dbManagerPort
 }
 
 func getKatibDBManagerClientAndConn() (*katibDBManagerClientAndConn, error) {

--- a/pkg/common/v1alpha3/katib_manager_util.go
+++ b/pkg/common/v1alpha3/katib_manager_util.go
@@ -17,7 +17,6 @@ package v1alpha3
 
 import (
 	"context"
-	"os"
 
 	"google.golang.org/grpc"
 
@@ -25,32 +24,19 @@ import (
 	"github.com/kubeflow/katib/pkg/controller.v1alpha3/consts"
 )
 
-const (
-	KatibDBManagerServiceIPEnvName   = "KATIB_DB_MANAGER_PORT_6789_TCP_ADDR"
-	KatibDBManagerServicePortEnvName = "KATIB_DB_MANAGER_PORT_6789_TCP_PORT"
-	KatibDBManagerService            = "katib-db-manager"
-	KatibDBManagerPort               = "6789"
-	KatibDBManagerAddr               = KatibDBManagerService + ":" + KatibDBManagerPort
-)
-
 type katibDBManagerClientAndConn struct {
 	Conn                 *grpc.ClientConn
 	KatibDBManagerClient api_pb.ManagerClient
 }
 
+// GetDBManagerAddr returns address of Katib DB Manager
 func GetDBManagerAddr() string {
-	ns := consts.DefaultKatibNamespace
-	if len(ns) == 0 {
-		addr := os.Getenv(KatibDBManagerServiceIPEnvName)
-		port := os.Getenv(KatibDBManagerServicePortEnvName)
-		if len(addr) > 0 && len(port) > 0 {
-			return addr + ":" + port
-		} else {
-			return KatibDBManagerAddr
-		}
-	} else {
-		return KatibDBManagerService + "." + ns + ":" + KatibDBManagerPort
+
+	if len(consts.DefaultKatibDBManagerNamespace) != 0 {
+		return consts.DefaultKatibDBManagerIP + "." + consts.DefaultKatibDBManagerNamespace + ":" + consts.DefaultKatibDBManagerPort
 	}
+
+	return consts.DefaultKatibDBManagerIP + ":" + consts.DefaultKatibDBManagerPort
 }
 
 func getKatibDBManagerClientAndConn() (*katibDBManagerClientAndConn, error) {

--- a/pkg/controller.v1alpha3/consts/const.go
+++ b/pkg/controller.v1alpha3/consts/const.go
@@ -40,12 +40,12 @@ const (
 	// DefaultKatibComposerEnvName is the default env name of katib suggestion composer
 	DefaultKatibComposerEnvName = "KATIB_SUGGESTION_COMPOSER"
 
-	// DefaultKatibDBManagerNamespaceEnvName is the env name of Katib DB Manager namespace
-	DefaultKatibDBManagerNamespaceEnvName = "KATIB_DB_MANAGER_NAMESPACE"
-	// DefaultKatibDBManagerIPEnvName is the env name of Katib DB Manager IP
-	DefaultKatibDBManagerIPEnvName = "KATIB_DB_MANAGER_IP"
-	// DefaultKatibDBManagerPortEnvName is the env name of Katib DB Manager Port
-	DefaultKatibDBManagerPortEnvName = "KATIB_DB_MANAGER_PORT"
+	// DefaultKatibDBManagerServiceNamespaceEnvName is the env name of Katib DB Manager namespace
+	DefaultKatibDBManagerServiceNamespaceEnvName = "KATIB_DB_MANAGER_SERVICE_NAMESPACE"
+	// DefaultKatibDBManagerServiceIPEnvName is the env name of Katib DB Manager IP
+	DefaultKatibDBManagerServiceIPEnvName = "KATIB_DB_MANAGER_SERVICE_IP"
+	// DefaultKatibDBManagerServicePortEnvName is the env name of Katib DB Manager Port
+	DefaultKatibDBManagerServicePortEnvName = "KATIB_DB_MANAGER_SERVICE_PORT"
 
 	// KatibConfigMapName is the config map constants
 	// Configmap name which includes Katib's configuration
@@ -136,10 +136,10 @@ var (
 	// DefaultComposer is the default composer of katib suggestion.
 	DefaultComposer = env.GetEnvOrDefault(DefaultKatibComposerEnvName, "General")
 
-	// DefaultKatibDBManagerNamespace is the default namespace of Katib DB Manager
-	DefaultKatibDBManagerNamespace = env.GetEnvOrDefault(DefaultKatibDBManagerNamespaceEnvName, DefaultKatibNamespace)
-	// DefaultKatibDBManagerIP is the default IP of Katib DB Manager
-	DefaultKatibDBManagerIP = env.GetEnvOrDefault(DefaultKatibDBManagerIPEnvName, "katib-db-manager")
-	// DefaultKatibDBManagerPort is the default Port of Katib DB Manager
-	DefaultKatibDBManagerPort = env.GetEnvOrDefault(DefaultKatibDBManagerPortEnvName, "6789")
+	// DefaultKatibDBManagerServiceNamespace is the default namespace of Katib DB Manager
+	DefaultKatibDBManagerServiceNamespace = env.GetEnvOrDefault(DefaultKatibDBManagerServiceNamespaceEnvName, DefaultKatibNamespace)
+	// DefaultKatibDBManagerServiceIP is the default IP of Katib DB Manager
+	DefaultKatibDBManagerServiceIP = env.GetEnvOrDefault(DefaultKatibDBManagerServiceIPEnvName, "katib-db-manager")
+	// DefaultKatibDBManagerServicePort is the default Port of Katib DB Manager
+	DefaultKatibDBManagerServicePort = env.GetEnvOrDefault(DefaultKatibDBManagerServicePortEnvName, "6789")
 )

--- a/pkg/controller.v1alpha3/consts/const.go
+++ b/pkg/controller.v1alpha3/consts/const.go
@@ -40,6 +40,13 @@ const (
 	// DefaultKatibComposerEnvName is the default env name of katib suggestion composer
 	DefaultKatibComposerEnvName = "KATIB_SUGGESTION_COMPOSER"
 
+	// DefaultKatibDBManagerNamespaceEnvName is the env name of Katib DB Manager namespace
+	DefaultKatibDBManagerNamespaceEnvName = "KATIB_DB_MANAGER_NAMESPACE"
+	// DefaultKatibDBManagerIPEnvName is the env name of Katib DB Manager IP
+	DefaultKatibDBManagerIPEnvName = "KATIB_DB_MANAGER_IP"
+	// DefaultKatibDBManagerPortEnvName is the env name of Katib DB Manager Port
+	DefaultKatibDBManagerPortEnvName = "KATIB_DB_MANAGER_PORT"
+
 	// KatibConfigMapName is the config map constants
 	// Configmap name which includes Katib's configuration
 	KatibConfigMapName = "katib-config"
@@ -115,7 +122,9 @@ const (
 	// AnnotationIstioSidecarInjectValue is the value of Istio Sidecar annotation
 	AnnotationIstioSidecarInjectValue = "false"
 
-	LabelTrialTemplateConfigMapName  = "app"
+	// LabelTrialTemplateConfigMapName is the label name for the Trial templates configMap
+	LabelTrialTemplateConfigMapName = "app"
+	// LabelTrialTemplateConfigMapValue is the label value for the Trial templates configMap
 	LabelTrialTemplateConfigMapValue = "katib-trial-templates"
 )
 
@@ -124,4 +133,11 @@ var (
 	DefaultKatibNamespace = env.GetEnvOrDefault(DefaultKatibNamespaceEnvName, "kubeflow")
 	// DefaultComposer is the default composer of katib suggestion.
 	DefaultComposer = env.GetEnvOrDefault(DefaultKatibComposerEnvName, "General")
+
+	// DefaultKatibDBManagerNamespace is the default namespace of Katib DB Manager
+	DefaultKatibDBManagerNamespace = env.GetEnvOrDefault(DefaultKatibDBManagerNamespaceEnvName, DefaultKatibNamespace)
+	// DefaultKatibDBManagerIP is the default IP of Katib DB Manager
+	DefaultKatibDBManagerIP = env.GetEnvOrDefault(DefaultKatibDBManagerIPEnvName, "katib-db-manager")
+	// DefaultKatibDBManagerPort is the default Port of Katib DB Manager
+	DefaultKatibDBManagerPort = env.GetEnvOrDefault(DefaultKatibDBManagerPortEnvName, "6789")
 )

--- a/pkg/ui/v1alpha3/backend.go
+++ b/pkg/ui/v1alpha3/backend.go
@@ -28,7 +28,7 @@ func NewKatibUIHandler() *KatibUIHandler {
 }
 
 func (k *KatibUIHandler) connectManager() (*grpc.ClientConn, api_pb_v1alpha3.ManagerClient) {
-	conn, err := grpc.Dial(common_v1alpha3.KatibDBManagerAddr, grpc.WithInsecure())
+	conn, err := grpc.Dial(common_v1alpha3.GetDBManagerAddr(), grpc.WithInsecure())
 	if err != nil {
 		log.Printf("Dial to GRPC failed: %v", err)
 		return nil, nil


### PR DESCRIPTION
Fixes this comment: https://github.com/kubeflow/katib/issues/981#issuecomment-600170773.

If users want to use their own DB Manager, they must specify these env variables in **Katib controller** and **Katib UI** manifests:

```
KATIB_DB_MANAGER_SERVICE_NAMESPACE = <db manager namespace>
KATIB_DB_MANAGER_SERVICE_IP = <db manager ip (service name)>
KATIB_DB_MANAGER_SERVICE_PORT = <db manager port>
```

Also, if user specifies `KATIB_DB_MANAGER_SERVICE_NAMESPACE=''`, we will use `KATIB_DB_MANAGER_SERVICE_IP:KATIB_DB_MANAGER_SERVICE_PORT` for DB manager address .

This might be useful, if user needs to send metrics to DataBase which is not deployed in Kubernetes.

I tried to deploy `katib-db-manager` in the different namespace than `katib-controller`. After set correct env, metrics got collected.

In the next PR I will create doc about all env variables that can be specifying in the manifest.

What do you think @johnugeorge @gaocegege @hougangliu ?

/cc @kunalyogenshah