### PR TITLE
Extend gRPC controller-algorithm communication & Add Suggestion state Exhausted

### DIFF
--- a/pkg/apis/controller/suggestions/v1alpha3/suggestion_types.go
+++ b/pkg/apis/controller/suggestions/v1alpha3/suggestion_types.go
@@ -100,6 +100,7 @@ const (
 	SuggestionRunning         SuggestionConditionType = "Running"
 	SuggestionSucceeded       SuggestionConditionType = "Succeeded"
 	SuggestionFailed          SuggestionConditionType = "Failed"
+	SuggestionExhausted       SuggestionConditionType = "Exhausted"
 )
 
 // +genclient

--- a/pkg/apis/controller/suggestions/v1alpha3/util.go
+++ b/pkg/apis/controller/suggestions/v1alpha3/util.go
@@ -64,8 +64,12 @@ func (suggestion *Suggestion) IsRunning() bool {
 	return hasCondition(suggestion, SuggestionRunning)
 }
 
+func (suggestion *Suggestion) IsExhausted() bool {
+	return hasCondition(suggestion, SuggestionExhausted)
+}
+
 func (suggestion *Suggestion) IsCompleted() bool {
-	return suggestion.IsSucceeded() || suggestion.IsFailed()
+	return suggestion.IsSucceeded() || suggestion.IsFailed() || suggestion.IsExhausted()
 }
 
 func (suggestion *Suggestion) setCondition(conditionType SuggestionConditionType, status v1.ConditionStatus, reason, message string) {
@@ -110,6 +114,14 @@ func (suggestion *Suggestion) MarkSuggestionStatusFailed(reason, message string)
 		suggestion.setCondition(SuggestionRunning, v1.ConditionFalse, currentCond.Reason, currentCond.Message)
 	}
 	suggestion.setCondition(SuggestionFailed, v1.ConditionTrue, reason, message)
+}
+
+func (suggestion *Suggestion) MarkSuggestionStatusExhausted(reason, message string) {
+	currentCond := getCondition(suggestion, SuggestionRunning)
+	if currentCond != nil {
+		suggestion.setCondition(SuggestionRunning, v1.ConditionFalse, currentCond.Reason, currentCond.Message)
+	}
+	suggestion.setCondition(SuggestionExhausted, v1.ConditionTrue, reason, message)
 }
 
 func (suggestion *Suggestion) MarkSuggestionStatusDeploymentReady(status v1.ConditionStatus, reason, message string) {

--- a/pkg/controller.v1alpha3/experiment/experiment_controller.go
+++ b/pkg/controller.v1alpha3/experiment/experiment_controller.go
@@ -388,10 +388,11 @@ func (r *ReconcileExperiment) ReconcileSuggestions(instance *experimentsv1alpha3
 		return nil, err
 	} else {
 		if original != nil {
-			if original.IsFailed() {
+			activeTrials := instance.Status.TrialsPending + instance.Status.TrialsRunning
+			if original.IsFailed() && activeTrials == 0 {
 				msg := "Suggestion has failed"
 				instance.MarkExperimentStatusFailed(util.ExperimentFailedReason, msg)
-			} else {
+			} else if !original.IsFailed() {
 				suggestion := original.DeepCopy()
 				if len(suggestion.Status.Suggestions) > int(currentCount) {
 					suggestions := suggestion.Status.Suggestions

--- a/pkg/controller.v1alpha3/experiment/experiment_controller.go
+++ b/pkg/controller.v1alpha3/experiment/experiment_controller.go
@@ -389,16 +389,25 @@ func (r *ReconcileExperiment) ReconcileSuggestions(instance *experimentsv1alpha3
 	} else {
 		if original != nil {
 			activeTrials := instance.Status.TrialsPending + instance.Status.TrialsRunning
-			if original.IsFailed() && activeTrials == 0 {
-				msg := "Suggestion has failed"
-				instance.MarkExperimentStatusFailed(util.ExperimentFailedReason, msg)
-			} else if !original.IsFailed() {
+			// If Suggestion is in failed/exhausted state, wait for active trials and use all produced suggestions
+			if (original.IsFailed() || original.IsExhausted()) && activeTrials == 0 && len(original.Status.Suggestions) == int(currentCount) {
+				if original.IsFailed() {
+					instance.MarkExperimentStatusFailed(util.ExperimentFailedReason, "Suggestion has failed")
+				} else {
+					msg := "Suggestion is exhausted"
+					if instance.Spec.Objective.Goal != nil {
+						instance.MarkExperimentStatusFailed(util.ExperimentFailedReason, msg)
+					} else {
+						instance.MarkExperimentStatusSucceeded(util.ExperimentSuggestionEndReachedReason, msg)
+					}
+				}
+			} else {
 				suggestion := original.DeepCopy()
 				if len(suggestion.Status.Suggestions) > int(currentCount) {
 					suggestions := suggestion.Status.Suggestions
 					assignments = suggestions[currentCount:]
 				}
-				if suggestion.Spec.Requests != suggestionRequestsCount {
+				if !original.IsCompleted() && suggestion.Spec.Requests != suggestionRequestsCount {
 					suggestion.Spec.Requests = suggestionRequestsCount
 					if err := r.UpdateSuggestion(suggestion); err != nil {
 						return nil, err

--- a/pkg/controller.v1alpha3/suggestion/suggestion_controller.go
+++ b/pkg/controller.v1alpha3/suggestion/suggestion_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -232,8 +233,13 @@ func (r *ReconcileSuggestion) ReconcileSuggestion(instance *suggestionsv1alpha3.
 	logger.Info("Sync assignments", "suggestions", instance.Spec.Requests)
 	if err = r.SyncAssignments(instance, experiment, trials.Items); err != nil {
 		if statusCode, ok := status.FromError(err); ok {
-			logger.Error(err, "Marking suggestion failed as get suggestions rpc failed")
-			instance.MarkSuggestionStatusFailed(SuggestionFailedReason, statusCode.Message())
+			if statusCode.Code() == codes.NotFound {
+				logger.Error(err, "Marking suggestion exhausted as get suggestions rpc failed")
+				instance.MarkSuggestionStatusExhausted(SuggestionExhaustedReason, statusCode.Message())
+			} else {
+				logger.Error(err, "Marking suggestion failed as get suggestions rpc failed")
+				instance.MarkSuggestionStatusFailed(SuggestionFailedReason, statusCode.Message())
+			}
 		}
 		return err
 	}

--- a/pkg/controller.v1alpha3/suggestion/suggestion_controller_status.go
+++ b/pkg/controller.v1alpha3/suggestion/suggestion_controller_status.go
@@ -15,6 +15,7 @@ const (
 	SuggestionSucceededReason    = "SuggestionSucceeded"
 	SuggestionFailedReason       = "SuggestionFailed"
 	SuggestionKilledReason       = "SuggestionKilled"
+	SuggestionExhaustedReason    = "SuggestionExhausted"
 )
 
 func (r *ReconcileSuggestion) updateStatus(s *suggestionsv1alpha3.Suggestion, oldS *suggestionsv1alpha3.Suggestion) error {

--- a/pkg/suggestion/v1alpha3/chocolate/base_service.py
+++ b/pkg/suggestion/v1alpha3/chocolate/base_service.py
@@ -168,7 +168,10 @@ class BaseChocolateService(object):
 
         if len(list_of_assignments) > 0:
             logger.info(
-                "GetSuggestions returns {} new Trials\n\n".format(request_number))
+                "GetSuggestions returns {} new Trials\n\n".format(
+                    len(list_of_assignments)))
+        elif request_number > 0:  # Raise nothing if requested_number == 0
+            raise StopIteration("Run out of assignments")
 
         return list_of_assignments
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

This PR targets kubeflow/katib#1122 and is a first iteration on the proposed solution.

**Special notes for your reviewer**:

This PR is not ready for merging since tests are not updated accordingly. But I will update/extend tests when we get to a final iteration of this PR.

You will also notice a few commits for the experiment to accept and consume all generated suggestions. This occurs when the controller requests, let's say 3 new suggestions (because it has the room to start another 3 trials) but the algorithm service cannot generate that many.
I can submit it as a separate issue & PR if you like. Currently, the PR contains all the features that are required for our use cases and is mainly here to show you the full picture.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
**TODO:** Add release-note

```release-note

```

cc @StefanoFioravanzo @andreyvelich @gaocegege 

Adding the `hold` label. Feel free to add another label (e.g., `wip`) if you feel it suits better.
/hold
