### PR TITLE
Support step for int parameter in Chocolate and Hyperopt Suggestion

### DIFF
--- a/pkg/suggestion/v1alpha3/chocolate/base_chocolate_service.py
+++ b/pkg/suggestion/v1alpha3/chocolate/base_chocolate_service.py
@@ -30,7 +30,7 @@ class BaseChocolateService(object):
             key = BaseChocolateService.encode(param.name)
             if param.type == INTEGER:
                 chocolate_search_space[key] = choco.quantized_uniform(
-                    int(param.min), int(param.max), 1)
+                    int(param.min), int(param.max), int(param.step))
             elif param.type == DOUBLE:
                 chocolate_search_space[key] = choco.quantized_uniform(
                     float(param.min), float(param.max), float(param.step))

--- a/pkg/suggestion/v1alpha3/hyperopt/base_hyperopt_service.py
+++ b/pkg/suggestion/v1alpha3/hyperopt/base_hyperopt_service.py
@@ -39,7 +39,8 @@ class BaseHyperoptService(object):
                 hyperopt_search_space[param.name] = hyperopt.hp.quniform(
                     param.name,
                     float(param.min),
-                    float(param.max), 1)
+                    float(param.max),
+                    float(param.step))
             elif param.type == DOUBLE:
                 hyperopt_search_space[param.name] = hyperopt.hp.uniform(
                     param.name,

--- a/pkg/suggestion/v1alpha3/internal/search_space.py
+++ b/pkg/suggestion/v1alpha3/internal/search_space.py
@@ -37,7 +37,11 @@ class HyperParameterSearchSpace(object):
     @staticmethod
     def convertParameter(p):
         if p.parameter_type == api.INT:
-            return HyperParameter.int(p.name, p.feasible_space.min, p.feasible_space.max)
+            # Default value for INT parameter step is 1
+            step = 1
+            if p.feasible_space.step != None and p.feasible_space.step != "":
+                step = p.feasible_space.step
+            return HyperParameter.int(p.name, p.feasible_space.min, p.feasible_space.max, step)
         elif p.parameter_type == api.DOUBLE:
             return HyperParameter.double(p.name, p.feasible_space.min, p.feasible_space.max, p.feasible_space.step)
         elif p.parameter_type == api.CATEGORICAL:
@@ -67,8 +71,8 @@ class HyperParameter(object):
                 self.name, self.type, ", ".join(self.list))
 
     @staticmethod
-    def int(name, min_, max_):
-        return HyperParameter(name, INTEGER, min_, max_, [], 0)
+    def int(name, min_, max_, step):
+        return HyperParameter(name, INTEGER, min_, max_, [], step)
 
     @staticmethod
     def double(name, min_, max_, step):


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1119.

I added parsing step in Internal Search Space function.
Default value for the int parameter step is 1.

/assign @gaocegege 
/cc @StefanoFioravanzo 
