### PR TITLE
String type for metric values

### DIFF
--- a/pkg/apis/controller/common/v1beta1/common_types.go
+++ b/pkg/apis/controller/common/v1beta1/common_types.go
@@ -83,10 +83,10 @@ type MetricStrategy struct {
 }
 
 type Metric struct {
-	Name   string  `json:"name,omitempty"`
-	Min    float64 `json:"min,omitempty"`
-	Max    float64 `json:"max,omitempty"`
-	Latest string  `json:"latest,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Min    string `json:"min,omitempty"`
+	Max    string `json:"max,omitempty"`
+	Latest string `json:"latest,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/apis/v1beta1/openapi_generated.go
+++ b/pkg/apis/v1beta1/openapi_generated.go
@@ -212,8 +212,8 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"min": {
 							SchemaProps: spec.SchemaProps{
-								Type:   []string{"number"},
-								Format: "double",
+								Type:   []string{"string"},
+								Format: "",
 							},
 						},
 						"max": {
@@ -223,6 +223,27 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 						"latest": {
+							SchemaProps: spec.SchemaProps{
+								Type:   []string{"string"},
+								Format: "",
+							},
+						},
+					},
+				},
+			},
+			Dependencies: []string{},
+		},
+		"github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1.MetricStrategy": {
+			Schema: spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Properties: map[string]spec.Schema{
+						"name": {
+							SchemaProps: spec.SchemaProps{
+								Type:   []string{"string"},
+								Format: "",
+							},
+						},
+						"value": {
 							SchemaProps: spec.SchemaProps{
 								Type:   []string{"string"},
 								Format: "",
@@ -292,12 +313,11 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						"metricStrategies": {
 							SchemaProps: spec.SchemaProps{
 								Description: "This field is allowed to missing, experiment defaulter (webhook) will fill it.",
-								Type:        []string{"object"},
-								AdditionalProperties: &spec.SchemaOrBool{
+								Type:        []string{"array"},
+								Items: &spec.SchemaOrArray{
 									Schema: &spec.Schema{
 										SchemaProps: spec.SchemaProps{
-											Type:   []string{"string"},
-											Format: "",
+											Ref: ref("github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1.MetricStrategy"),
 										},
 									},
 								},
@@ -306,7 +326,8 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					},
 				},
 			},
-			Dependencies: []string{},
+			Dependencies: []string{
+				"github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1.MetricStrategy"},
 		},
 		"github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1.Observation": {
 			Schema: spec.Schema{
@@ -380,6 +401,37 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 			},
 			Dependencies: []string{
 				"github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1.FileSystemPath", "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1.FilterSpec", "k8s.io/api/core/v1.HTTPGetAction"},
+		},
+		"github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.ConfigMapSource": {
+			Schema: spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Description: "ConfigMapSource references the config map where Trial template is located",
+					Properties: map[string]spec.Schema{
+						"configMapName": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Name of config map where Trial template is located",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
+						"configMapNamespace": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Namespace of config map where Trial template is located",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
+						"templatePath": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Path in config map where Trial template is located",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
+					},
+				},
+			},
+			Dependencies: []string{},
 		},
 		"github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.Experiment": {
 			Schema: spec.Schema{
@@ -795,27 +847,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 			},
 			Dependencies: []string{},
 		},
-		"github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.GoTemplate": {
-			Schema: spec.Schema{
-				SchemaProps: spec.SchemaProps{
-					Properties: map[string]spec.Schema{
-						"templateSpec": {
-							SchemaProps: spec.SchemaProps{
-								Ref: ref("github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.TemplateSpec"),
-							},
-						},
-						"rawTemplate": {
-							SchemaProps: spec.SchemaProps{
-								Type:   []string{"string"},
-								Format: "",
-							},
-						},
-					},
-				},
-			},
-			Dependencies: []string{
-				"github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.TemplateSpec"},
-		},
 		"github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.GraphConfig": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
@@ -980,26 +1011,30 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 			Dependencies: []string{
 				"github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.FeasibleSpace"},
 		},
-		"github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.TemplateSpec": {
+		"github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.TrialParameterSpec": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
+					Description: "TrialParameterSpec describes parameters that must be replaced in Trial template",
 					Properties: map[string]spec.Schema{
-						"configMapName": {
+						"name": {
 							SchemaProps: spec.SchemaProps{
-								Type:   []string{"string"},
-								Format: "",
+								Description: "Name of the parameter that must be replaced in Trial template",
+								Type:        []string{"string"},
+								Format:      "",
 							},
 						},
-						"configMapNamespace": {
+						"description": {
 							SchemaProps: spec.SchemaProps{
-								Type:   []string{"string"},
-								Format: "",
+								Description: "Description of the parameter",
+								Type:        []string{"string"},
+								Format:      "",
 							},
 						},
-						"templatePath": {
+						"reference": {
 							SchemaProps: spec.SchemaProps{
-								Type:   []string{"string"},
-								Format: "",
+								Description: "Reference to the parameter in search space",
+								Type:        []string{"string"},
+								Format:      "",
 							},
 						},
 					},
@@ -1007,26 +1042,71 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 			},
 			Dependencies: []string{},
 		},
-		"github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.TrialTemplate": {
+		"github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.TrialSource": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
+					Description: "TrialSource represent the source for Trial template Only one source can be specified",
 					Properties: map[string]spec.Schema{
-						"retain": {
+						"trialSpec": {
 							SchemaProps: spec.SchemaProps{
-								Type:   []string{"boolean"},
-								Format: "",
+								Description: "TrialSpec represents Trial template in unstructured format",
+								Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured"),
 							},
 						},
-						"goTemplate": {
+						"configMap": {
 							SchemaProps: spec.SchemaProps{
-								Ref: ref("github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.GoTemplate"),
+								Description: "ConfigMap spec represents a reference to ConfigMap",
+								Ref:         ref("github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.ConfigMapSource"),
 							},
 						},
 					},
 				},
 			},
 			Dependencies: []string{
-				"github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.GoTemplate"},
+				"github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.ConfigMapSource", "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured"},
+		},
+		"github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.TrialTemplate": {
+			Schema: spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Description: "TrialTemplate describes structure of Trial template",
+					Properties: map[string]spec.Schema{
+						"retain": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Retain indicates that Trial resources must be not cleanup",
+								Type:        []string{"boolean"},
+								Format:      "",
+							},
+						},
+						"trialSpec": {
+							SchemaProps: spec.SchemaProps{
+								Description: "TrialSpec represents Trial template in unstructured format",
+								Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured"),
+							},
+						},
+						"configMap": {
+							SchemaProps: spec.SchemaProps{
+								Description: "ConfigMap spec represents a reference to ConfigMap",
+								Ref:         ref("github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.ConfigMapSource"),
+							},
+						},
+						"trialParameters": {
+							SchemaProps: spec.SchemaProps{
+								Description: "List of parameres that are used in Trial template",
+								Type:        []string{"array"},
+								Items: &spec.SchemaOrArray{
+									Schema: &spec.Schema{
+										SchemaProps: spec.SchemaProps{
+											Ref: ref("github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.TrialParameterSpec"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Dependencies: []string{
+				"github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.ConfigMapSource", "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1.TrialParameterSpec", "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured"},
 		},
 		"github.com/kubeflow/katib/pkg/apis/controller/suggestions/v1beta1.Suggestion": {
 			Schema: spec.Schema{
@@ -1454,8 +1534,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						"runSpec": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Raw text for the trial run spec. This can be any generic Kubernetes runtime object. The trial operator should create the resource as written, and let the corresponding resource controller (e.g. tf-operator) handle the rest.",
-								Type:        []string{"string"},
-								Format:      "",
+								Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured"),
 							},
 						},
 						"retainRun": {
@@ -1476,7 +1555,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 				},
 			},
 			Dependencies: []string{
-				"github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1.MetricsCollectorSpec", "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1.ObjectiveSpec", "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1.ParameterAssignment"},
+				"github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1.MetricsCollectorSpec", "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1.ObjectiveSpec", "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1.ParameterAssignment", "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured.Unstructured"},
 		},
 		"github.com/kubeflow/katib/pkg/apis/controller/trials/v1beta1.TrialStatus": {
 			Schema: spec.Schema{

--- a/pkg/apis/v1beta1/swagger.json
+++ b/pkg/apis/v1beta1/swagger.json
@@ -268,7 +268,7 @@
         },
         "runSpec": {
           "description": "Raw text for the trial run spec. This can be any generic Kubernetes runtime object. The trial operator should create the resource as written, and let the corresponding resource controller (e.g. tf-operator) handle the rest.",
-          "type": "string"
+          "$ref": "#/definitions/v1.unstructured.Unstructured"
         }
       }
     },
@@ -336,6 +336,23 @@
           "$ref": "#/definitions/v1.Container"
         },
         "kind": {
+          "type": "string"
+        }
+      }
+    },
+    "v1beta1.ConfigMapSource": {
+      "description": "ConfigMapSource references the config map where Trial template is located",
+      "properties": {
+        "configMapName": {
+          "description": "Name of config map where Trial template is located",
+          "type": "string"
+        },
+        "configMapNamespace": {
+          "description": "Namespace of config map where Trial template is located",
+          "type": "string"
+        },
+        "templatePath": {
+          "description": "Path in config map where Trial template is located",
           "type": "string"
         }
       }
@@ -627,16 +644,6 @@
         }
       }
     },
-    "v1beta1.GoTemplate": {
-      "properties": {
-        "rawTemplate": {
-          "type": "string"
-        },
-        "templateSpec": {
-          "$ref": "#/definitions/v1beta1.TemplateSpec"
-        }
-      }
-    },
     "v1beta1.GraphConfig": {
       "description": "GraphConfig contains a config of DAG",
       "properties": {
@@ -666,14 +673,22 @@
           "type": "string"
         },
         "max": {
-          "type": "number",
-          "format": "double"
+          "type": "string"
         },
         "min": {
-          "type": "number",
-          "format": "double"
+          "type": "string"
         },
         "name": {
+          "type": "string"
+        }
+      }
+    },
+    "v1beta1.MetricStrategy": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
           "type": "string"
         }
       }
@@ -717,9 +732,9 @@
         },
         "metricStrategies": {
           "description": "This field is allowed to missing, experiment defaulter (webhook) will fill it.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v1beta1.MetricStrategy"
           }
         },
         "objectiveMetricName": {
@@ -821,26 +836,57 @@
         }
       }
     },
-    "v1beta1.TemplateSpec": {
+    "v1beta1.TrialParameterSpec": {
+      "description": "TrialParameterSpec describes parameters that must be replaced in Trial template",
       "properties": {
-        "configMapName": {
+        "description": {
+          "description": "Description of the parameter",
           "type": "string"
         },
-        "configMapNamespace": {
+        "name": {
+          "description": "Name of the parameter that must be replaced in Trial template",
           "type": "string"
         },
-        "templatePath": {
+        "reference": {
+          "description": "Reference to the parameter in search space",
           "type": "string"
         }
       }
     },
-    "v1beta1.TrialTemplate": {
+    "v1beta1.TrialSource": {
+      "description": "TrialSource represent the source for Trial template Only one source can be specified",
       "properties": {
-        "goTemplate": {
-          "$ref": "#/definitions/v1beta1.GoTemplate"
+        "configMap": {
+          "description": "ConfigMap spec represents a reference to ConfigMap",
+          "$ref": "#/definitions/v1beta1.ConfigMapSource"
+        },
+        "trialSpec": {
+          "description": "TrialSpec represents Trial template in unstructured format",
+          "$ref": "#/definitions/v1.unstructured.Unstructured"
+        }
+      }
+    },
+    "v1beta1.TrialTemplate": {
+      "description": "TrialTemplate describes structure of Trial template",
+      "properties": {
+        "configMap": {
+          "description": "ConfigMap spec represents a reference to ConfigMap",
+          "$ref": "#/definitions/v1beta1.ConfigMapSource"
         },
         "retain": {
+          "description": "Retain indicates that Trial resources must be not cleanup",
           "type": "boolean"
+        },
+        "trialParameters": {
+          "description": "List of parameres that are used in Trial template",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v1beta1.TrialParameterSpec"
+          }
+        },
+        "trialSpec": {
+          "description": "TrialSpec represents Trial template in unstructured format",
+          "$ref": "#/definitions/v1.unstructured.Unstructured"
         }
       }
     }

--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -135,6 +135,9 @@ const (
 
 	// TrialTemplateReplaceFormatRegex is the regex for Trial template format
 	TrialTemplateReplaceFormatRegex = "\\{trialParameters\\..+?\\}"
+
+	// UnavailableMetricValue is the value when metric was not reported or metric value can't be converted to float64
+	UnavailableMetricValue = "unavailable"
 )
 
 var (

--- a/pkg/controller.v1beta1/suggestion/suggestionclient/suggestionclient.go
+++ b/pkg/controller.v1beta1/suggestion/suggestionclient/suggestionclient.go
@@ -3,7 +3,6 @@ package suggestionclient
 import (
 	"context"
 	"fmt"
-	"math"
 	"time"
 
 	"google.golang.org/grpc"
@@ -18,6 +17,7 @@ import (
 	suggestionsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/suggestions/v1beta1"
 	trialsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/trials/v1beta1"
 	suggestionapi "github.com/kubeflow/katib/pkg/apis/manager/v1beta1"
+	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -267,20 +267,18 @@ func convertTrialObservation(strategies []commonapiv1beta1.MetricStrategy, obser
 			var value string
 			switch strategy, _ := strategyMap[m.Name]; strategy {
 			case commonapiv1beta1.ExtractByMin:
-				if math.IsNaN(m.Min) {
+				if m.Min == consts.UnavailableMetricValue {
 					value = m.Latest
 				} else {
-					value = fmt.Sprintf("%f", m.Min)
+					value = m.Min
 				}
 			case commonapiv1beta1.ExtractByMax:
-				if math.IsNaN(m.Max) {
+				if m.Max == consts.UnavailableMetricValue {
 					value = m.Latest
 				} else {
-					value = fmt.Sprintf("%f", m.Max)
+					value = m.Max
 				}
 			case commonapiv1beta1.ExtractByLatest:
-				value = m.Latest
-			default:
 				value = m.Latest
 			}
 			resObservation.Metrics = append(resObservation.Metrics, &suggestionapi.Metric{
@@ -289,7 +287,6 @@ func convertTrialObservation(strategies []commonapiv1beta1.MetricStrategy, obser
 			})
 		}
 	}
-
 	return resObservation
 }
 

--- a/pkg/controller.v1beta1/trial/trial_controller_test.go
+++ b/pkg/controller.v1beta1/trial/trial_controller_test.go
@@ -280,11 +280,11 @@ func TestGetObjectiveMetricValue(t *testing.T) {
 	errMetric, accMetric, err := getMetricsFromLogs(metricStrategies)
 	g.Expect(err).ShouldNot(gomega.HaveOccurred())
 	g.Expect(errMetric.Latest).To(gomega.Equal("0.07"))
-	g.Expect(errMetric.Max).To(gomega.Equal(0.1))
-	g.Expect(errMetric.Min).To(gomega.Equal(0.01))
+	g.Expect(errMetric.Max).To(gomega.Equal("0.1"))
+	g.Expect(errMetric.Min).To(gomega.Equal("0.01"))
 	g.Expect(accMetric.Latest).To(gomega.Equal("0.67"))
-	g.Expect(accMetric.Max).To(gomega.Equal(0.72))
-	g.Expect(accMetric.Min).To(gomega.Equal(0.6))
+	g.Expect(accMetric.Max).To(gomega.Equal("0.72"))
+	g.Expect(accMetric.Min).To(gomega.Equal("0.6"))
 }
 
 func newFakeTrialWithTFJob() *trialsv1beta1.Trial {

--- a/pkg/controller.v1beta1/trial/trial_controller_util.go
+++ b/pkg/controller.v1beta1/trial/trial_controller_util.go
@@ -130,7 +130,7 @@ func isTrialObservationAvailable(instance *trialsv1beta1.Trial) bool {
 	objectiveMetricName := instance.Spec.Objective.ObjectiveMetricName
 	if instance.Status.Observation != nil && instance.Status.Observation.Metrics != nil {
 		for _, metric := range instance.Status.Observation.Metrics {
-			if metric.Name == objectiveMetricName {
+			if metric.Name == objectiveMetricName && metric.Latest != consts.UnavailableMetricValue {
 				return true
 			}
 		}

--- a/test/e2e/v1beta1/resume-e2e-experiment.go
+++ b/test/e2e/v1beta1/resume-e2e-experiment.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strconv"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -20,6 +21,7 @@ import (
 
 	commonv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
 	experimentsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
+	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 	controllerUtil "github.com/kubeflow/katib/pkg/controller.v1beta1/util"
 	"github.com/kubeflow/katib/pkg/util/v1beta1/katibclient"
 )
@@ -142,9 +144,12 @@ func main() {
 	if exp.Spec.Objective.Goal != nil {
 		goal = *exp.Spec.Objective.Goal
 	}
-	if (exp.Spec.Objective.Goal != nil && objectiveType == commonv1beta1.ObjectiveTypeMinimize && metric.Min < goal) ||
-		(exp.Spec.Objective.Goal != nil && objectiveType == commonv1beta1.ObjectiveTypeMaximize && metric.Max > goal) {
-		log.Print("Objective Goal reached")
+	// If min metric is set, max be set also
+	minMetric, err := strconv.ParseFloat(metric.Min, 64)
+	maxMetric, _ := strconv.ParseFloat(metric.Max, 64)
+	if err == nil &&
+		((exp.Spec.Objective.Goal != nil && objectiveType == commonv1beta1.ObjectiveTypeMinimize && metric.Min != consts.UnavailableMetricValue && minMetric < goal) ||
+			(exp.Spec.Objective.Goal != nil && objectiveType == commonv1beta1.ObjectiveTypeMaximize && metric.Max != consts.UnavailableMetricValue && maxMetric > goal)) {
 	} else {
 
 		if exp.Status.Trials != *exp.Spec.MaxTrialCount {

--- a/test/e2e/v1beta1/resume-e2e-experiment.go
+++ b/test/e2e/v1beta1/resume-e2e-experiment.go
@@ -21,7 +21,6 @@ import (
 
 	commonv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
 	experimentsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
-	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 	controllerUtil "github.com/kubeflow/katib/pkg/controller.v1beta1/util"
 	"github.com/kubeflow/katib/pkg/util/v1beta1/katibclient"
 )
@@ -148,8 +147,8 @@ func main() {
 	minMetric, err := strconv.ParseFloat(metric.Min, 64)
 	maxMetric, _ := strconv.ParseFloat(metric.Max, 64)
 	if err == nil &&
-		((exp.Spec.Objective.Goal != nil && objectiveType == commonv1beta1.ObjectiveTypeMinimize && metric.Min != consts.UnavailableMetricValue && minMetric < goal) ||
-			(exp.Spec.Objective.Goal != nil && objectiveType == commonv1beta1.ObjectiveTypeMaximize && metric.Max != consts.UnavailableMetricValue && maxMetric > goal)) {
+		((exp.Spec.Objective.Goal != nil && objectiveType == commonv1beta1.ObjectiveTypeMinimize && minMetric < goal) ||
+			(exp.Spec.Objective.Goal != nil && objectiveType == commonv1beta1.ObjectiveTypeMaximize && maxMetric > goal)) {
 	} else {
 
 		if exp.Status.Trials != *exp.Spec.MaxTrialCount {

--- a/test/e2e/v1beta1/run-e2e-experiment.go
+++ b/test/e2e/v1beta1/run-e2e-experiment.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strconv"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -20,6 +21,7 @@ import (
 
 	commonv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
 	experimentsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
+	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 	controllerUtil "github.com/kubeflow/katib/pkg/controller.v1beta1/util"
 	"github.com/kubeflow/katib/pkg/util/v1beta1/katibclient"
 )
@@ -125,8 +127,12 @@ func main() {
 	if exp.Spec.Objective.Goal != nil {
 		goal = *exp.Spec.Objective.Goal
 	}
-	if (exp.Spec.Objective.Goal != nil && objectiveType == commonv1beta1.ObjectiveTypeMinimize && metric.Min < goal) ||
-		(exp.Spec.Objective.Goal != nil && objectiveType == commonv1beta1.ObjectiveTypeMaximize && metric.Max > goal) {
+	// If min metric is set, max be set also
+	minMetric, err := strconv.ParseFloat(metric.Min, 64)
+	maxMetric, _ := strconv.ParseFloat(metric.Max, 64)
+	if err == nil &&
+		((exp.Spec.Objective.Goal != nil && objectiveType == commonv1beta1.ObjectiveTypeMinimize && metric.Min != consts.UnavailableMetricValue && minMetric < goal) ||
+			(exp.Spec.Objective.Goal != nil && objectiveType == commonv1beta1.ObjectiveTypeMaximize && metric.Max != consts.UnavailableMetricValue && maxMetric > goal)) {
 		log.Print("Objective Goal reached")
 	} else {
 

--- a/test/e2e/v1beta1/run-e2e-experiment.go
+++ b/test/e2e/v1beta1/run-e2e-experiment.go
@@ -21,7 +21,6 @@ import (
 
 	commonv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
 	experimentsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
-	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 	controllerUtil "github.com/kubeflow/katib/pkg/controller.v1beta1/util"
 	"github.com/kubeflow/katib/pkg/util/v1beta1/katibclient"
 )
@@ -131,8 +130,8 @@ func main() {
 	minMetric, err := strconv.ParseFloat(metric.Min, 64)
 	maxMetric, _ := strconv.ParseFloat(metric.Max, 64)
 	if err == nil &&
-		((exp.Spec.Objective.Goal != nil && objectiveType == commonv1beta1.ObjectiveTypeMinimize && metric.Min != consts.UnavailableMetricValue && minMetric < goal) ||
-			(exp.Spec.Objective.Goal != nil && objectiveType == commonv1beta1.ObjectiveTypeMaximize && metric.Max != consts.UnavailableMetricValue && maxMetric > goal)) {
+		((exp.Spec.Objective.Goal != nil && objectiveType == commonv1beta1.ObjectiveTypeMinimize && minMetric < goal) ||
+			(exp.Spec.Objective.Goal != nil && objectiveType == commonv1beta1.ObjectiveTypeMaximize && maxMetric > goal)) {
 		log.Print("Objective Goal reached")
 	} else {
 


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1227.

I changed metric value from `float64` to `string`.
If metrics can't be reported, `unavailable` value will be recorded.

I added condition that `metric.Latest` can't be `unavailable` here: https://github.com/andreyvelich/katib/blob/cd6b37b3614cd226781c0feac1dcf6d568d07f01/pkg/controller.v1beta1/trial/trial_controller_util.go#L133-L135.
If **Objective** metric values were not reported, Trial will be in `False` status and `Succeeded` condition with this message:
`Warning  MetricsUnavailable  2m11s (x2 over 2m11s)  trial-controller  Metrics are not available for Job`.

Experiment will be still running and waiting until at least one **Objective** metric value will be reported.

I think it is correct workflow, since user can see that **Objective** metric is not printed by training container, modify the training container image and manually restart the Trial, by deleting appropriate BatchJob, TFJob, etc.. .

What do you think @sperlingxx @gaocegege @johnugeorge ?

/assign @gaocegege @johnugeorge @sperlingxx 
