### PR TITLE
controllers watch katib objects with specific APIVersion 

### DIFF
--- a/pkg/controller.v1alpha3/consts/const.go
+++ b/pkg/controller.v1alpha3/consts/const.go
@@ -136,6 +136,9 @@ const (
 	LabelTrialTemplateConfigMapName = "app"
 	// LabelTrialTemplateConfigMapValue is the label value for the Trial templates configMap
 	LabelTrialTemplateConfigMapValue = "katib-trial-templates"
+
+	// APIVersion of katib CRD which controllers watch, to avoid controllers watching objects with wrong version.
+	APIVersionToWatch = "kubeflow.org/v1alpha3"
 )
 
 var (

--- a/pkg/controller.v1alpha3/experiment/experiment_controller.go
+++ b/pkg/controller.v1alpha3/experiment/experiment_controller.go
@@ -115,8 +115,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 // addWatch adds a new Controller to mgr with r as the reconcile.Reconciler
 func addWatch(mgr manager.Manager, c controller.Controller) error {
+	experimentType := experimentsv1alpha3.Experiment{}
+	experimentType.APIVersion = consts.APIVersionToWatch
+	trialType := trialsv1alpha3.Trial{}
+	trialType.APIVersion = consts.APIVersionToWatch
+	suggestionType := suggestionsv1alpha3.Suggestion{}
+	suggestionType.APIVersion = consts.APIVersionToWatch
+
 	// Watch for changes to Experiment
-	err := c.Watch(&source.Kind{Type: &experimentsv1alpha3.Experiment{}}, &handler.EnqueueRequestForObject{})
+	err := c.Watch(&source.Kind{Type: &experimentType}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		log.Error(err, "Experiment watch failed")
 		return err
@@ -124,10 +131,10 @@ func addWatch(mgr manager.Manager, c controller.Controller) error {
 
 	// Watch for trials for the experiments
 	err = c.Watch(
-		&source.Kind{Type: &trialsv1alpha3.Trial{}},
+		&source.Kind{Type: &trialType},
 		&handler.EnqueueRequestForOwner{
 			IsController: true,
-			OwnerType:    &experimentsv1alpha3.Experiment{},
+			OwnerType:    &experimentType,
 		})
 
 	if err != nil {
@@ -136,10 +143,10 @@ func addWatch(mgr manager.Manager, c controller.Controller) error {
 	}
 
 	err = c.Watch(
-		&source.Kind{Type: &suggestionsv1alpha3.Suggestion{}},
+		&source.Kind{Type: &suggestionType},
 		&handler.EnqueueRequestForOwner{
 			IsController: true,
-			OwnerType:    &experimentsv1alpha3.Experiment{},
+			OwnerType:    &experimentType,
 		})
 
 	if err != nil {

--- a/pkg/controller.v1alpha3/suggestion/suggestion_controller.go
+++ b/pkg/controller.v1alpha3/suggestion/suggestion_controller.go
@@ -75,6 +75,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	suggestionType := suggestionsv1alpha3.Suggestion{}
+	suggestionType.APIVersion = consts.APIVersionToWatch
+
 	err = c.Watch(&source.Kind{Type: &suggestionsv1alpha3.Suggestion{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		return err
@@ -82,7 +85,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	err = c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
-		OwnerType:    &suggestionsv1alpha3.Suggestion{},
+		OwnerType:    &suggestionType,
 	})
 	if err != nil {
 		return err
@@ -90,7 +93,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	err = c.Watch(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
-		OwnerType:    &suggestionsv1alpha3.Suggestion{},
+		OwnerType:    &suggestionType,
 	})
 	if err != nil {
 		return err

--- a/pkg/controller.v1alpha3/trial/trial_controller.go
+++ b/pkg/controller.v1alpha3/trial/trial_controller.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/kubeflow/katib/pkg/controller.v1alpha3/consts"
 
 	batchv1beta "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -86,8 +87,11 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	trialType := trialsv1alpha3.Trial{}
+	trialType.APIVersion = consts.APIVersionToWatch
+
 	// Watch for changes to Trial
-	err = c.Watch(&source.Kind{Type: &trialsv1alpha3.Trial{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(&source.Kind{Type: &trialType}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		log.Error(err, "Trial watch error")
 		return err
@@ -98,7 +102,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		&source.Kind{Type: &batchv1beta.CronJob{}},
 		&handler.EnqueueRequestForOwner{
 			IsController: true,
-			OwnerType:    &trialsv1alpha3.Trial{},
+			OwnerType:    &trialType,
 		})
 
 	if err != nil {
@@ -113,7 +117,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			&source.Kind{Type: unstructuredJob},
 			&handler.EnqueueRequestForOwner{
 				IsController: true,
-				OwnerType:    &trialsv1alpha3.Trial{},
+				OwnerType:    &trialType,
 			})
 		if err != nil {
 			if meta.IsNoMatchError(err) {

--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -146,6 +146,9 @@ const (
 
 	// UnavailableMetricValue is the value when metric was not reported or metric value can't be converted to float64
 	UnavailableMetricValue = "unavailable"
+
+	// APIVersion of katib CRD which controllers watch, to avoid controllers watching objects with wrong version.
+	APIVersionToWatch = "kubeflow.org/v1beta1"
 )
 
 var (

--- a/pkg/controller.v1beta1/experiment/experiment_controller.go
+++ b/pkg/controller.v1beta1/experiment/experiment_controller.go
@@ -111,8 +111,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 // addWatch adds a new Controller to mgr with r as the reconcile.Reconciler
 func addWatch(mgr manager.Manager, c controller.Controller) error {
+	experimentType := experimentsv1beta1.Experiment{}
+	experimentType.APIVersion = consts.APIVersionToWatch
+	trialType := trialsv1beta1.Trial{}
+	trialType.APIVersion = consts.APIVersionToWatch
+	suggestionType := suggestionsv1beta1.Suggestion{}
+	suggestionType.APIVersion = consts.APIVersionToWatch
+
 	// Watch for changes to Experiment
-	err := c.Watch(&source.Kind{Type: &experimentsv1beta1.Experiment{}}, &handler.EnqueueRequestForObject{})
+	err := c.Watch(&source.Kind{Type: &experimentType}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		log.Error(err, "Experiment watch failed")
 		return err
@@ -120,10 +127,10 @@ func addWatch(mgr manager.Manager, c controller.Controller) error {
 
 	// Watch for trials for the experiments
 	err = c.Watch(
-		&source.Kind{Type: &trialsv1beta1.Trial{}},
+		&source.Kind{Type: &trialType},
 		&handler.EnqueueRequestForOwner{
 			IsController: true,
-			OwnerType:    &experimentsv1beta1.Experiment{},
+			OwnerType:    &experimentType,
 		})
 
 	if err != nil {
@@ -132,10 +139,10 @@ func addWatch(mgr manager.Manager, c controller.Controller) error {
 	}
 
 	err = c.Watch(
-		&source.Kind{Type: &suggestionsv1beta1.Suggestion{}},
+		&source.Kind{Type: &suggestionType},
 		&handler.EnqueueRequestForOwner{
 			IsController: true,
-			OwnerType:    &experimentsv1beta1.Experiment{},
+			OwnerType:    &experimentType,
 		})
 
 	if err != nil {

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller.go
@@ -75,14 +75,17 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	err = c.Watch(&source.Kind{Type: &suggestionsv1beta1.Suggestion{}}, &handler.EnqueueRequestForObject{})
+	suggestionType := suggestionsv1beta1.Suggestion{}
+	suggestionType.APIVersion = consts.APIVersionToWatch
+
+	err = c.Watch(&source.Kind{Type: &suggestionType}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		return err
 	}
 
 	err = c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
-		OwnerType:    &suggestionsv1beta1.Suggestion{},
+		OwnerType:    &suggestionType,
 	})
 	if err != nil {
 		return err
@@ -90,7 +93,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	err = c.Watch(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
-		OwnerType:    &suggestionsv1beta1.Suggestion{},
+		OwnerType:    &suggestionType,
 	})
 	if err != nil {
 		return err

--- a/pkg/controller.v1beta1/trial/trial_controller.go
+++ b/pkg/controller.v1beta1/trial/trial_controller.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	trialsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/trials/v1beta1"
+	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/trial/managerclient"
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/util"
 	jobv1beta1 "github.com/kubeflow/katib/pkg/job/v1beta1"
@@ -84,8 +85,11 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	trialType := trialsv1beta1.Trial{}
+	trialType.APIVersion = consts.APIVersionToWatch
+
 	// Watch for changes to Trial
-	err = c.Watch(&source.Kind{Type: &trialsv1beta1.Trial{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(&source.Kind{Type: &trialType}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		log.Error(err, "Trial watch error")
 		return err
@@ -96,7 +100,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		&source.Kind{Type: &batchv1beta.CronJob{}},
 		&handler.EnqueueRequestForOwner{
 			IsController: true,
-			OwnerType:    &trialsv1beta1.Trial{},
+			OwnerType:    &trialType,
 		})
 
 	if err != nil {
@@ -111,7 +115,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			&source.Kind{Type: unstructuredJob},
 			&handler.EnqueueRequestForOwner{
 				IsController: true,
-				OwnerType:    &trialsv1beta1.Trial{},
+				OwnerType:    &trialType,
 			})
 		if err != nil {
 			if meta.IsNoMatchError(err) {
@@ -123,7 +127,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			log.Info("Job watch added successfully", "CRD Kind", gvk.Kind)
 		}
 	}
-	log.Info("Trial  controller created")
+	log.Info("Trial controller created")
 	return nil
 }
 


### PR DESCRIPTION
For now, both v1alpha3 and v1beta1 controllers can watch katib objects(experiments/suggestions/trials) of all versions. It will cause objects being watched by controller who is responsible for other versions. The problem occurs when we deploy both v1alpha3 controller and v1beta1 controller in same cluster. In my opinion, to update katib from v1alpha3 to v1beta1 without breaking existing workloads,  it is essential to deploy katib controllers of multiple versions in same cluster.

cc @andreyvelich @gaocegege @johnugeorge 