### PR TITLE
Validate possible operations for Grid suggestion

### DIFF
--- a/pkg/suggestion/v1beta1/chocolate/service.py
+++ b/pkg/suggestion/v1beta1/chocolate/service.py
@@ -18,11 +18,14 @@ import grpc
 from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.apis.manager.v1beta1.python import api_pb2_grpc
 
-from pkg.suggestion.v1beta1.internal.constant import DOUBLE
+from pkg.suggestion.v1beta1.internal.constant import (INTEGER, DOUBLE, CATEGORICAL, DISCRETE)
 from pkg.suggestion.v1beta1.internal.search_space import HyperParameterSearchSpace
 from pkg.suggestion.v1beta1.internal.trial import Trial, Assignment
 from pkg.suggestion.v1beta1.chocolate.base_service import BaseChocolateService
 from pkg.suggestion.v1beta1.internal.base_health_service import HealthServicer
+
+import numpy as np
+import itertools
 
 logger = logging.getLogger(__name__)
 
@@ -38,11 +41,32 @@ class ChocolateService(api_pb2_grpc.SuggestionServicer, HealthServicer):
         if algorithm_name == "grid":
             search_space = HyperParameterSearchSpace.convert(
                 request.experiment)
+            available_space = {}
             for param in search_space.params:
-                if param.type == DOUBLE:
+                if param.type == INTEGER:
+                    available_space[param.name] = range(int(param.min), int(param.max)+1, int(param.step))
+
+                elif param.type == DOUBLE:
                     if param.step == "" or param.step is None:
                         return self._set_validate_context_error(
-                            context, "param {} step is nil".format(param.name))
+                            context, "Param: {} step is nil".format(param.name))
+                    double_list = np.arange(float(param.min), float(param.max)+float(param.step), float(param.step))
+                    if double_list[-1] > float(param.max):
+                        double_list = double_list[:-1]
+                    available_space[param.name] = double_list
+
+                elif param.type == CATEGORICAL or param.type == DISCRETE:
+                    available_space[param.name] = param.list
+
+            num_combinations = len(list(itertools.product(*available_space.values())))
+            max_trial_count = request.experiment.spec.max_trial_count
+
+            if max_trial_count > num_combinations:
+                return self._set_validate_context_error(
+                    context, "Max Trial Count: {} > all possible search space combinations: {}".format(
+                        max_trial_count, num_combinations)
+                )
+
         return api_pb2.ValidateAlgorithmSettingsReply()
 
     def GetSuggestions(self, request, context):

--- a/pkg/suggestion/v1beta1/chocolate/service.py
+++ b/pkg/suggestion/v1beta1/chocolate/service.py
@@ -18,7 +18,7 @@ import grpc
 from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.apis.manager.v1beta1.python import api_pb2_grpc
 
-from pkg.suggestion.v1beta1.internal.constant import (INTEGER, DOUBLE, CATEGORICAL, DISCRETE)
+from pkg.suggestion.v1beta1.internal.constant import INTEGER, DOUBLE, CATEGORICAL, DISCRETE
 from pkg.suggestion.v1beta1.internal.search_space import HyperParameterSearchSpace
 from pkg.suggestion.v1beta1.internal.trial import Trial, Assignment
 from pkg.suggestion.v1beta1.chocolate.base_service import BaseChocolateService

--- a/test/suggestion/v1beta1/test_chocolate_service.py
+++ b/test/suggestion/v1beta1/test_chocolate_service.py
@@ -184,7 +184,7 @@ class TestChocolate(unittest.TestCase):
         self.assertEqual(2, len(response.parameter_assignments))
 
     def test_validate_algorithm_settings(self):
-        # Valid case
+        # Valid case.
         experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="grid",
@@ -224,8 +224,8 @@ class TestChocolate(unittest.TestCase):
         _, _, code, _ = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.OK)
 
-        # Invalid cases
-        # Empty step
+        # Invalid cases.
+        # Empty step.
         experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="grid",
@@ -246,7 +246,7 @@ class TestChocolate(unittest.TestCase):
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
         self.assertEqual(details, 'Param: param-1 step is nil')
 
-        # Max trial count > search space combinations
+        # Max trial count > search space combinations.
         experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="grid",

--- a/test/suggestion/v1beta1/test_hyperopt_service.py
+++ b/test/suggestion/v1beta1/test_hyperopt_service.py
@@ -26,7 +26,7 @@ import utils
 class TestHyperopt(unittest.TestCase):
     def setUp(self):
         servicers = {
-            api_pb2.DESCRIPTOR.services_by_name['Suggestion']: HyperoptService(
+            api_pb2.DESCRIPTOR.services_by_name["Suggestion"]: HyperoptService(
             )
         }
 
@@ -191,8 +191,8 @@ class TestHyperopt(unittest.TestCase):
 
         get_suggestion = self.test_server.invoke_unary_unary(
             method_descriptor=(api_pb2.DESCRIPTOR
-                               .services_by_name['Suggestion']
-                               .methods_by_name['GetSuggestions']),
+                               .services_by_name["Suggestion"]
+                               .methods_by_name["GetSuggestions"]),
             invocation_metadata={},
             request=request, timeout=1)
 
@@ -202,7 +202,7 @@ class TestHyperopt(unittest.TestCase):
         self.assertEqual(2, len(response.parameter_assignments))
 
     def test_validate_algorithm_settings(self):
-        # valid cases
+        # Valid cases.
         experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="tpe",
@@ -230,16 +230,19 @@ class TestHyperopt(unittest.TestCase):
         _, _, code, _ = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.OK)
 
-        # invalid cases
+        # Invalid cases.
+        # Unknown algorithm name.
         experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="unknown"
             )
         )
+
         _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
-        self.assertEqual(details, 'unknown algorithm name unknown')
+        self.assertEqual(details, "unknown algorithm name unknown")
 
+        # Unknown algorithm setting name.
         experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="random",
@@ -248,10 +251,12 @@ class TestHyperopt(unittest.TestCase):
                 ]
             )
         )
+
         _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
-        self.assertEqual(details, 'unknown setting unknown_conf for algorithm random')
+        self.assertEqual(details, "unknown setting unknown_conf for algorithm random")
 
+        # Invalid gamma value.
         experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="tpe",
@@ -260,10 +265,12 @@ class TestHyperopt(unittest.TestCase):
                 ]
             )
         )
+
         _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
-        self.assertEqual(details, 'gamma should be in the range of (0, 1)')
+        self.assertEqual(details, "gamma should be in the range of (0, 1)")
 
+        # Invalid n_EI_candidates value.
         experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="tpe",
@@ -272,10 +279,12 @@ class TestHyperopt(unittest.TestCase):
                 ]
             )
         )
+
         _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
-        self.assertEqual(details, 'n_EI_candidates should be great than zero')
+        self.assertEqual(details, "n_EI_candidates should be great than zero")
 
+        # Invalid random_state value.
         experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="tpe",
@@ -284,10 +293,12 @@ class TestHyperopt(unittest.TestCase):
                 ]
             )
         )
+
         _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
-        self.assertEqual(details, 'random_state should be great or equal than zero')
+        self.assertEqual(details, "random_state should be great or equal than zero")
 
+        # Invalid prior_weight value.
         experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="tpe",
@@ -296,10 +307,11 @@ class TestHyperopt(unittest.TestCase):
                 ]
             )
         )
+
         _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
-        self.assertTrue(details.startswith('failed to validate prior_weight(aaa)'))
+        self.assertTrue(details.startswith("failed to validate prior_weight(aaa)"))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/suggestion/v1beta1/test_hyperopt_service.py
+++ b/test/suggestion/v1beta1/test_hyperopt_service.py
@@ -20,6 +20,8 @@ import grpc_testing
 from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.suggestion.v1beta1.hyperopt.service import HyperoptService
 
+import utils
+
 
 class TestHyperopt(unittest.TestCase):
     def setUp(self):
@@ -200,100 +202,101 @@ class TestHyperopt(unittest.TestCase):
         self.assertEqual(2, len(response.parameter_assignments))
 
     def test_validate_algorithm_settings(self):
-        experiment_spec = [None]
-
-        def call_validate():
-            experiment = api_pb2.Experiment(name="test", spec=experiment_spec[0])
-            request = api_pb2.ValidateAlgorithmSettingsRequest(experiment=experiment)
-
-            validate_algorithm_settings = self.test_server.invoke_unary_unary(
-                method_descriptor=(api_pb2.DESCRIPTOR
-                                   .services_by_name['Suggestion']
-                                   .methods_by_name['ValidateAlgorithmSettings']),
-                invocation_metadata={},
-                request=request, timeout=1)
-
-            return validate_algorithm_settings.termination()
-
         # valid cases
-        algorithm_spec = api_pb2.AlgorithmSpec(
-            algorithm_name="tpe",
-            algorithm_settings=[
-                api_pb2.AlgorithmSetting(
-                    name="random_state",
-                    value="10"
-                ),
-                api_pb2.AlgorithmSetting(
-                    name="gamma",
-                    value="0.25"
-                ),
-                api_pb2.AlgorithmSetting(
-                    name="prior_weight",
-                    value="1.0"
-                ),
-                api_pb2.AlgorithmSetting(
-                    name="n_EI_candidates",
-                    value="24"
-                ),
-            ],
+        experiment_spec = api_pb2.ExperimentSpec(
+            algorithm=api_pb2.AlgorithmSpec(
+                algorithm_name="tpe",
+                algorithm_setting=[
+                    api_pb2.AlgorithmSetting(
+                        name="random_state",
+                        value="10"
+                    ),
+                    api_pb2.AlgorithmSetting(
+                        name="gamma",
+                        value="0.25"
+                    ),
+                    api_pb2.AlgorithmSetting(
+                        name="prior_weight",
+                        value="1.0"
+                    ),
+                    api_pb2.AlgorithmSetting(
+                        name="n_EI_candidates",
+                        value="24"
+                    ),
+                ]
+            )
         )
-        experiment_spec[0] = api_pb2.ExperimentSpec(algorithm=algorithm_spec)
-        self.assertEqual(call_validate()[2], grpc.StatusCode.OK)
+
+        _, _, code, _ = utils.call_validate(self.test_server, experiment_spec)
+        self.assertEqual(code, grpc.StatusCode.OK)
 
         # invalid cases
-        experiment_spec[0] = api_pb2.ExperimentSpec(
-            algorithm=api_pb2.AlgorithmSpec(algorithm_name="unknown"))
-        _, _, code, details = call_validate()
+        experiment_spec = api_pb2.ExperimentSpec(
+            algorithm=api_pb2.AlgorithmSpec(
+                algorithm_name="unknown"
+            )
+        )
+        _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
         self.assertEqual(details, 'unknown algorithm name unknown')
 
-        experiment_spec[0] = api_pb2.ExperimentSpec(
+        experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="random",
-                algorithm_settings=[
-                    api_pb2.AlgorithmSetting(name="unknown_conf", value="1111")]
-            ))
-        _, _, code, details = call_validate()
+                algorithm_setting=[
+                    api_pb2.AlgorithmSetting(name="unknown_conf", value="1111")
+                ]
+            )
+        )
+        _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
         self.assertEqual(details, 'unknown setting unknown_conf for algorithm random')
 
-        experiment_spec[0] = api_pb2.ExperimentSpec(
+        experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="tpe",
-                algorithm_settings=[
-                    api_pb2.AlgorithmSetting(name="gamma", value="1.5")]
-            ))
-        _, _, code, details = call_validate()
+                algorithm_setting=[
+                    api_pb2.AlgorithmSetting(name="gamma", value="1.5")
+                ]
+            )
+        )
+        _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
         self.assertEqual(details, 'gamma should be in the range of (0, 1)')
 
-        experiment_spec[0] = api_pb2.ExperimentSpec(
+        experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="tpe",
-                algorithm_settings=[
-                    api_pb2.AlgorithmSetting(name="n_EI_candidates", value="0")]
-            ))
-        _, _, code, details = call_validate()
+                algorithm_setting=[
+                    api_pb2.AlgorithmSetting(name="n_EI_candidates", value="0")
+                ]
+            )
+        )
+        _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
         self.assertEqual(details, 'n_EI_candidates should be great than zero')
 
-        experiment_spec[0] = api_pb2.ExperimentSpec(
+        experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="tpe",
-                algorithm_settings=[
-                    api_pb2.AlgorithmSetting(name="random_state", value="-1")]
-            ))
-        _, _, code, details = call_validate()
+                algorithm_setting=[
+                    api_pb2.AlgorithmSetting(name="random_state", value="-1")
+                ]
+            )
+        )
+        _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
         self.assertEqual(details, 'random_state should be great or equal than zero')
 
-        experiment_spec[0] = api_pb2.ExperimentSpec(
+        experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="tpe",
-                algorithm_settings=[
-                    api_pb2.AlgorithmSetting(name="prior_weight", value="aaa")]
-            ))
-        _, _, code, details = call_validate()
+                algorithm_setting=[
+                    api_pb2.AlgorithmSetting(name="prior_weight", value="aaa")
+                ]
+            )
+        )
+        _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
         self.assertTrue(details.startswith('failed to validate prior_weight(aaa)'))
 

--- a/test/suggestion/v1beta1/test_hyperopt_service.py
+++ b/test/suggestion/v1beta1/test_hyperopt_service.py
@@ -206,7 +206,7 @@ class TestHyperopt(unittest.TestCase):
         experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="tpe",
-                algorithm_setting=[
+                algorithm_settings=[
                     api_pb2.AlgorithmSetting(
                         name="random_state",
                         value="10"
@@ -246,7 +246,7 @@ class TestHyperopt(unittest.TestCase):
         experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="random",
-                algorithm_setting=[
+                algorithm_settings=[
                     api_pb2.AlgorithmSetting(name="unknown_conf", value="1111")
                 ]
             )
@@ -260,7 +260,7 @@ class TestHyperopt(unittest.TestCase):
         experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="tpe",
-                algorithm_setting=[
+                algorithm_settings=[
                     api_pb2.AlgorithmSetting(name="gamma", value="1.5")
                 ]
             )
@@ -274,7 +274,7 @@ class TestHyperopt(unittest.TestCase):
         experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="tpe",
-                algorithm_setting=[
+                algorithm_settings=[
                     api_pb2.AlgorithmSetting(name="n_EI_candidates", value="0")
                 ]
             )
@@ -288,7 +288,7 @@ class TestHyperopt(unittest.TestCase):
         experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="tpe",
-                algorithm_setting=[
+                algorithm_settings=[
                     api_pb2.AlgorithmSetting(name="random_state", value="-1")
                 ]
             )
@@ -302,7 +302,7 @@ class TestHyperopt(unittest.TestCase):
         experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="tpe",
-                algorithm_setting=[
+                algorithm_settings=[
                     api_pb2.AlgorithmSetting(name="prior_weight", value="aaa")
                 ]
             )

--- a/test/suggestion/v1beta1/test_skopt_service.py
+++ b/test/suggestion/v1beta1/test_skopt_service.py
@@ -268,7 +268,7 @@ class TestSkopt(unittest.TestCase):
                     api_pb2.AlgorithmSetting(name="acq_func", value="unknown")]
             )
         )
-        wrong_algorithm_setting = experiment_spec[0].algorithm.algorithm_settings[0]
+        wrong_algorithm_setting = experiment_spec.algorithm.algorithm_settings[0]
 
         _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
@@ -286,7 +286,7 @@ class TestSkopt(unittest.TestCase):
                     api_pb2.AlgorithmSetting(name="acq_optimizer", value="unknown")]
             )
         )
-        wrong_algorithm_setting = experiment_spec[0].algorithm.algorithm_settings[0]
+        wrong_algorithm_setting = experiment_spec.algorithm.algorithm_settings[0]
 
         _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)

--- a/test/suggestion/v1beta1/test_skopt_service.py
+++ b/test/suggestion/v1beta1/test_skopt_service.py
@@ -20,11 +20,13 @@ import grpc_testing
 from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.suggestion.v1beta1.skopt.service import SkoptService
 
+import utils
+
 
 class TestSkopt(unittest.TestCase):
     def setUp(self):
         servicers = {
-            api_pb2.DESCRIPTOR.services_by_name['Suggestion']: SkoptService(
+            api_pb2.DESCRIPTOR.services_by_name["Suggestion"]: SkoptService(
             )
         }
 
@@ -177,8 +179,8 @@ class TestSkopt(unittest.TestCase):
 
         get_suggestion = self.test_server.invoke_unary_unary(
             method_descriptor=(api_pb2.DESCRIPTOR
-                .services_by_name['Suggestion']
-                .methods_by_name['GetSuggestions']),
+                               .services_by_name["Suggestion"]
+                               .methods_by_name["GetSuggestions"]),
             invocation_metadata={},
             request=request, timeout=1)
 
@@ -188,89 +190,87 @@ class TestSkopt(unittest.TestCase):
         self.assertEqual(2, len(response.parameter_assignments))
 
     def test_validate_algorithm_settings(self):
-        experiment_spec = [None]
-
-        def call_validate():
-            experiment = api_pb2.Experiment(name="test", spec=experiment_spec[0])
-            request = api_pb2.ValidateAlgorithmSettingsRequest(experiment=experiment)
-
-            validate_algorithm_settings = self.test_server.invoke_unary_unary(
-                method_descriptor=(api_pb2.DESCRIPTOR
-                    .services_by_name['Suggestion']
-                    .methods_by_name['ValidateAlgorithmSettings']),
-                invocation_metadata={},
-                request=request, timeout=1)
-
-            return validate_algorithm_settings.termination()
-
-        # valid cases
-        algorithm_spec = api_pb2.AlgorithmSpec(
-            algorithm_name="bayesianoptimization",
-            algorithm_settings=[
-                api_pb2.AlgorithmSetting(
-                    name="random_state",
-                    value="10"
-                )
-            ],
+        # Valid cases.
+        experiment_spec = api_pb2.ExperimentSpec(
+            algorithm=api_pb2.AlgorithmSpec(
+                algorithm_name="bayesianoptimization",
+                algorithm_settings=[
+                    api_pb2.AlgorithmSetting(
+                        name="random_state",
+                        value="10"
+                    )
+                ],
+            )
         )
-        experiment_spec[0] = api_pb2.ExperimentSpec(algorithm=algorithm_spec)
-        self.assertEqual(call_validate()[2], grpc.StatusCode.OK)
 
-        # invalid cases
-        # unknown algorithm name
-        experiment_spec[0] = api_pb2.ExperimentSpec(
-            algorithm=api_pb2.AlgorithmSpec(algorithm_name="unknown"))
-        _, _, code, details = call_validate()
+        _, _, code, _ = utils.call_validate(self.test_server, experiment_spec)
+        self.assertEqual(code, grpc.StatusCode.OK)
+
+        # Invalid cases.
+        # Unknown algorithm name.
+        experiment_spec = api_pb2.ExperimentSpec(
+            algorithm=api_pb2.AlgorithmSpec(algorithm_name="unknown")
+        )
+
+        _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
-        self.assertEqual(details, 'unknown algorithm name unknown')
+        self.assertEqual(details, "unknown algorithm name unknown")
 
-        # unknown config name
-        experiment_spec[0] = api_pb2.ExperimentSpec(
+        # Unknown config name.
+        experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="bayesianoptimization",
                 algorithm_settings=[
                     api_pb2.AlgorithmSetting(name="unknown_conf", value="1111")]
-            ))
-        _, _, code, details = call_validate()
-        self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
-        self.assertEqual(details, 'unknown setting unknown_conf for algorithm bayesianoptimization')
+            )
+        )
 
-        # unknown base_estimator
-        experiment_spec[0] = api_pb2.ExperimentSpec(
+        _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
+        self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
+        self.assertEqual(details, "unknown setting unknown_conf for algorithm bayesianoptimization")
+
+        # Unknown base_estimator
+        experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="bayesianoptimization",
                 algorithm_settings=[
                     api_pb2.AlgorithmSetting(name="base_estimator", value="unknown estimator")]
-            ))
-        _, _, code, details = call_validate()
-        wrong_algorithm_setting = experiment_spec[0].algorithm.algorithm_settings[0]
+            )
+        )
+        wrong_algorithm_setting = experiment_spec.algorithm.algorithm_settings[0]
+
+        _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
         self.assertEqual(details,
                          "{name} {value} is not supported in Bayesian optimization".format(
                              name=wrong_algorithm_setting.name,
                              value=wrong_algorithm_setting.value))
 
-        # wrong n_initial_points
-        experiment_spec[0] = api_pb2.ExperimentSpec(
+        # Wrong n_initial_points
+        experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="bayesianoptimization",
                 algorithm_settings=[
                     api_pb2.AlgorithmSetting(name="n_initial_points", value="-1")]
-            ))
-        _, _, code, details = call_validate()
-        wrong_algorithm_setting = experiment_spec[0].algorithm.algorithm_settings[0]
+            )
+        )
+        wrong_algorithm_setting = experiment_spec.algorithm.algorithm_settings[0]
+
+        _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
         self.assertEqual(details, "{name} should be great or equal than zero".format(name=wrong_algorithm_setting.name))
 
-        # unknown acq_func
-        experiment_spec[0] = api_pb2.ExperimentSpec(
+        # Unknown acq_func
+        experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="bayesianoptimization",
                 algorithm_settings=[
                     api_pb2.AlgorithmSetting(name="acq_func", value="unknown")]
-            ))
-        _, _, code, details = call_validate()
+            )
+        )
         wrong_algorithm_setting = experiment_spec[0].algorithm.algorithm_settings[0]
+
+        _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
         self.assertEqual(details,
                          "{name} {value} is not supported in Bayesian optimization".format(
@@ -278,15 +278,17 @@ class TestSkopt(unittest.TestCase):
                              value=wrong_algorithm_setting.value
                          ))
 
-        # unknown acq_optimizer
-        experiment_spec[0] = api_pb2.ExperimentSpec(
+        # Unknown acq_optimizer
+        experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="bayesianoptimization",
                 algorithm_settings=[
                     api_pb2.AlgorithmSetting(name="acq_optimizer", value="unknown")]
-            ))
-        _, _, code, details = call_validate()
+            )
+        )
         wrong_algorithm_setting = experiment_spec[0].algorithm.algorithm_settings[0]
+
+        _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
         self.assertEqual(details,
                          "{name} {value} is not supported in Bayesian optimization".format(
@@ -294,18 +296,20 @@ class TestSkopt(unittest.TestCase):
                              value=wrong_algorithm_setting.value
                          ))
 
-        # wrong random_state
-        experiment_spec[0] = api_pb2.ExperimentSpec(
+        # Wrong random_state
+        experiment_spec = api_pb2.ExperimentSpec(
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name="bayesianoptimization",
                 algorithm_settings=[
                     api_pb2.AlgorithmSetting(name="random_state", value="-1")]
-            ))
-        _, _, code, details = call_validate()
-        wrong_algorithm_setting = experiment_spec[0].algorithm.algorithm_settings[0]
+            )
+        )
+        wrong_algorithm_setting = experiment_spec.algorithm.algorithm_settings[0]
+
+        _, _, code, details = utils.call_validate(self.test_server, experiment_spec)
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
         self.assertEqual(details, "{name} should be great or equal than zero".format(name=wrong_algorithm_setting.name))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/suggestion/v1beta1/utils.py
+++ b/test/suggestion/v1beta1/utils.py
@@ -1,0 +1,18 @@
+
+from pkg.apis.manager.v1beta1.python import api_pb2
+
+
+def call_validate(test_server, experiment_spec):
+    experiment = api_pb2.Experiment(name="validation-test", spec=experiment_spec)
+
+    request = api_pb2.ValidateAlgorithmSettingsRequest(experiment=experiment)
+    validate_algorithm_settings = test_server.invoke_unary_unary(
+        method_descriptor=(api_pb2.DESCRIPTOR
+                           .services_by_name['Suggestion']
+                           .methods_by_name['ValidateAlgorithmSettings']),
+        invocation_metadata={},
+        request=request, timeout=1)
+
+    response, metadata, code, details = validate_algorithm_settings.termination()
+
+    return response, metadata, code, details


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1122.

I added validation for Chocolate Grid suggestion to check if `max_trial_count` >= all possible search space combination.
Also, I moved `call_validate()` test function to utils to use it in Chocolate also.

/assign @gaocegege @johnugeorge 
/cc @sperlingxx 