### PR TITLE
Fix paths in prow config

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -11,9 +11,10 @@ workflows:
       - pkg/apis/controller/experiments/v1alpha3/*
       - pkg/apis/controller/trials/v1alpha3/*
       - pkg/apis/controller/suggestions/v1alpha3/*
-      - pkg/apis/controller/*.go
+      - pkg/apis/controller/a*.go
       - pkg/apis/manager/health/*
       - pkg/apis/manager/v1alpha3/*
+      - pkg/apis/v1alpha3/*
       - pkg/common/v1alpha3/*
       - pkg/controller.v1alpha3/*
       - pkg/db/v1alpha3/*
@@ -34,10 +35,11 @@ workflows:
       - cmd/suggestion/skopt/v1alpha3/*
       - cmd/suggestion/goptuna/v1alpha3/*
       - cmd/ui/v1alpha3/*
-      - examples/v1alpha3/*.yaml
-      - examples/v1alpha3/nas/*
+      - examples/v1alpha3/*
       - test/e2e/v1alpha3/*
       - test/scripts/v1alpha3/*
+      - test/suggestion/v1alpha3/*
+      - test/unit/v1alpha3/*
       - test/workflows/*
       - manifests/v1alpha3/*
       - scripts/v1alpha3/*
@@ -54,9 +56,10 @@ workflows:
       - pkg/apis/controller/experiments/v1alpha3/*
       - pkg/apis/controller/trials/v1alpha3/*
       - pkg/apis/controller/suggestions/v1alpha3/*
-      - pkg/apis/controller/*.go
+      - pkg/apis/controller/a*.go
       - pkg/apis/manager/health/*
       - pkg/apis/manager/v1alpha3/*
+      - pkg/apis/v1alpha3/*
       - pkg/common/v1alpha3/*
       - pkg/controller.v1alpha3/*
       - pkg/db/v1alpha3/*
@@ -77,10 +80,11 @@ workflows:
       - cmd/suggestion/skopt/v1alpha3/*
       - cmd/suggestion/goptuna/v1alpha3/*
       - cmd/ui/v1alpha3/*
-      - examples/v1alpha3/*.yaml
-      - examples/v1alpha3/nas/*
+      - examples/v1alpha3/*
       - test/e2e/v1alpha3/*
       - test/scripts/v1alpha3/*
+      - test/suggestion/v1alpha3/*
+      - test/unit/v1alpha3/*
       - test/workflows/*
       - manifests/v1alpha3/*
       - scripts/v1alpha3/*
@@ -97,9 +101,10 @@ workflows:
       - pkg/apis/controller/experiments/v1beta1/*
       - pkg/apis/controller/trials/v1beta1/*
       - pkg/apis/controller/suggestions/v1beta1/*
-      - pkg/apis/controller/*.go
+      - pkg/apis/controller/a*.go
       - pkg/apis/manager/health/*
       - pkg/apis/manager/v1beta1/*
+      - pkg/apis/v1beta1/*
       - pkg/common/v1beta1/*
       - pkg/controller.v1beta1/*
       - pkg/db/v1beta1/*
@@ -120,10 +125,11 @@ workflows:
       - cmd/suggestion/skopt/v1beta1/*
       - cmd/suggestion/goptuna/v1beta1/*
       - cmd/ui/v1beta1/*
-      - examples/v1beta1/*.yaml
-      - examples/v1beta1/nas/*
+      - examples/v1beta1/*
       - test/e2e/v1beta1/*
       - test/scripts/v1beta1/*
+      - test/suggestion/v1beta1/*
+      - test/unit/v1beta1/*
       - test/workflows/*
       - manifests/v1beta1/*
       - scripts/v1beta1/*
@@ -140,9 +146,10 @@ workflows:
       - pkg/apis/controller/experiments/v1beta1/*
       - pkg/apis/controller/trials/v1beta1/*
       - pkg/apis/controller/suggestions/v1beta1/*
-      - pkg/apis/controller/*.go
+      - pkg/apis/controller/a*.go
       - pkg/apis/manager/health/*
       - pkg/apis/manager/v1beta1/*
+      - pkg/apis/v1beta1/*
       - pkg/common/v1beta1/*
       - pkg/controller.v1beta1/*
       - pkg/db/v1beta1/*
@@ -163,10 +170,11 @@ workflows:
       - cmd/suggestion/skopt/v1beta1/*
       - cmd/suggestion/goptuna/v1beta1/*
       - cmd/ui/v1beta1/*
-      - examples/v1beta1/*.yaml
-      - examples/v1beta1/nas/*
+      - examples/v1beta1/*
       - test/e2e/v1beta1/*
       - test/scripts/v1beta1/*
+      - test/suggestion/v1beta1/*
+      - test/unit/v1beta1/*
       - test/workflows/*
       - manifests/v1beta1/*
       - scripts/v1beta1/*


### PR DESCRIPTION
I made few changes in prow to not trigger v1alpha3 workflow when we make changes in v1beta1:

1. Changed to `pkg/apis/controller/a*.go`. `pkg/apis/controller/*.go` was triggering workflow for any changes in `.go` files under `pkg/apis/controller` dir. 
Here is an example: https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kubeflow_katib/1140/kubeflow-katib-presubmit/1271359897765679104/. `Triggering workflow e2e-v1alpha3 because pkg/apis/controller/common/v1beta1/common_types.go in dir pkg/apis/controller/*.go is modified.`
2. Added `pkg/apis/v1alpha3/*`.
3. Changed to `examples/v1alpha3/*`, I think we should trigger workflow if we make changes in Training containers examples.
4. To trigger correct test for `test/workflows/components/workflows-<version>.libsonnet` we can wait until https://github.com/kubeflow/testing/issues/585 will be done. For now we can keep  `test/workflows/*`

/assign @johnugeorge @gaocegege 