### PR TITLE
UI: Fix comparison of metric values in Metrics Info Plot

### DIFF
--- a/pkg/ui/v1alpha3/hp.go
+++ b/pkg/ui/v1alpha3/hp.go
@@ -202,9 +202,9 @@ func (k *KatibUIHandler) FetchHPJobTrialInfo(w http.ResponseWriter, r *http.Requ
 
 		if formatCurrentTime == prevMetricTimeValue[m.Metric.Name][0] &&
 			((objectiveType == commonv1alpha3.ObjectiveTypeMinimize &&
-				(newMetricValue < prevMetricValue)) ||
+				newMetricValue < prevMetricValue) ||
 				(objectiveType == commonv1alpha3.ObjectiveTypeMaximize &&
-					(newMetricValue > prevMetricValue))) {
+					newMetricValue > prevMetricValue)) {
 
 			prevMetricTimeValue[m.Metric.Name][1] = m.Metric.Value
 			for i := len(resultArray) - 1; i >= 0; i-- {


### PR DESCRIPTION
We should cast metrics to float values before making comparison between values.
Comparing string values can be not right.

/assign @gaocegege @johnugeorge 