### PR TITLE
Unittest for DARTS Suggestion

### DIFF
--- a/test/scripts/v1alpha3/python-tests.sh
+++ b/test/scripts/v1alpha3/python-tests.sh
@@ -27,5 +27,5 @@ pip install -r cmd/suggestion/hyperopt/v1alpha3/requirements.txt
 pip install -r cmd/suggestion/skopt/v1alpha3/requirements.txt
 pip install -r cmd/suggestion/nas/enas/v1alpha3/requirements.txt
 pip install -r cmd/suggestion/hyperband/v1alpha3/requirements.txt
-pop install -r cmd/suggestion/nas/darts/v1alpha3/requirements.txt
+pip install -r cmd/suggestion/nas/darts/v1alpha3/requirements.txt
 pytest -s ./test

--- a/test/scripts/v1alpha3/python-tests.sh
+++ b/test/scripts/v1alpha3/python-tests.sh
@@ -27,4 +27,5 @@ pip install -r cmd/suggestion/hyperopt/v1alpha3/requirements.txt
 pip install -r cmd/suggestion/skopt/v1alpha3/requirements.txt
 pip install -r cmd/suggestion/nas/enas/v1alpha3/requirements.txt
 pip install -r cmd/suggestion/hyperband/v1alpha3/requirements.txt
+pop install -r cmd/suggestion/nas/darts/v1alpha3/requirements.txt
 pytest -s ./test

--- a/test/suggestion/v1alpha3/test_chocolate_service.py
+++ b/test/suggestion/v1alpha3/test_chocolate_service.py
@@ -8,7 +8,7 @@ from pkg.apis.manager.v1alpha3.python import api_pb2
 from pkg.suggestion.v1alpha3.chocolate.service import ChocolateService
 
 
-class TestHyperopt(unittest.TestCase):
+class TestChocolate(unittest.TestCase):
     def setUp(self):
         servicers = {
             api_pb2.DESCRIPTOR.services_by_name['Suggestion']: ChocolateService(
@@ -114,12 +114,6 @@ class TestHyperopt(unittest.TestCase):
             spec=api_pb2.ExperimentSpec(
                 algorithm=api_pb2.AlgorithmSpec(
                     algorithm_name="grid",
-                    algorithm_setting=[
-                        api_pb2.AlgorithmSetting(
-                            name="random_state",
-                            value="10"
-                        )
-                    ],
                 ),
                 objective=api_pb2.ObjectiveSpec(
                     type=api_pb2.MAXIMIZE,
@@ -167,7 +161,7 @@ class TestHyperopt(unittest.TestCase):
                                .services_by_name['Suggestion']
                                .methods_by_name['GetSuggestions']),
             invocation_metadata={},
-            request=request, timeout=1)
+            request=request, timeout=100)
 
         response, metadata, code, details = get_suggestion.termination()
         print(response.parameter_assignments)

--- a/test/suggestion/v1alpha3/test_chocolate_service.py
+++ b/test/suggestion/v1alpha3/test_chocolate_service.py
@@ -174,7 +174,6 @@ class TestHyperopt(unittest.TestCase):
         self.assertEqual(code, grpc.StatusCode.OK)
         self.assertEqual(2, len(response.parameter_assignments))
 
-# TODO(gaocegege): sqlite3.ProgrammingError in CI, fix it.
-# sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread.
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/suggestion/v1alpha3/test_darts_service.py
+++ b/test/suggestion/v1alpha3/test_darts_service.py
@@ -1,0 +1,105 @@
+import grpc
+import grpc_testing
+import unittest
+import json
+
+from pkg.apis.manager.v1alpha3.python import api_pb2_grpc
+from pkg.apis.manager.v1alpha3.python import api_pb2
+
+from pkg.suggestion.v1alpha3.nas.darts.service import DartsService
+
+
+class TestDarts(unittest.TestCase):
+    def setUp(self):
+        servicers = {
+            api_pb2.DESCRIPTOR.services_by_name['Suggestion']: DartsService(
+            )
+        }
+
+        self.test_server = grpc_testing.server_from_dictionary(
+            servicers, grpc_testing.strict_real_time())
+
+    def test_get_suggestion(self):
+        experiment = api_pb2.Experiment(
+            name="darts-experiment",
+            spec=api_pb2.ExperimentSpec(
+                algorithm=api_pb2.AlgorithmSpec(
+                    algorithm_name="darts",
+                    algorithm_setting=[
+                        api_pb2.AlgorithmSetting(
+                            name="num_epoch",
+                            value="10"
+                        )
+                    ],
+                ),
+                objective=api_pb2.ObjectiveSpec(
+                    type=api_pb2.MAXIMIZE,
+                    objective_metric_name="Best-Genotype"
+                ),
+                parallel_trial_count=1,
+                max_trial_count=1,
+                nas_config=api_pb2.NasConfig(
+                    graph_config=api_pb2.GraphConfig(
+                        num_layers=3,
+                    ),
+                    operations=api_pb2.NasConfig.Operations(
+                        operation=[
+                            api_pb2.Operation(
+                                operation_type="separable_convolution",
+                                parameter_specs=api_pb2.Operation.ParameterSpecs(
+                                    parameters=[
+                                        api_pb2.ParameterSpec(
+                                            name="filter_size",
+                                            parameter_type=api_pb2.CATEGORICAL,
+                                            feasible_space=api_pb2.FeasibleSpace(
+                                                max=None, min=None, list=["3", "5"])
+                                        ),
+                                    ]
+                                )
+                            ),
+                        ],
+                    )
+                )
+            )
+        )
+
+        request = api_pb2.GetSuggestionsRequest(
+            experiment=experiment,
+            request_number=1,
+        )
+
+        get_suggestion = self.test_server.invoke_unary_unary(
+            method_descriptor=(api_pb2.DESCRIPTOR
+                               .services_by_name['Suggestion']
+                               .methods_by_name['GetSuggestions']),
+            invocation_metadata={},
+            request=request, timeout=100)
+
+        response, metadata, code, details = get_suggestion.termination()
+        print(response.parameter_assignments)
+
+        self.assertEqual(code, grpc.StatusCode.OK)
+        self.assertEqual(1, len(response.parameter_assignments))
+
+        exp_algorithm_settings = {}
+        for setting in experiment.spec.algorithm.algorithm_setting:
+            exp_algorithm_settings[setting.name] = setting.value
+
+        exp_num_layers = experiment.spec.nas_config.graph_config.num_layers
+
+        exp_search_space = ["separable_convolution_3x3", "separable_convolution_5x5"]
+        for pa in response.parameter_assignments[0].assignments:
+            if (pa.name == "algorithm-settings"):
+                algorithm_settings = pa.value.replace("\'", "\"")
+                algorithm_settings = json.loads(algorithm_settings)
+                self.assertDictContainsSubset(exp_algorithm_settings, algorithm_settings)
+            elif (pa.name == "num-layers"):
+                self.assertEqual(exp_num_layers, int(pa.value))
+            elif (pa.name == "search-space"):
+                search_space = pa.value.replace("\'", "\"")
+                search_space = json.loads(search_space)
+                self.assertEqual(exp_search_space, search_space)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Part of https://github.com/kubeflow/katib/issues/1167.

I added unittest for Darts service and removed failed from chocolate unittest, it should work now without warning on same thread running.

In the future we can add e2e test for Darts, I think.
This can be done after we implement more parameters in `AlgorithmSettings` to control Darts running. Currently, running Darts on CPU is extremely long.

/assign @johnugeorge @gaocegege 