### PR TITLE
New Trial Template validation

### DIFF
--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -128,6 +128,13 @@ const (
 	LabelTrialTemplateConfigMapName = "app"
 	// LabelTrialTemplateConfigMapValue is the label value for the Trial templates configMap
 	LabelTrialTemplateConfigMapValue = "katib-trial-templates"
+
+	// TrialTemplateReplaceFormat is the format to make substitution in Trial template from Names in TrialParameters
+	// E.g if Name = learningRate, according value in Trial template must be ${trialParameters.learningRate}
+	TrialTemplateReplaceFormat = "${trialParameters.%v}"
+
+	// TrialTemplateReplaceFormatRegex is the regex for Trial template format
+	TrialTemplateReplaceFormatRegex = "\\{trialParameters\\..+?\\}"
 )
 
 var (

--- a/pkg/controller.v1beta1/experiment/manifest/generator.go
+++ b/pkg/controller.v1beta1/experiment/manifest/generator.go
@@ -79,9 +79,11 @@ func (g *DefaultGenerator) GetRunSpecWithHyperParameters(experiment *experiments
 		return nil, fmt.Errorf("ConvertStringToUnstructured failed: %v", err)
 	}
 
+	fmt.Printf("-------------------runSpec2-------------%v", runSpec.Object)
 	// Set name and namespace for Run Spec
 	runSpec.SetName(trialName)
 	runSpec.SetNamespace(trialNamespace)
+	fmt.Printf("-------------------runSpec2-------------%v", runSpec.Object)
 
 	return runSpec, nil
 }

--- a/pkg/controller.v1beta1/experiment/manifest/generator.go
+++ b/pkg/controller.v1beta1/experiment/manifest/generator.go
@@ -79,11 +79,9 @@ func (g *DefaultGenerator) GetRunSpecWithHyperParameters(experiment *experiments
 		return nil, fmt.Errorf("ConvertStringToUnstructured failed: %v", err)
 	}
 
-	fmt.Printf("-------------------runSpec2-------------%v", runSpec.Object)
 	// Set name and namespace for Run Spec
 	runSpec.SetName(trialName)
 	runSpec.SetNamespace(trialNamespace)
-	fmt.Printf("-------------------runSpec2-------------%v", runSpec.Object)
 
 	return runSpec, nil
 }

--- a/pkg/mock/v1beta1/experiment/manifest/generator.go
+++ b/pkg/mock/v1beta1/experiment/manifest/generator.go
@@ -81,6 +81,21 @@ func (mr *MockGeneratorMockRecorder) GetSuggestionConfigData(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSuggestionConfigData", reflect.TypeOf((*MockGenerator)(nil).GetSuggestionConfigData), arg0)
 }
 
+// GetTrialTemplate mocks base method
+func (m *MockGenerator) GetTrialTemplate(arg0 *v1beta10.Experiment) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTrialTemplate", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTrialTemplate indicates an expected call of GetTrialTemplate
+func (mr *MockGeneratorMockRecorder) GetTrialTemplate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrialTemplate", reflect.TypeOf((*MockGenerator)(nil).GetTrialTemplate), arg0)
+}
+
 // InjectClient mocks base method
 func (m *MockGenerator) InjectClient(arg0 client.Client) {
 	m.ctrl.T.Helper()

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -276,7 +276,7 @@ func (g *DefaultValidator) validateSupportedJob(runSpec *unstructured.Unstructur
 			return nil
 		}
 	}
-	return fmt.Errorf("Invalid spec.TrialTemplate. Job type %v not supported", gvk)
+	return fmt.Errorf("Job type %v not supported", gvk)
 }
 
 func validatePatchJob(runSpec *unstructured.Unstructured, job interface{}, jobType string) error {
@@ -290,13 +290,13 @@ func validatePatchJob(runSpec *unstructured.Unstructured, job interface{}, jobTy
 	// Create Patch on tranformed Job (e.g: Job, TFJob) using unstructured JSON
 	runSpecPatchOperations, err := jsonPatch.CreatePatch(runSpecAfter, runSpecBefore)
 	if err != nil {
-		return fmt.Errorf("Invalid spec.TrialTemplate. Create patch error: %v", err)
+		return fmt.Errorf("Create patch error: %v", err)
 	}
 
 	for _, operation := range runSpecPatchOperations {
 		// If operation != "remove" some values from trialTemplate were not converted
 		if operation.Operation != "remove" {
-			return fmt.Errorf("Invalid spec.TrialTemplate. Unable to convert: %v - %v to %v, converted template: %v", operation.Path, operation.Value, jobType, string(runSpecAfter))
+			return fmt.Errorf("Unable to convert: %v - %v to %v, converted template: %v", operation.Path, operation.Value, jobType, string(runSpecAfter))
 		}
 	}
 

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -9,14 +9,21 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	commonapiv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
 	experimentsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
+	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/experiment/manifest"
+	util "github.com/kubeflow/katib/pkg/controller.v1beta1/util"
 	jobv1beta1 "github.com/kubeflow/katib/pkg/job/v1beta1"
 	mccommon "github.com/kubeflow/katib/pkg/metricscollector/v1beta1/common"
+	batchv1 "k8s.io/api/batch/v1"
+
+	pytorchv1 "github.com/kubeflow/pytorch-operator/pkg/apis/pytorch/v1"
+	tfv1 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1"
 )
 
 var log = logf.Log.WithName("experiment-validating-webhook")
@@ -128,40 +135,126 @@ func (g *DefaultValidator) validateResumePolicy(resume experimentsv1beta1.Resume
 	return nil
 }
 
-//TODO: Add Validation for new Trial Template
 func (g *DefaultValidator) validateTrialTemplate(instance *experimentsv1beta1.Experiment) error {
-	// trialName := fmt.Sprintf("%s-trial", instance.GetName())
-	// runSpec, err := g.GetRunSpec(instance, instance.GetName(), trialName, instance.GetNamespace())
-	// if err != nil {
-	// 	return fmt.Errorf("Invalid spec.trialTemplate: %v.", err)
-	// }
 
-	// bufSize := 1024
-	// buf := bytes.NewBufferString(runSpec)
+	trialTemplate := instance.Spec.TrialTemplate
 
-	// job := &unstructured.Unstructured{}
-	// if err := k8syaml.NewYAMLOrJSONDecoder(buf, bufSize).Decode(job); err != nil {
-	// 	return fmt.Errorf("Invalid spec.trialTemplate: %v.", err)
-	// }
+	// Check if trialParameters exists
+	if trialTemplate.TrialParameters == nil {
+		return fmt.Errorf("spec.trialTemplate.trialParameters must be specified")
+	}
 
-	// if err := g.validateSupportedJob(job); err != nil {
-	// 	return fmt.Errorf("Invalid spec.trialTemplate: %v.", err)
-	// }
+	// Check if trialSpec or configMap exists
+	if trialTemplate.TrialSource.TrialSpec == nil && trialTemplate.TrialSource.ConfigMap == nil {
+		return fmt.Errorf("spec.trialTemplate.trialSpec or spec.trialTemplate.configMap must be specified")
+	}
 
-	// if job.GetNamespace() != instance.GetNamespace() {
-	// 	return fmt.Errorf("Invalid spec.trialTemplate: metadata.namespace should be %s or {{.NameSpace}}", instance.GetNamespace())
-	// }
-	// if job.GetName() != trialName {
-	// 	return fmt.Errorf("Invalid spec.trialTemplate: metadata.name should be {{.Trial}}")
-	// }
+	// Check if trialSpec and configMap doesn't exist together
+	if trialTemplate.TrialSource.TrialSpec != nil && trialTemplate.TrialSource.ConfigMap != nil {
+		return fmt.Errorf("Only one of spec.trialTemplate.trialSpec or spec.trialTemplate.configMap can be specified")
+	}
+
+	// Check if configMap parameters are specified
+	if trialTemplate.ConfigMap != nil &&
+		(trialTemplate.TrialSource.ConfigMap.ConfigMapName == "" ||
+			trialTemplate.TrialSource.ConfigMap.ConfigMapNamespace == "" ||
+			trialTemplate.TrialSource.ConfigMap.TemplatePath == "") {
+		return fmt.Errorf("For spec.trialTemplate.configMap .configMapName and .configMapNamespace and .templatePath must be specified")
+	}
+
+	// Check if Trial template can be parsed to string
+	trialTemplateStr, err := g.GetTrialTemplate(instance)
+	if err != nil {
+		return fmt.Errorf("Unable to parse spec.trialTemplate: %v", err)
+	}
+
+	trialParametersNames := make(map[string]bool)
+	trialParametersRefs := make(map[string]bool)
+
+	for _, parameter := range trialTemplate.TrialParameters {
+		// Check if all trialParameters contain name and reference. Or name contains invalid character
+		if parameter.Name == "" || parameter.Reference == "" ||
+			strings.Index(parameter.Name, "{") != -1 || strings.Index(parameter.Name, "}") != -1 {
+			return fmt.Errorf("Invalid spec.trialTemplate.trialParameters: %v", parameter)
+		}
+
+		// Check if parameter names are not duplicated
+		if _, ok := trialParametersNames[parameter.Name]; ok {
+			return fmt.Errorf("Parameter name %v can't be duplicated in spec.trialTemplate.trialParameters: %v", parameter.Name, trialTemplate.TrialParameters)
+		}
+		// Check if parameter references are not duplicated
+		if _, ok := trialParametersRefs[parameter.Reference]; ok {
+			return fmt.Errorf("Parameter reference %v can't be duplicated in spec.trialTemplate.trialParameters: %v", parameter.Reference, trialTemplate.TrialParameters)
+		}
+		trialParametersNames[parameter.Name] = true
+		trialParametersRefs[parameter.Reference] = true
+
+		// Check if trialParameters contains all substitution for Trial template
+		if strings.Index(trialTemplateStr, fmt.Sprintf(consts.TrialTemplateReplaceFormat, parameter.Name)) == -1 {
+			return fmt.Errorf("Parameter name: %v in spec.trialParameters not found in spec.trialTemplate: %v", parameter.Name, trialTemplateStr)
+		}
+
+		trialTemplateStr = strings.Replace(trialTemplateStr, fmt.Sprintf(consts.TrialTemplateReplaceFormat, parameter.Name), "test-value", -1)
+	}
+
+	// Check if Trial template contains all substitution for trialParameters
+	substitutionRegex := regexp.MustCompile(consts.TrialTemplateReplaceFormatRegex)
+	notReplacedParams := substitutionRegex.FindAllString(trialTemplateStr, -1)
+	if len(notReplacedParams) != 0 {
+		return fmt.Errorf("Parameters: %v in spec.trialTemplate not found in spec.trialParameters: %v", notReplacedParams, trialTemplate.TrialParameters)
+	}
+
+	// Check if Trial template can be converted to unstructured
+	runSpec, err := util.ConvertStringToUnstructured(trialTemplateStr)
+	if err != nil {
+		return fmt.Errorf("Unable to convert spec.trialTemplate: %v to unstructured", trialTemplateStr)
+	}
+
+	// Check if metadata.name and metatdata.namespace is omittied
+	if runSpec.GetName() != "" || runSpec.GetNamespace() != "" {
+		return fmt.Errorf("metadata.name and metadata.namespace in spec.trialTemplate must be omitted")
+	}
+
+	// Check if ApiVersion and Kind is specified
+	if runSpec.GetAPIVersion() == "" || runSpec.GetKind() == "" {
+		return fmt.Errorf("apiVersion and kind in spec.trialTemplate must be specified")
+	}
+
+	// Check if Job is supported
+	// Check if Job can be converted to Batch Job/TFJob/PyTorchJob
+	// Not default CRDs can be omitted later
+	if err := g.validateSupportedJob(runSpec); err != nil {
+		return fmt.Errorf("Invalid spec.trialTemplate: %v", err)
+	}
+
 	return nil
 }
 
-func (g *DefaultValidator) validateSupportedJob(job *unstructured.Unstructured) error {
-	gvk := job.GroupVersionKind()
+func (g *DefaultValidator) validateSupportedJob(runSpec *unstructured.Unstructured) error {
+	gvk := runSpec.GroupVersionKind()
 	supportedJobs := jobv1beta1.SupportedJobList
 	for _, sJob := range supportedJobs {
 		if gvk == sJob {
+			switch gvk.Kind {
+			case consts.JobKindJob:
+				batchJob := &batchv1.Job{}
+				err := runtime.DefaultUnstructuredConverter.FromUnstructured(runSpec.Object, &batchJob)
+				if err != nil {
+					return fmt.Errorf("Unable to convert spec.TrialTemplate to BatchJob: %v", err)
+				}
+			case consts.JobKindTF:
+				tfJob := &tfv1.TFJob{}
+				err := runtime.DefaultUnstructuredConverter.FromUnstructured(runSpec.Object, &tfJob)
+				if err != nil {
+					return fmt.Errorf("Unable to convert spec.TrialTemplate to TFJob: %v", err)
+				}
+			case consts.JobKindPyTorch:
+				pytorchJob := &pytorchv1.PyTorchJob{}
+				err := runtime.DefaultUnstructuredConverter.FromUnstructured(runSpec.Object, &pytorchJob)
+				if err != nil {
+					return fmt.Errorf("Unable to convert spec.TrialTemplate to PyTorchJob: %v", err)
+				}
+			}
 			return nil
 		}
 	}

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -8,6 +8,10 @@ import (
 	"strconv"
 	"strings"
 
+	pytorchv1 "github.com/kubeflow/pytorch-operator/pkg/apis/pytorch/v1"
+	tfv1 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1"
+	jsonPatch "github.com/mattbaird/jsonpatch"
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -21,11 +25,6 @@ import (
 	util "github.com/kubeflow/katib/pkg/controller.v1beta1/util"
 	jobv1beta1 "github.com/kubeflow/katib/pkg/job/v1beta1"
 	mccommon "github.com/kubeflow/katib/pkg/metricscollector/v1beta1/common"
-
-	pytorchv1 "github.com/kubeflow/pytorch-operator/pkg/apis/pytorch/v1"
-	tfv1 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1"
-	jsonPatch "github.com/mattbaird/jsonpatch"
-	batchv1 "k8s.io/api/batch/v1"
 )
 
 var log = logf.Log.WithName("experiment-validating-webhook")

--- a/pkg/webhook/v1beta1/experiment/validator/validator_test.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator_test.go
@@ -2,7 +2,6 @@ package validator
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -864,7 +863,7 @@ func newFakeTrialTemplate(trialJob interface{}, trialParameters []experimentsv1b
 
 	trialSpec, err := util.ConvertObjectToUnstructured(trialJob)
 	if err != nil {
-		fmt.Errorf("ConvertObjectToUnstructured error: %v", err)
+		log.Error(err, "ConvertObjectToUnstructured error")
 	}
 
 	return &experimentsv1beta1.TrialTemplate{
@@ -879,12 +878,12 @@ func convertBatchJobToString(batchJob *batchv1.Job) string {
 
 	batchJobUnstr, err := util.ConvertObjectToUnstructured(batchJob)
 	if err != nil {
-		fmt.Errorf("ConvertObjectToUnstructured error: %v", err)
+		log.Error(err, "ConvertObjectToUnstructured error")
 	}
 
 	batchJobStr, err := util.ConvertUnstructuredToString(batchJobUnstr)
 	if err != nil {
-		fmt.Errorf("ConvertUnstructuredToString error: %v", err)
+		log.Error(err, "ConvertUnstructuredToString error")
 	}
 
 	return batchJobStr

--- a/pkg/webhook/v1beta1/experiment/validator/validator_test.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -15,8 +17,6 @@ import (
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 	util "github.com/kubeflow/katib/pkg/controller.v1beta1/util"
 	manifestmock "github.com/kubeflow/katib/pkg/mock/v1beta1/experiment/manifest"
-	batchv1 "k8s.io/api/batch/v1"
-	v1 "k8s.io/api/core/v1"
 )
 
 func init() {

--- a/test/e2e/v1beta1/invalid-experiment.yaml
+++ b/test/e2e/v1beta1/invalid-experiment.yaml
@@ -44,7 +44,8 @@ spec:
         description: Training model optimizer (sdg, adam or ftrl)
         reference: optimizer
     trialSpec:
-      apiVersion: batch/v1 # Invalid, Kind must be specified
+      apiVersion: batch/v1
+      kind: InvalidKind # Invalid Kind to check validation webhook
       spec:
         template:
           spec:


### PR DESCRIPTION
Part of: https://github.com/kubeflow/katib/issues/1208.

I added Validation for the New Trial Template. 
I believe I covered all test cases.
The most tricky part is how to validate that user specifies fully correct Job, TFJob or PyTorch Job (That all APIs are correct).

We can't just convert `unstructured` to according Kubernetes structure (e.g `batchv1.Job{}`) and convert it back to `unstructured`. And then use `DeepEqual` to compare with original.

After transforming Trial template to Kubernetes Job, some parameters will be added by default. For example, `metadata.creationTimestamp` will be `nil`. So JSON structure of original and transformed job is different.

My idea is to use JSON patch. After converting `unstructured` to Kubernetes structure we can try to use JSON patch on this structure with original `unstructured`. If all parameters from `unstructured` were transformed to Kubernetes Job, JSON patch will have only `remove` operations.

If not, we print to user which fields can't be converted.

I think that can work.

/assign @johnugeorge @gaocegege 