### PR TITLE
Fix Katib e2e tests

### DIFF
--- a/test/scripts/v1alpha3/run-custom-metricscollector.sh
+++ b/test/scripts/v1alpha3/run-custom-metricscollector.sh
@@ -24,8 +24,6 @@ set -o pipefail
 CLUSTER_NAME="${CLUSTER_NAME}"
 ZONE="${GCP_ZONE}"
 PROJECT="${GCP_PROJECT}"
-NAMESPACE="${DEPLOY_NAMESPACE}"
-REGISTRY="${GCP_REGISTRY}"
 GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
 
 echo "Activating service-account"
@@ -57,8 +55,7 @@ cd ${GO_DIR}/test/e2e/v1alpha3
 echo "Running e2e custom metricscollector experiment"
 export KUBECONFIG=$HOME/.kube/config
 ./run-e2e-experiment ../../../examples/v1alpha3/custom-metricscollector-example.yaml
-kubectl -n kubeflow describe suggestion
+kubectl -n kubeflow describe experiment custom-metricscollector-example
 kubectl delete -f ../../../examples/v1alpha3/custom-metricscollector-example.yaml
-kubectl describe pods
-kubectl describe deploy
+
 exit 0

--- a/test/scripts/v1alpha3/run-file-metricscollector.sh
+++ b/test/scripts/v1alpha3/run-file-metricscollector.sh
@@ -24,8 +24,6 @@ set -o pipefail
 CLUSTER_NAME="${CLUSTER_NAME}"
 ZONE="${GCP_ZONE}"
 PROJECT="${GCP_PROJECT}"
-NAMESPACE="${DEPLOY_NAMESPACE}"
-REGISTRY="${GCP_REGISTRY}"
 GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
 
 echo "Activating service-account"
@@ -57,8 +55,7 @@ cd ${GO_DIR}/test/e2e/v1alpha3
 echo "Running e2e file metricscollector experiment"
 export KUBECONFIG=$HOME/.kube/config
 ./run-e2e-experiment ../../../examples/v1alpha3/file-metricscollector-example.yaml
-kubectl -n kubeflow describe suggestion
+kubectl -n kubeflow describe experiment file-metricscollector-example
 kubectl delete -f ../../../examples/v1alpha3/file-metricscollector-example.yaml
-kubectl describe pods
-kubectl describe deploy
+
 exit 0

--- a/test/scripts/v1alpha3/run-pytorchjob.sh
+++ b/test/scripts/v1alpha3/run-pytorchjob.sh
@@ -24,8 +24,6 @@ set -o pipefail
 CLUSTER_NAME="${CLUSTER_NAME}"
 ZONE="${GCP_ZONE}"
 PROJECT="${GCP_PROJECT}"
-NAMESPACE="${DEPLOY_NAMESPACE}"
-REGISTRY="${GCP_REGISTRY}"
 GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
 
 echo "Activating service-account"
@@ -57,8 +55,7 @@ cd ${GO_DIR}/test/e2e/v1alpha3
 echo "Running e2e pytorchjob random experiment"
 export KUBECONFIG=$HOME/.kube/config
 ./run-e2e-experiment ../../../examples/v1alpha3/pytorchjob-example.yaml
-kubectl -n kubeflow describe suggestion
+kubectl -n kubeflow describe experiment pytorchjob-example
 kubectl -n kubeflow delete experiment pytorchjob-example
-kubectl describe pods
-kubectl describe deploy
+
 exit 0

--- a/test/scripts/v1alpha3/run-suggestion-bayesian.sh
+++ b/test/scripts/v1alpha3/run-suggestion-bayesian.sh
@@ -24,8 +24,6 @@ set -o pipefail
 CLUSTER_NAME="${CLUSTER_NAME}"
 ZONE="${GCP_ZONE}"
 PROJECT="${GCP_PROJECT}"
-NAMESPACE="${DEPLOY_NAMESPACE}"
-REGISTRY="${GCP_REGISTRY}"
 GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
 
 echo "Activating service-account"
@@ -57,9 +55,7 @@ cd ${GO_DIR}/test/e2e/v1alpha3
 echo "Running e2e skopt bayesian optimization experiment"
 export KUBECONFIG=$HOME/.kube/config
 ./run-e2e-experiment ../../../examples/v1alpha3/bayesianoptimization-example.yaml
-kubectl -n kubeflow describe suggestion
-kubectl -n kubeflow describe pods
+kubectl -n kubeflow describe experiment bayesianoptimization-example
 kubectl -n kubeflow delete experiment bayesianoptimization-example
-kubectl describe pods
-kubectl describe deploy
+
 exit 0

--- a/test/scripts/v1alpha3/run-suggestion-grid.sh
+++ b/test/scripts/v1alpha3/run-suggestion-grid.sh
@@ -24,8 +24,6 @@ set -o pipefail
 CLUSTER_NAME="${CLUSTER_NAME}"
 ZONE="${GCP_ZONE}"
 PROJECT="${GCP_PROJECT}"
-NAMESPACE="${DEPLOY_NAMESPACE}"
-REGISTRY="${GCP_REGISTRY}"
 GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
 
 echo "Activating service-account"
@@ -57,8 +55,7 @@ cd ${GO_DIR}/test/e2e/v1alpha3
 echo "Running e2e chocolate grid experiment"
 export KUBECONFIG=$HOME/.kube/config
 ./run-e2e-experiment ../../../examples/v1alpha3/grid-example.yaml
-kubectl -n kubeflow describe suggestion
+kubectl -n kubeflow describe experiment grid-example
 kubectl -n kubeflow delete experiment grid-example
-kubectl describe pods
-kubectl describe deploy
+
 exit 0

--- a/test/scripts/v1alpha3/run-suggestion-hyperband.sh
+++ b/test/scripts/v1alpha3/run-suggestion-hyperband.sh
@@ -24,7 +24,6 @@ set -o pipefail
 CLUSTER_NAME="${CLUSTER_NAME}"
 ZONE="${GCP_ZONE}"
 PROJECT="${GCP_PROJECT}"
-NAMESPACE="${DEPLOY_NAMESPACE}"
 GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
 
 echo "Activating service-account"
@@ -51,16 +50,12 @@ kubectl -n kubeflow get svc
 echo "Katib pods"
 kubectl -n kubeflow get pod
 
-mkdir -p ${GO_DIR}
-cp -r . ${GO_DIR}/
-cp -r pkg/apis/manager/v1alpha3/python/* ${GO_DIR}/test/e2e/v1alpha3
 cd ${GO_DIR}/test/e2e/v1alpha3
 
 echo "Running e2e hyperband experiment"
 export KUBECONFIG=$HOME/.kube/config
 ./run-e2e-experiment ../../../examples/v1alpha3/hyperband-example.yaml
-kubectl -n kubeflow describe suggestion
+kubectl -n kubeflow describe experiment hyperband-example
 kubectl -n kubeflow delete experiment hyperband-example
-kubectl describe pods
-kubectl describe deploy
+
 exit 0

--- a/test/scripts/v1alpha3/run-suggestion-nasrl.sh
+++ b/test/scripts/v1alpha3/run-suggestion-nasrl.sh
@@ -24,8 +24,6 @@ set -o pipefail
 CLUSTER_NAME="${CLUSTER_NAME}"
 ZONE="${GCP_ZONE}"
 PROJECT="${GCP_PROJECT}"
-NAMESPACE="${DEPLOY_NAMESPACE}"
-REGISTRY="${GCP_REGISTRY}"
 GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
 
 echo "Activating service-account"
@@ -52,14 +50,12 @@ kubectl -n kubeflow get svc
 echo "Katib pods"
 kubectl -n kubeflow get pod
 
-mkdir -p ${GO_DIR}
-cp -r . ${GO_DIR}/
-cp -r pkg/apis/manager/v1alpha3/python/* ${GO_DIR}/test/e2e/v1alpha3
 cd ${GO_DIR}/test/e2e/v1alpha3
 
 echo "Running e2e NASRL experiment"
 export KUBECONFIG=$HOME/.kube/config
 ./run-e2e-experiment ../../../examples/v1alpha3/nasjob-example-RL-cpu.yaml
-kubectl -n kubeflow describe suggestion
+kubectl -n kubeflow describe experiment nas-rl-example-cpu
 kubectl -n kubeflow delete experiment nas-rl-example-cpu
+
 exit 0

--- a/test/scripts/v1alpha3/run-suggestion-random.sh
+++ b/test/scripts/v1alpha3/run-suggestion-random.sh
@@ -24,8 +24,6 @@ set -o pipefail
 CLUSTER_NAME="${CLUSTER_NAME}"
 ZONE="${GCP_ZONE}"
 PROJECT="${GCP_PROJECT}"
-NAMESPACE="${DEPLOY_NAMESPACE}"
-REGISTRY="${GCP_REGISTRY}"
 GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
 
 echo "Activating service-account"
@@ -57,10 +55,10 @@ cd ${GO_DIR}/test/e2e/v1alpha3
 echo "Running e2e hyperopt random experiment"
 export KUBECONFIG=$HOME/.kube/config
 ./run-e2e-experiment ../../../examples/v1alpha3/random-example.yaml
+kubectl -n kubeflow describe experiment random-example
 echo "Resuming the completed random experiment"
 ./resume-e2e-experiment ../../../examples/v1alpha3/random-example.yaml
-kubectl -n kubeflow describe suggestion
+kubectl -n kubeflow describe experiment random-example
 kubectl -n kubeflow delete experiment random-example
-kubectl describe pods
-kubectl describe deploy
+
 exit 0

--- a/test/scripts/v1alpha3/run-suggestion-tpe.sh
+++ b/test/scripts/v1alpha3/run-suggestion-tpe.sh
@@ -24,8 +24,6 @@ set -o pipefail
 CLUSTER_NAME="${CLUSTER_NAME}"
 ZONE="${GCP_ZONE}"
 PROJECT="${GCP_PROJECT}"
-NAMESPACE="${DEPLOY_NAMESPACE}"
-REGISTRY="${GCP_REGISTRY}"
 GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
 
 echo "Activating service-account"
@@ -57,8 +55,7 @@ cd ${GO_DIR}/test/e2e/v1alpha3
 echo "Running e2e hyperopt tpe experiment"
 export KUBECONFIG=$HOME/.kube/config
 ./run-e2e-experiment ../../../examples/v1alpha3/tpe-example.yaml
-kubectl -n kubeflow describe suggestion
+kubectl -n kubeflow describe experiment tpe-example
 kubectl -n kubeflow delete experiment tpe-example
-kubectl describe pods
-kubectl describe deploy
+
 exit 0

--- a/test/scripts/v1alpha3/run-tfjob.sh
+++ b/test/scripts/v1alpha3/run-tfjob.sh
@@ -24,8 +24,6 @@ set -o pipefail
 CLUSTER_NAME="${CLUSTER_NAME}"
 ZONE="${GCP_ZONE}"
 PROJECT="${GCP_PROJECT}"
-NAMESPACE="${DEPLOY_NAMESPACE}"
-REGISTRY="${GCP_REGISTRY}"
 GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
 
 echo "Activating service-account"
@@ -57,8 +55,7 @@ cd ${GO_DIR}/test/e2e/v1alpha3
 echo "Running e2e tfjob random experiment"
 export KUBECONFIG=$HOME/.kube/config
 ./run-e2e-experiment ../../../examples/v1alpha3/tfjob-example.yaml
-kubectl -n kubeflow describe suggestion
+kubectl -n kubeflow describe experiment tfjob-example
 kubectl -n kubeflow delete experiment tfjob-example
-kubectl describe pods
-kubectl describe deploy
+
 exit 0


### PR DESCRIPTION
I made few changes in e2e test. I hope it will fix running problems.

1. Deleted part of creating ${GO_DIR}. According to this PR: https://github.com/kubeflow/katib/pull/802, we deleted from some e2e test this part. I think it should fix problem with `cp: cannot create symbolic link` error.
2. Deleted `NAMESPACE` and `REGISTRY` env variable, since it is not needed.
3. Deleted part of describing pods and deploy in default namespace and other describe in some e2e test.
4. I left only `describe` appropriate Experiment in each e2e test. I think it is more informative.

/assign @johnugeorge @gaocegege 