### PR TITLE
Fix logger namespace

### DIFF
--- a/pkg/suggestion/v1alpha3/chocolate/base_chocolate_service.py
+++ b/pkg/suggestion/v1alpha3/chocolate/base_chocolate_service.py
@@ -7,7 +7,7 @@ import base64
 from pkg.suggestion.v1alpha3.internal.search_space import *
 from pkg.suggestion.v1alpha3.internal.trial import *
 
-logger = logging.getLogger("BaseChocolateService")
+logger = logging.getLogger(__name__)
 
 
 class BaseChocolateService(object):

--- a/pkg/suggestion/v1alpha3/chocolate_service.py
+++ b/pkg/suggestion/v1alpha3/chocolate_service.py
@@ -10,7 +10,7 @@ from pkg.suggestion.v1alpha3.internal.trial import Trial, Assignment
 from pkg.suggestion.v1alpha3.chocolate.base_chocolate_service import BaseChocolateService
 from pkg.suggestion.v1alpha3.base_health_service import HealthServicer
 
-logger = logging.getLogger("ChocolateService")
+logger = logging.getLogger(__name__)
 
 
 class ChocolateService(

--- a/pkg/suggestion/v1alpha3/hyperopt/base_hyperopt_service.py
+++ b/pkg/suggestion/v1alpha3/hyperopt/base_hyperopt_service.py
@@ -5,7 +5,7 @@ import logging
 from pkg.suggestion.v1alpha3.internal.search_space import *
 from pkg.suggestion.v1alpha3.internal.trial import *
 
-logger = logging.getLogger("BaseHyperoptService")
+logger = logging.getLogger(__name__)
 
 TPE_ALGORITHM_NAME = "tpe"
 RANDOM_ALGORITHM_NAME = "random"

--- a/pkg/suggestion/v1alpha3/hyperopt_service.py
+++ b/pkg/suggestion/v1alpha3/hyperopt_service.py
@@ -8,7 +8,7 @@ from pkg.suggestion.v1alpha3.internal.trial import Trial, Assignment
 from pkg.suggestion.v1alpha3.hyperopt.base_hyperopt_service import BaseHyperoptService
 from pkg.suggestion.v1alpha3.base_health_service import HealthServicer
 
-logger = logging.getLogger("HyperoptRandomService")
+logger = logging.getLogger(__name__)
 
 
 class HyperoptService(api_pb2_grpc.SuggestionServicer, HealthServicer):

--- a/pkg/suggestion/v1alpha3/internal/search_space.py
+++ b/pkg/suggestion/v1alpha3/internal/search_space.py
@@ -10,7 +10,7 @@ CATEGORICAL = "CATEGORICAL"
 DISCRETE = "DISCRETE"
 
 logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger("HyperParameterSearchSpace")
+logger = logging.getLogger(__name__)
 
 
 class HyperParameterSearchSpace(object):

--- a/pkg/suggestion/v1alpha3/internal/trial.py
+++ b/pkg/suggestion/v1alpha3/internal/trial.py
@@ -3,7 +3,7 @@ from pkg.apis.manager.v1alpha3.python import api_pb2 as api
 
 
 logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger("Trial")
+logger = logging.getLogger(__name__)
 
 
 class Trial(object):

--- a/pkg/suggestion/v1alpha3/skopt/base_skopt_service.py
+++ b/pkg/suggestion/v1alpha3/skopt/base_skopt_service.py
@@ -7,7 +7,7 @@ from pkg.suggestion.v1alpha3.internal.search_space import *
 from pkg.suggestion.v1alpha3.internal.trial import *
 import datetime
 
-logger = logging.getLogger("BaseSkoptService")
+logger = logging.getLogger(__name__)
 
 
 class BaseSkoptService(object):

--- a/pkg/suggestion/v1alpha3/skopt_service.py
+++ b/pkg/suggestion/v1alpha3/skopt_service.py
@@ -8,7 +8,7 @@ from pkg.suggestion.v1alpha3.skopt.base_skopt_service import BaseSkoptService
 from pkg.suggestion.v1alpha3.base_health_service import HealthServicer
 
 
-logger = logging.getLogger("SkoptService")
+logger = logging.getLogger(__name__)
 
 
 class SkoptService(api_pb2_grpc.SuggestionServicer, HealthServicer):


### PR DESCRIPTION
**What this PR does / why we need it**:

See the following quotes from the Python official documentation.

> The name is potentially a period-separated hierarchical value, like foo.bar.baz (though it could also be just plain foo, for example). Loggers that are further down in the hierarchical list are children of loggers higher up in the list. For example, given a logger with a name of foo, loggers with names of foo.bar, foo.bar.baz, and foo.bam are all descendants of foo. The logger name hierarchy is analogous to the Python package hierarchy, and identical to it if you organise your loggers on a per-module basis using the recommended construction logging.getLogger(__name__).

https://docs.python.org/3/library/logging.html


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:

None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
