### PR TITLE
Fix Trial template config map in v1beta1

### DIFF
--- a/manifests/v1beta1/katib-controller/trial-template-configmap.yaml
+++ b/manifests/v1beta1/katib-controller/trial-template-configmap.yaml
@@ -43,34 +43,34 @@ data:
           restartPolicy: Never
   pytorchJobTemplate: |-
     apiVersion: "kubeflow.org/v1"
-      kind: PyTorchJob
-      spec:
-        pytorchReplicaSpecs:
-          Master:
-            replicas: 1
-            restartPolicy: OnFailure
-            template:
-              spec:
-                containers:
-                  - name: pytorch
-                    image: gcr.io/kubeflow-ci/pytorch-dist-mnist-test:v1.0
-                    imagePullPolicy: Always
-                    command:
-                      - "python"
-                      - "/var/mnist.py"
-                      - "--lr=${trialParameters.learningRate}"
-                      - "--momentum=${trialParameters.momentum}"
-          Worker:
-            replicas: 2
-            restartPolicy: OnFailure
-            template:
-              spec:
-                containers:
-                  - name: pytorch
-                    image: gcr.io/kubeflow-ci/pytorch-dist-mnist-test:v1.0
-                    imagePullPolicy: Always
-                    command:
-                      - "python"
-                      - "/var/mnist.py"
-                      - "--lr=${trialParameters.learningRate}"
-                      - "--momentum=${trialParameters.momentum}"
+    kind: PyTorchJob
+    spec:
+      pytorchReplicaSpecs:
+        Master:
+          replicas: 1
+          restartPolicy: OnFailure
+          template:
+            spec:
+              containers:
+                - name: pytorch
+                  image: gcr.io/kubeflow-ci/pytorch-dist-mnist-test:v1.0
+                  imagePullPolicy: Always
+                  command:
+                    - "python"
+                    - "/var/mnist.py"
+                    - "--lr=${trialParameters.learningRate}"
+                    - "--momentum=${trialParameters.momentum}"
+        Worker:
+          replicas: 2
+          restartPolicy: OnFailure
+          template:
+            spec:
+              containers:
+                - name: pytorch
+                  image: gcr.io/kubeflow-ci/pytorch-dist-mnist-test:v1.0
+                  imagePullPolicy: Always
+                  command:
+                    - "python"
+                    - "/var/mnist.py"
+                    - "--lr=${trialParameters.learningRate}"
+                    - "--momentum=${trialParameters.momentum}"


### PR DESCRIPTION
I fixed indentation for PyTorch Trial Template and renamed it to `trial-template-configmap.yaml` to be consistent with `kubeflow/manifests`.

/assign @gaocegege @johnugeorge 