### PR TITLE
Remove Suggestion Request from Update Suggestion

### DIFF
--- a/pkg/controller.v1alpha3/experiment/experiment_controller.go
+++ b/pkg/controller.v1alpha3/experiment/experiment_controller.go
@@ -388,7 +388,7 @@ func (r *ReconcileExperiment) ReconcileSuggestions(instance *experimentsv1alpha3
 				}
 				if suggestion.Spec.Requests != suggestionRequestsCount {
 					suggestion.Spec.Requests = suggestionRequestsCount
-					if err := r.UpdateSuggestion(suggestion, suggestionRequestsCount); err != nil {
+					if err := r.UpdateSuggestion(suggestion); err != nil {
 						return nil, err
 					}
 				}

--- a/pkg/controller.v1alpha3/experiment/experiment_controller_test.go
+++ b/pkg/controller.v1alpha3/experiment/experiment_controller_test.go
@@ -133,7 +133,7 @@ func TestReconcileExperiment(t *testing.T) {
 				},
 			},
 		}, nil).AnyTimes()
-	suggestion.EXPECT().UpdateSuggestion(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	suggestion.EXPECT().UpdateSuggestion(gomock.Any()).Return(nil).AnyTimes()
 	mockCtrl3 := gomock.NewController(t)
 	defer mockCtrl3.Finish()
 	generator := manifestmock.NewMockGenerator(mockCtrl)

--- a/pkg/controller.v1alpha3/experiment/suggestion/fake/fake.go
+++ b/pkg/controller.v1alpha3/experiment/suggestion/fake/fake.go
@@ -17,6 +17,6 @@ func (f *Fake) GetOrCreateSuggestion(instance *experimentsv1alpha3.Experiment, s
 	return nil, nil
 }
 
-func (f *Fake) UpdateSuggestion(suggestion *suggestionsv1alpha3.Suggestion, suggestionRequests int32) error {
+func (f *Fake) UpdateSuggestion(suggestion *suggestionsv1alpha3.Suggestion) error {
 	return nil
 }

--- a/pkg/controller.v1alpha3/experiment/suggestion/suggestion.go
+++ b/pkg/controller.v1alpha3/experiment/suggestion/suggestion.go
@@ -21,7 +21,7 @@ var log = logf.Log.WithName("experiment-suggestion-client")
 
 type Suggestion interface {
 	GetOrCreateSuggestion(instance *experimentsv1alpha3.Experiment, suggestionRequests int32) (*suggestionsv1alpha3.Suggestion, error)
-	UpdateSuggestion(suggestion *suggestionsv1alpha3.Suggestion, suggestionRequests int32) error
+	UpdateSuggestion(suggestion *suggestionsv1alpha3.Suggestion) error
 }
 
 type General struct {
@@ -79,7 +79,7 @@ func (g *General) createSuggestion(instance *experimentsv1alpha3.Experiment, sug
 	return nil
 }
 
-func (g *General) UpdateSuggestion(suggestion *suggestionsv1alpha3.Suggestion, suggestionRequests int32) error {
+func (g *General) UpdateSuggestion(suggestion *suggestionsv1alpha3.Suggestion) error {
 	if err := g.Update(context.TODO(), suggestion); err != nil {
 		return err
 	}

--- a/pkg/mock/v1alpha3/experiment/suggestion/suggestion.go
+++ b/pkg/mock/v1alpha3/experiment/suggestion/suggestion.go
@@ -50,15 +50,15 @@ func (mr *MockSuggestionMockRecorder) GetOrCreateSuggestion(arg0, arg1 interface
 }
 
 // UpdateSuggestion mocks base method
-func (m *MockSuggestion) UpdateSuggestion(arg0 *v1alpha30.Suggestion, arg1 int32) error {
+func (m *MockSuggestion) UpdateSuggestion(arg0 *v1alpha30.Suggestion) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSuggestion", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdateSuggestion", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateSuggestion indicates an expected call of UpdateSuggestion
-func (mr *MockSuggestionMockRecorder) UpdateSuggestion(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSuggestionMockRecorder) UpdateSuggestion(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSuggestion", reflect.TypeOf((*MockSuggestion)(nil).UpdateSuggestion), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSuggestion", reflect.TypeOf((*MockSuggestion)(nil).UpdateSuggestion), arg0)
 }


### PR DESCRIPTION
I removed `suggestionRequestsCount` from `UpdateSuggestion` function call, because we don't use it.
We update suggestion CR with new instance.

/assign @gaocegege @johnugeorge 
/cc @sperlingxx