### PR TITLE
UI: Show all namespaces in experiment list 

### DIFF
--- a/pkg/ui/v1beta1/frontend/src/reducers/hpMonitor.js
+++ b/pkg/ui/v1beta1/frontend/src/reducers/hpMonitor.js
@@ -2,7 +2,7 @@ import * as actions from '../actions/hpMonitorActions';
 
 const initialState = {
   experimentName: '',
-  experimentNamespace: '',
+  experimentNamespace: 'All namespaces',
   filterType: {
     Created: true,
     Running: true,
@@ -27,8 +27,7 @@ const hpMonitorReducer = (state = initialState, action) => {
         job =>
           job.name.includes(action.experimentName) &&
           (job.namespace == action.experimentNamespace ||
-            action.experimentNamespace == 'All namespaces' ||
-            action.experimentNamespace.length == 0),
+            action.experimentNamespace == 'All namespaces'),
       );
       let types = Object.assign({}, state.filterType);
       var typeKeys = Object.keys(types);
@@ -51,8 +50,7 @@ const hpMonitorReducer = (state = initialState, action) => {
         job =>
           job.name.includes(state.experimentName) &&
           (job.namespace == state.experimentNamespace ||
-            state.experimentNamespace == 'All namespaces' ||
-            state.experimentNamespace.length == 0),
+            state.experimentNamespace == 'All namespaces'),
       );
       types = Object.assign({}, state.filterType);
       types[action.filter] = action.checked;
@@ -82,8 +80,7 @@ const hpMonitorReducer = (state = initialState, action) => {
           filters.includes(job.status) &&
           job.name.includes(state.experimentName) &&
           (job.namespace == state.experimentNamespace ||
-            state.experimentNamespace == 'All namespaces' ||
-            state.experimentNamespace.length == 0),
+            state.experimentNamespace == 'All namespaces'),
       );
       return {
         ...state,

--- a/pkg/ui/v1beta1/frontend/src/reducers/nasMonitor.js
+++ b/pkg/ui/v1beta1/frontend/src/reducers/nasMonitor.js
@@ -2,7 +2,7 @@ import * as actions from '../actions/nasMonitorActions';
 
 const initialState = {
   experimentName: '',
-  experimentNamespace: '',
+  experimentNamespace: 'All namespaces',
   filter: '',
   filterType: {
     Created: true,
@@ -25,8 +25,7 @@ const nasMonitorReducer = (state = initialState, action) => {
         job =>
           job.name.includes(action.experimentName) &&
           (job.namespace == action.experimentNamespace ||
-            action.experimentNamespace == 'All namespaces' ||
-            action.experimentNamespace.length == 0),
+            action.experimentNamespace == 'All namespaces'),
       );
       let types = Object.assign({}, state.filterType);
       var typeKeys = Object.keys(types);
@@ -80,8 +79,7 @@ const nasMonitorReducer = (state = initialState, action) => {
           filters.includes(job.status) &&
           job.name.includes(state.experimentName) &&
           (job.namespace == state.experimentNamespace ||
-            state.experimentNamespace == 'All namespaces' ||
-            state.experimentNamespace.length == 0),
+            state.experimentNamespace == 'All namespaces'),
       );
       return {
         ...state,


### PR DESCRIPTION
After this PR, user can view directly all namespaces when clicking on monitor, like in Trial template.
![namespace-select](https://user-images.githubusercontent.com/31112157/84906665-2894f100-b0aa-11ea-86a4-089de180b860.gif)

There will be no empty blank element.


/assign @gaocegege @johnugeorge 