### PR TITLE
Support Categorical string values in Chocolate Suggestion

### DIFF
--- a/examples/v1alpha3/grid-example.yaml
+++ b/examples/v1alpha3/grid-example.yaml
@@ -34,35 +34,34 @@ spec:
       feasibleSpace:
         min: "10"
         max: "15"
-    # Grid doesn't support categorical, refer to https://chocolate.readthedocs.io/api/sample.html#chocolate.Grid
-    # - name: --optimizer
-    #   parameterType: categorical
-    #   feasibleSpace:
-    #     list:
-    #     - sgd
-    #     - adam
-    #     - ftrl
+    - name: --optimizer
+      parameterType: categorical
+      feasibleSpace:
+        list:
+          - sgd
+          - adam
+          - ftrl
   trialTemplate:
     goTemplate:
-        rawTemplate: |-
-          apiVersion: batch/v1
-          kind: Job
-          metadata:
-            name: {{.Trial}}
-            namespace: {{.NameSpace}}
-          spec:
-            template:
-              spec:
-                containers:
-                - name: {{.Trial}}
-                  image: docker.io/kubeflowkatib/mxnet-mnist
-                  command:
-                  - "python3"
-                  - "/opt/mxnet-mnist/mnist.py"
-                  - "--batch-size=64"
-                  {{- with .HyperParameters}}
-                  {{- range .}}
-                  - "{{.Name}}={{.Value}}"
-                  {{- end}}
-                  {{- end}}
-                restartPolicy: Never
+      rawTemplate: |-
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: {{.Trial}}
+          namespace: {{.NameSpace}}
+        spec:
+          template:
+            spec:
+              containers:
+              - name: {{.Trial}}
+                image: docker.io/kubeflowkatib/mxnet-mnist
+                command:
+                - "python3"
+                - "/opt/mxnet-mnist/mnist.py"
+                - "--batch-size=64"
+                {{- with .HyperParameters}}
+                {{- range .}}
+                - "{{.Name}}={{.Value}}"
+                {{- end}}
+                {{- end}}
+              restartPolicy: Never


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1124.
After this PR all Chocolate algorithms should support string values for Categorical parameters.

I insert index of the list to DB instead of list value.

/assign @gaocegege @johnugeorge 