### PR TITLE
Update doc for training container images with DARTS

### DIFF
--- a/examples/v1alpha3/README.md
+++ b/examples/v1alpha3/README.md
@@ -335,6 +335,12 @@ docker.io/kubeflowkatib/enas-cnn-cifar10-gpu
 docker.io/kubeflowkatib/enas-cnn-cifar10-cpu
 ```
 
+- Pytorch cifar10 CNN example for DARTS, [source](https://github.com/kubeflow/katib/blob/master/examples/v1alpha3/nas/darts-cnn-cifar10/Dockerfile)
+
+```
+docker.io/kubeflowkatib/darts-cnn-cifar10
+```
+
 - Pytorch operator mnist example, [source](https://github.com/kubeflow/pytorch-operator/blob/master/examples/mnist/mnist.py).
 
 ```

--- a/examples/v1beta1/README.md
+++ b/examples/v1beta1/README.md
@@ -365,6 +365,12 @@ docker.io/kubeflowkatib/enas-cnn-cifar10-gpu
 docker.io/kubeflowkatib/enas-cnn-cifar10-cpu
 ```
 
+- Pytorch cifar10 CNN example for DARTS, [source](https://github.com/kubeflow/katib/blob/master/examples/v1beta1/nas/darts-cnn-cifar10/Dockerfile)
+
+```
+docker.io/kubeflowkatib/darts-cnn-cifar10
+```
+
 - Pytorch operator mnist example, [source](https://github.com/kubeflow/pytorch-operator/blob/master/examples/mnist/mnist.py).
 
 ```


### PR DESCRIPTION
I updated doc with DARTS training container image `docker.io/kubeflowkatib/darts-cnn-cifar10`. 

/assign @gaocegege @johnugeorge 