### PR TITLE
Bump up the Go version to 1.14.2 at Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ jobs:
   include:
     - name: "Go unit tests, gofmt, golint and coveralls"
       language: go
-      go: "1.12.5"
+      go: "1.14.2"
       go_import_path: github.com/kubeflow/katib
       install:
         - curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v1.0.7/kubebuilder_1.0.7_linux_amd64.tar.gz"

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -22,7 +22,7 @@ if ! which gofmt > /dev/null; then
   exit 1
 fi
 
-diff=$(find . -name "*.go" | grep -v "\/vendor\/" | xargs gofmt -s -d 2>&1)
+diff=$(find . -name "*.go" | grep -v "\/vendor\/" | grep -v "\.pb\.go$" | xargs gofmt -s -d 2>&1)
 if [[ -n "${diff}" ]]; then
   echo "${diff}"
   echo


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

In the PR #1131, I added `gonum` as a dependency. Then CI fails at `go vet ./pkg/...` because it raises syntax error at the following line:
https://github.com/kubeflow/katib/blob/71a59ff49adf24d428b76ae6d94d599aa5759b6f/vendor/gonum.org/v1/gonum/lapack/gonum/lapack.go#L39

It seems that the above line uses the syntax added from Go 1.13. See [this commit](https://github.com/gonum/gonum/commit/32189f28b71ad0780d99b0dfd39523492dc72a71) for details.

```
$ GOROOT=/usr/local/go1.12 /usr/local/go1.12/bin/go vet ./pkg/...
# github.com/kubeflow/katib/vendor/gonum.org/v1/gonum/lapack/gonum
vendor/gonum.org/v1/gonum/lapack/gonum/lapack.go:39:15: syntax error: unexpected p, expecting semicolon or newline or )
$
```

```
$ GOROOT=/usr/local/go1.13 /usr/local/go1.13/bin/go vet ./pkg/...
$
```

I checked Dockerfiles under `cmd/` directory but all go versions aren't fixed. So I guess we can bump up the Go version to 1.14.2 which is the latest version.

https://github.com/kubeflow/katib/blob/4fbf77dadfd6be29f5680cfcdf88ca10f82d8a8b/cmd/db-manager/v1alpha3/Dockerfile#L1

https://github.com/kubeflow/katib/blob/61e5188d5f4ad654edfdcc4bc8d9e0a1a68c1d2a/cmd/katib-controller/v1alpha3/Dockerfile#L2

https://github.com/kubeflow/katib/blob/c18bab6c64adf2d572cd3f61b58ca7ae1870def5/cmd/metricscollector/v1alpha3/file-metricscollector/Dockerfile#L2

https://github.com/kubeflow/katib/blob/4057a5823e5a806c5dc8f04eb07bb27e5336a673/cmd/ui/v1alpha3/Dockerfile#L8

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
