### PR TITLE
Fix additional metrics in TF Event metrics collector

### DIFF
--- a/cmd/metricscollector/v1alpha3/tfevent-metricscollector/main.py
+++ b/cmd/metricscollector/v1alpha3/tfevent-metricscollector/main.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
 
     WaitOtherMainProcesses(completed_marked_dir=opt.dir_path)
 
-    mc = MetricsCollector(opt.metric_names.split(','))
+    mc = MetricsCollector(opt.metric_names.split(';'))
     observation_log = mc.parse_file(opt.dir_path)
 
     channel = grpc.beta.implementations.insecure_channel(


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1188.
I changed split metrics from "," to ";".
See comment: https://github.com/kubeflow/katib/issues/1188#issuecomment-630320234.

Do we need to modify TF Job example (https://github.com/kubeflow/katib/blob/master/examples/v1alpha3/tfjob-example.yaml) with additional metric, for example: `cross_entropy_1`?

/assign @johnugeorge @gaocegege 
/cc @sadeel