### PR TITLE
ENAS enable to add None values in algorithm settings

### DIFF
--- a/pkg/suggestion/v1alpha3/nas/enas/AlgorithmSettings.py
+++ b/pkg/suggestion/v1alpha3/nas/enas/AlgorithmSettings.py
@@ -11,6 +11,8 @@ algorithmSettingsValidator = {
     "controller_train_steps":       [int, [1, 'inf']],
     "controller_log_every_steps":   [int, [1, 'inf']],
 }
+enableNoneSettingsList = [
+    "controller_temperature", "controller_tanh_const", "controller_entropy_weight", "controller_skip_weight"]
 
 
 # TODO: Enable to add None values, e.g in controller_temperature parameter
@@ -32,7 +34,10 @@ def parseAlgorithmSettings(settings_raw):
     for setting in settings_raw:
         s_name = setting.name
         s_value = setting.value
-        s_type = algorithmSettingsValidator[s_name][0]
-        algorithm_settings_default[s_name] = s_type(s_value)
+        if s_value == "None":
+            algorithm_settings_default[s_name] = None
+        else:
+            s_type = algorithmSettingsValidator[s_name][0]
+            algorithm_settings_default[s_name] = s_type(s_value)
 
     return algorithm_settings_default

--- a/pkg/suggestion/v1alpha3/nas/enas/AlgorithmSettings.py
+++ b/pkg/suggestion/v1alpha3/nas/enas/AlgorithmSettings.py
@@ -15,7 +15,6 @@ enableNoneSettingsList = [
     "controller_temperature", "controller_tanh_const", "controller_entropy_weight", "controller_skip_weight"]
 
 
-# TODO: Enable to add None values, e.g in controller_temperature parameter
 def parseAlgorithmSettings(settings_raw):
 
     algorithm_settings_default = {

--- a/pkg/suggestion/v1alpha3/nas/enas/Controller.py
+++ b/pkg/suggestion/v1alpha3/nas/enas/Controller.py
@@ -190,7 +190,7 @@ class Controller(object):
         normalize = tf.dtypes.cast((self.num_layers * (self.num_layers - 1) / 2), tf.float32)
         self.skip_rate = tf.dtypes.cast((self.skip_count / normalize), tf.float32)
 
-        if self.controller_entropy_weight:
+        if self.controller_entropy_weight is not None:
             self.reward += self.controller_entropy_weight * self.sample_entropy
 
         self.sample_log_probs = tf.reduce_sum(self.sample_log_probs)


### PR DESCRIPTION
After this PR user can specify None values for some algorithm settings defined in `enableNoneSettingsList`.

This might be useful for some experiments with ENAS.

/assign @johnugeorge @gaocegege 