### PR TITLE
Change scikit-learn version to 0.22.0 for BO Suggestion

### DIFF
--- a/cmd/suggestion/skopt/v1alpha3/requirements.txt
+++ b/cmd/suggestion/skopt/v1alpha3/requirements.txt
@@ -2,7 +2,7 @@ grpcio==1.23.0
 duecredit===0.7.0
 cloudpickle==0.5.6
 numpy>=1.13.3
-scikit-learn>=0.19.0
+scikit-learn==0.22.0
 scipy>=0.19.1
 forestci==0.3
 protobuf==3.9.1


### PR DESCRIPTION
New version of Scikit learn: 0.23, doesn't work with scikit-optimize version: 0.5.2.
I changed Scikit learn version to 0.22 for BO Suggestion.

/assign @gaocegege @johnugeorge 