### PR TITLE
Support one and two NN layers in DARTS

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -35,6 +35,7 @@ workflows:
     - cmd/suggestion/goptuna/v1alpha3/*
     - cmd/ui/v1alpha3/*
     - examples/v1alpha3/*.yaml
+    - examples/v1alpha3/nas/*
     - test/e2e/v1alpha3/*
     - test/scripts/v1alpha3/*
     - test/workflows/*
@@ -77,6 +78,7 @@ workflows:
     - cmd/suggestion/goptuna/v1alpha3/*
     - cmd/ui/v1alpha3/*
     - examples/v1alpha3/*.yaml
+    - examples/v1alpha3/nas/*
     - test/e2e/v1alpha3/*
     - test/scripts/v1alpha3/*
     - test/workflows/*


### PR DESCRIPTION
I added support for one and two neural network layers in DARTS.

If Num Layers = 1, only Normal Cell is used.
If Num Layers = 2, First layer: Normal Cell, Second Layer: Reduction Cell.
That will be useful for e2e test in the future.

I have pushed to `docker.io/kubeflowkatib/darts-cnn-cifar10` new image.
/assign @gaocegege @johnugeorge 