### PR TITLE
Revert 1176 PR (Support string metric values)

### DIFF
--- a/pkg/apis/controller/common/v1alpha3/common_types.go
+++ b/pkg/apis/controller/common/v1alpha3/common_types.go
@@ -67,8 +67,8 @@ type ParameterAssignment struct {
 }
 
 type Metric struct {
-	Name  string `json:"name,omitempty"`
-	Value string `json:"value,omitempty"`
+	Name  string  `json:"name,omitempty"`
+	Value float64 `json:"value,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/controller.v1alpha3/experiment/util/status_util.go
+++ b/pkg/controller.v1alpha3/experiment/util/status_util.go
@@ -16,8 +16,6 @@ limitations under the License.
 package util
 
 import (
-	"strconv"
-
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	commonv1alpha3 "github.com/kubeflow/katib/pkg/apis/controller/common/v1alpha3"
@@ -79,35 +77,28 @@ func updateTrialsSummary(instance *experimentsv1alpha3.Experiment, trials *trial
 			sts.PendingTrialList = append(sts.PendingTrialList, trial.Name)
 		}
 
-		objectiveMetricValueStr := getObjectiveMetricValue(trial, objectiveMetricName)
-		if objectiveMetricValueStr == nil {
-			continue
-		}
-		objectiveMetricValue, err := strconv.ParseFloat(*objectiveMetricValueStr, 64)
-
-		// For string metrics values best trial is the latest
-		if err != nil {
-			bestTrialIndex = index
+		objectiveMetricValue := getObjectiveMetricValue(trial, objectiveMetricName)
+		if objectiveMetricValue == nil {
 			continue
 		}
 
-		//initialize vars to objective metric value of the first trial
+		//intialize vars to objective metric value of the first trial
 		if bestTrialIndex == -1 {
-			bestTrialValue = objectiveMetricValue
+			bestTrialValue = *objectiveMetricValue
 			bestTrialIndex = index
 		}
 
 		if objectiveType == commonv1alpha3.ObjectiveTypeMinimize {
-			if objectiveMetricValue < bestTrialValue {
-				bestTrialValue = objectiveMetricValue
+			if *objectiveMetricValue < bestTrialValue {
+				bestTrialValue = *objectiveMetricValue
 				bestTrialIndex = index
 			}
 			if instance.Spec.Objective.Goal != nil && bestTrialValue <= objectiveValueGoal {
 				isObjectiveGoalReached = true
 			}
 		} else if objectiveType == commonv1alpha3.ObjectiveTypeMaximize {
-			if objectiveMetricValue > bestTrialValue {
-				bestTrialValue = objectiveMetricValue
+			if *objectiveMetricValue > bestTrialValue {
+				bestTrialValue = *objectiveMetricValue
 				bestTrialIndex = index
 			}
 			if instance.Spec.Objective.Goal != nil && bestTrialValue >= objectiveValueGoal {
@@ -140,7 +131,7 @@ func updateTrialsSummary(instance *experimentsv1alpha3.Experiment, trials *trial
 	return isObjectiveGoalReached
 }
 
-func getObjectiveMetricValue(trial trialsv1alpha3.Trial, objectiveMetricName string) *string {
+func getObjectiveMetricValue(trial trialsv1alpha3.Trial, objectiveMetricName string) *float64 {
 	if trial.Status.Observation == nil {
 		return nil
 	}

--- a/pkg/controller.v1alpha3/suggestion/suggestionclient/suggestionclient.go
+++ b/pkg/controller.v1alpha3/suggestion/suggestionclient/suggestionclient.go
@@ -256,7 +256,7 @@ func convertTrialObservation(observation *commonapiv1alpha3.Observation) *sugges
 		for _, m := range observation.Metrics {
 			resObservation.Metrics = append(resObservation.Metrics, &suggestionapi.Metric{
 				Name:  m.Name,
-				Value: m.Value,
+				Value: fmt.Sprintf("%f", m.Value),
 			})
 		}
 	}

--- a/pkg/controller.v1alpha3/trial/trial_controller_util.go
+++ b/pkg/controller.v1alpha3/trial/trial_controller_util.go
@@ -171,36 +171,27 @@ func isJobSucceeded(jobCondition *commonv1.JobCondition) bool {
 	return false
 }
 
-func getBestObjectiveMetricValue(metricLogs []*api_pb.MetricLog, objectiveType commonv1alpha3.ObjectiveType) *string {
+func getBestObjectiveMetricValue(metricLogs []*api_pb.MetricLog, objectiveType commonv1alpha3.ObjectiveType) *float64 {
 	metricLogSize := len(metricLogs)
 	if metricLogSize == 0 {
 		return nil
 	}
 
-	bestObjectiveValue, err := strconv.ParseFloat(metricLogs[0].Metric.Value, 64)
-	bestIndex := 0
-
-	if err != nil {
-		// If metrics are string values return the latest value
-		return &metricLogs[len(metricLogs)-1].Metric.Value
-	}
-
-	for idx, metricLog := range metricLogs[1:] {
+	bestObjectiveValue, _ := strconv.ParseFloat(metricLogs[0].Metric.Value, 64)
+	for _, metricLog := range metricLogs[1:] {
 		objectiveMetricValue, _ := strconv.ParseFloat(metricLog.Metric.Value, 64)
 		if objectiveType == commonv1alpha3.ObjectiveTypeMinimize {
 			if objectiveMetricValue < bestObjectiveValue {
 				bestObjectiveValue = objectiveMetricValue
-				bestIndex = idx + 1
 			}
 		} else if objectiveType == commonv1alpha3.ObjectiveTypeMaximize {
 			if objectiveMetricValue > bestObjectiveValue {
 				bestObjectiveValue = objectiveMetricValue
-				bestIndex = idx + 1
 			}
 		}
 
 	}
-	return &metricLogs[bestIndex].Metric.Value
+	return &bestObjectiveValue
 }
 
 func needUpdateFinalizers(trial *trialsv1alpha3.Trial) (bool, []string) {

--- a/test/e2e/v1alpha3/run-e2e-experiment.go
+++ b/test/e2e/v1alpha3/run-e2e-experiment.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"strconv"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -29,7 +28,7 @@ const (
 	timeout = 30 * time.Minute
 )
 
-func verifyResult(exp *experimentsv1alpha3.Experiment) (*string, error) {
+func verifyResult(exp *experimentsv1alpha3.Experiment) (*float64, error) {
 	if len(exp.Status.CurrentOptimalTrial.ParameterAssignments) == 0 {
 		return nil, fmt.Errorf("Best parameter assignments not updated in status")
 	}
@@ -111,11 +110,11 @@ func main() {
 		log.Fatal("Experiment run timed out")
 	}
 
-	metricValStr, err := verifyResult(exp)
+	metricVal, err := verifyResult(exp)
 	if err != nil {
 		log.Fatal(err)
 	}
-	if metricValStr == nil {
+	if metricVal == nil {
 		log.Fatal("Metric value in CurrentOptimalTrial not populated")
 	}
 
@@ -124,11 +123,8 @@ func main() {
 	if exp.Spec.Objective.Goal != nil {
 		goal = *exp.Spec.Objective.Goal
 	}
-
-	metricVal, err := strconv.ParseFloat(*metricValStr, 64)
-	if err == nil &&
-		((exp.Spec.Objective.Goal != nil && objectiveType == commonv1alpha3.ObjectiveTypeMinimize && metricVal < goal) ||
-			(exp.Spec.Objective.Goal != nil && objectiveType == commonv1alpha3.ObjectiveTypeMaximize && metricVal > goal)) {
+	if (exp.Spec.Objective.Goal != nil && objectiveType == commonv1alpha3.ObjectiveTypeMinimize && *metricVal < goal) ||
+		(exp.Spec.Objective.Goal != nil && objectiveType == commonv1alpha3.ObjectiveTypeMaximize && *metricVal > goal) {
 		log.Print("Objective Goal reached")
 	} else {
 


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1186.
String metric values can break current Running Katib user's Experiments.

I reverted this commit from the upstream, we will add this commit after we switch to the new Katib version.

/assign @johnugeorge @gaocegege @sperlingxx 