### PR TITLE
Fix Trial parameter name for v1beta1 DARTS example

### DIFF
--- a/examples/v1beta1/nas/darts-example-gpu.yaml
+++ b/examples/v1beta1/nas/darts-example-gpu.yaml
@@ -65,7 +65,7 @@ spec:
         description: Search Space of DARTS Experiment
         reference: search-space
       - name: numberLayers
-        description: Number of layers of Neural Network
+        description: Number of Neural Network layers
         reference: num-layers
     trialSpec:
       apiVersion: batch/v1

--- a/examples/v1beta1/nas/darts-example-gpu.yaml
+++ b/examples/v1beta1/nas/darts-example-gpu.yaml
@@ -64,9 +64,9 @@ spec:
       - name: searchSpace
         description: Search Space of DARTS Experiment
         reference: search-space
-      - name: num-layers
+      - name: numberLayers
         description: Number of layers of Neural Network
-        reference: numberLayers
+        reference: num-layers
     trialSpec:
       apiVersion: batch/v1
       kind: Job


### PR DESCRIPTION
There was a mistake in Trial parameter name for DARTS example.
/cc @johnugeorge @gaocegege 