### PR TITLE
New Trial Template API

### DIFF
--- a/pkg/apis/controller/experiments/v1beta1/experiment_types.go
+++ b/pkg/apis/controller/experiments/v1beta1/experiment_types.go
@@ -19,6 +19,7 @@ import (
 	common "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type ExperimentSpec struct {
@@ -187,8 +188,36 @@ type FeasibleSpace struct {
 }
 
 type TrialTemplate struct {
-	Retain     bool        `json:"retain,omitempty"`
+	// Retain indicates that Trial resources must be not cleanup
+	Retain bool `json:"retain,omitempty"`
+
 	GoTemplate *GoTemplate `json:"goTemplate,omitempty"`
+
+	// List of parameres that are used in Trial template
+	TrialParameters []TrialParameterSpec `json:"trialParameters,omitempty"`
+
+	// Trial spec contains Trial template in unstructured format
+	TrialSpec *unstructured.Unstructured `json:"trialSpec,omitempty"`
+
+	// Name of config map where Trial template is located
+	ConfigMapName string `json:"configMapName,omitempty"`
+
+	// Namespace of config map where Trial template is located
+	ConfigMapNamespace string `json:"configMapNamespace,omitempty"`
+
+	// Path in config map where Trial template is located
+	TemplatePath string `json:"templatePath,omitempty"`
+}
+
+type TrialParameterSpec struct {
+	// Name of the parameter that must be replaced in Trial template
+	Name string `json:"name,omitempty"`
+
+	// Description of the parameter
+	Description string `json:"description,omitempty"`
+
+	// Reference to the parameter in search space
+	Reference string `json:"reference,omitempty"`
 }
 
 type TemplateSpec struct {


### PR DESCRIPTION
This is new API for Trial Template.
See comment: https://github.com/kubeflow/katib/issues/906#issuecomment-632149834.

In `TrialParameters` user must define parameters that are replaced in Trial Template.
As @gaocegege proposed, I added `Reference` to make connection between `TrialParameters` and `Parameters` (search space).
Also, in `TrialSpec` `metadata.name` and `metadata.namespace` must be omitted, since we automatically added it in Katib controller.

I added ConfigMap specification to `TrialTemplate`, if user wants to read Trial Template from configMap.

In the future, we can extend `TrialTemplate` with custom settings (for example, how to get succeeded state of the Job), to support any Kubernetes CRDs.
In this CRDs we should be able to run TrialJobs, such as Argo, etc (https://github.com/kubeflow/katib/issues/1081).

/assign @gaocegege @jlewi @johnugeorge @sperlingxx
/cc @czheng94 @terrykong @nielsmeima 
