### PR TITLE
Modify new algorithm service doc

### DIFF
--- a/docs/new-algorithm-service.md
+++ b/docs/new-algorithm-service.md
@@ -149,7 +149,7 @@ To add a e2e test for the new algorithm, in [test/scripts/v1alpha3](../test/scri
 
 2. Create a new script `build-suggestion-xxx.sh` to build new suggestion. Here is an example [test/scripts/v1alpha3/build-suggestion-hyperopt.sh](../test/scripts/v1alpha3/build-suggestion-hyperopt.sh).
 
-3. Update `check-katib-ready.sh`(../test/scripts/v1alpha3/check-katib-ready.sh) script to modify `katib-config.yaml` with new test suggestion image name. For example (Replace `<name>` with new suggestion name):
+3. Update [`check-katib-ready.sh`](../test/scripts/v1alpha3/check-katib-ready.sh) script to modify `katib-config.yaml` with the new test suggestion image name. We use `gcr.io/kubeflow-ci` registry to run presubmit tests. For example (Replace `<name>` with the new suggestion name):
 
 ```
 sed -i -e "s@gcr.io\/kubeflow-images-public\/katib\/v1alpha3\/suggestion-<name>@${REGISTRY}\/${REPO_NAME}\/v1alpha3\/suggestion-<name>@" manifests/v1alpha3/katib-controller/katib-config.yaml

--- a/docs/new-algorithm-service.md
+++ b/docs/new-algorithm-service.md
@@ -149,7 +149,13 @@ To add a e2e test for the new algorithm, in [test/scripts/v1alpha3](../test/scri
 
 2. Create a new script `build-suggestion-xxx.sh` to build new suggestion. Here is an example [test/scripts/v1alpha3/build-suggestion-hyperopt.sh](../test/scripts/v1alpha3/build-suggestion-hyperopt.sh).
 
-3. Create a new script `run-suggestion-xxx.sh` to run new suggestion. Below is an example (Replace `<name>` with the new algorithm name):
+3. Update `check-katib-ready.sh`(../test/scripts/v1alpha3/check-katib-ready.sh) script to modify `katib-config.yaml` with new test suggestion image name. For example (Replace `<name>` with new suggestion name):
+
+```
+sed -i -e "s@gcr.io\/kubeflow-images-public\/katib\/v1alpha3\/suggestion-<name>@${REGISTRY}\/${REPO_NAME}\/v1alpha3\/suggestion-<name>@" manifests/v1alpha3/katib-controller/katib-config.yaml
+```
+
+4. Create a new script `run-suggestion-xxx.sh` to run new suggestion. Below is an example (Replace `<name>` with the new algorithm name):
 
 ```bash
 #!/bin/bash


### PR DESCRIPTION
I added step to new algorithm service doc to modify `check-katib-ready.sh` script.
To run e2e test we should change registry to `gcr.io/kubeflow-ci`.

/assign @johnugeorge @gaocegege 