### PR TITLE
Support string metrics values in Controller

### DIFF
--- a/pkg/apis/controller/common/v1alpha3/common_types.go
+++ b/pkg/apis/controller/common/v1alpha3/common_types.go
@@ -67,8 +67,8 @@ type ParameterAssignment struct {
 }
 
 type Metric struct {
-	Name  string  `json:"name,omitempty"`
-	Value float64 `json:"value,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/controller.v1alpha3/suggestion/suggestionclient/suggestionclient.go
+++ b/pkg/controller.v1alpha3/suggestion/suggestionclient/suggestionclient.go
@@ -256,7 +256,7 @@ func convertTrialObservation(observation *commonapiv1alpha3.Observation) *sugges
 		for _, m := range observation.Metrics {
 			resObservation.Metrics = append(resObservation.Metrics, &suggestionapi.Metric{
 				Name:  m.Name,
-				Value: fmt.Sprintf("%f", m.Value),
+				Value: m.Value,
 			})
 		}
 	}

--- a/test/e2e/v1alpha3/run-e2e-experiment.go
+++ b/test/e2e/v1alpha3/run-e2e-experiment.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"log"
 	"os"
+	"strconv"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -27,7 +29,7 @@ const (
 	timeout = 30 * time.Minute
 )
 
-func verifyResult(exp *experimentsv1alpha3.Experiment) (*float64, error) {
+func verifyResult(exp *experimentsv1alpha3.Experiment) (*string, error) {
 	if len(exp.Status.CurrentOptimalTrial.ParameterAssignments) == 0 {
 		return nil, fmt.Errorf("Best parameter assignments not updated in status")
 	}
@@ -109,11 +111,11 @@ func main() {
 		log.Fatal("Experiment run timed out")
 	}
 
-	metricVal, err := verifyResult(exp)
+	metricValStr, err := verifyResult(exp)
 	if err != nil {
 		log.Fatal(err)
 	}
-	if metricVal == nil {
+	if metricValStr == nil {
 		log.Fatal("Metric value in CurrentOptimalTrial not populated")
 	}
 
@@ -122,8 +124,11 @@ func main() {
 	if exp.Spec.Objective.Goal != nil {
 		goal = *exp.Spec.Objective.Goal
 	}
-	if (exp.Spec.Objective.Goal != nil && objectiveType == commonv1alpha3.ObjectiveTypeMinimize && *metricVal < goal) ||
-		(exp.Spec.Objective.Goal != nil && objectiveType == commonv1alpha3.ObjectiveTypeMaximize && *metricVal > goal) {
+
+	metricVal, err := strconv.ParseFloat(*metricValStr, 64)
+	if err != nil &&
+		((exp.Spec.Objective.Goal != nil && objectiveType == commonv1alpha3.ObjectiveTypeMinimize && metricVal < goal) ||
+			(exp.Spec.Objective.Goal != nil && objectiveType == commonv1alpha3.ObjectiveTypeMaximize && metricVal > goal)) {
 		log.Print("Objective Goal reached")
 	} else {
 


### PR DESCRIPTION
I added support for string values in `CurrentOptimalTrial.Observation.Metrics` for Experiment and `Observation.Metrics` for Trial. This will be useful if user wants to report some text information from Trial.
See comment: https://github.com/kubeflow/katib/pull/1175#issue-412394244.