### PR TITLE
support trial meta injection in trial template rendering

### DIFF
--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -152,9 +152,9 @@ const (
 	TrialTemplateMetaReplaceFormatRegex = "\\{trialSpec\\.metadata\\..+?\\}"
 
 	// valid keys of trial metadata which are used to make substitution in Trial template
-	TrialTemplateMetaKeyOfName = "name"
-	TrialTemplateMetaKeyOfNamespace = "namespace"
-	TrialTemplateMetaKeyOfKind = "kind"
+	TrialTemplateMetaKeyOfName       = "name"
+	TrialTemplateMetaKeyOfNamespace  = "namespace"
+	TrialTemplateMetaKeyOfKind       = "kind"
 	TrialTemplateMetaKeyOfAPIVersion = "apiVersion"
 
 	// UnavailableMetricValue is the value when metric was not reported or metric value can't be converted to float64

--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -141,13 +141,17 @@ const (
 	// E.g if Name = learningRate, according value in Trial template must be ${trialParameters.learningRate}
 	TrialTemplateParamReplaceFormat = "${trialParameters.%v}"
 
-	// TrialTemplateParamReplaceFormatRegex is the regex for Trial template format
+	// TrialTemplateParamReplaceFormatRegex is the regex for TrialParameters format in Trial template
 	TrialTemplateParamReplaceFormatRegex = "\\{trialParameters\\..+?\\}"
 
+	// TrialTemplateMetaReplaceFormat is the format to make substitution in Trial template from metadata of Trial
+	// E.g if we want to fetch name of current trial, according value in Trial template must be ${trialSpec.metadata.name}
 	TrialTemplateMetaReplaceFormat = "${trialSpec.metadata.%v}"
 
+	// TrialTemplateMetaReplaceFormatRegex is the regex for TrialMetadata format in Trial template
 	TrialTemplateMetaReplaceFormatRegex = "\\{trialSpec\\.metadata\\..+?\\}"
 
+	// valid keys of trial metadata which are used to make substitution in Trial template
 	TrialTemplateMetaKeyOfName = "name"
 	TrialTemplateMetaKeyOfNamespace = "namespace"
 	TrialTemplateMetaKeyOfKind = "kind"

--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -142,20 +142,18 @@ const (
 	TrialTemplateParamReplaceFormat = "${trialParameters.%v}"
 
 	// TrialTemplateParamReplaceFormatRegex is the regex for TrialParameters format in Trial template
-	TrialTemplateParamReplaceFormatRegex = "\\{trialParameters\\..+?\\}"
-
-	// TrialTemplateMetaReplaceFormat is the format to make substitution in Trial template from metadata of Trial
-	// E.g if we want to fetch name of current trial, according value in Trial template must be ${trialSpec.metadata.name}
-	TrialTemplateMetaReplaceFormat = "${trialSpec.metadata.%v}"
+	TrialTemplateParamReplaceFormatRegex = "\\$\\{trialParameters\\..+?\\}"
 
 	// TrialTemplateMetaReplaceFormatRegex is the regex for TrialMetadata format in Trial template
-	TrialTemplateMetaReplaceFormatRegex = "\\{trialSpec\\.metadata\\..+?\\}"
+	TrialTemplateMetaReplaceFormatRegex = "\\$\\{trialSpec\\.(.+?)\\}"
 
 	// valid keys of trial metadata which are used to make substitution in Trial template
-	TrialTemplateMetaKeyOfName       = "name"
-	TrialTemplateMetaKeyOfNamespace  = "namespace"
-	TrialTemplateMetaKeyOfKind       = "kind"
-	TrialTemplateMetaKeyOfAPIVersion = "apiVersion"
+	TrialTemplateMetaKeyOfName        = "Name"
+	TrialTemplateMetaKeyOfNamespace   = "Namespace"
+	TrialTemplateMetaKeyOfKind        = "Kind"
+	TrialTemplateMetaKeyOfAPIVersion  = "APIVersion"
+	TrialTemplateMetaKeyOfAnnotations = "Annotations"
+	TrialTemplateMetaKeyOfLabels      = "Labels"
 
 	// UnavailableMetricValue is the value when metric was not reported or metric value can't be converted to float64
 	UnavailableMetricValue = "unavailable"

--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -146,6 +146,8 @@ const (
 
 	// TrialTemplateMetaReplaceFormatRegex is the regex for TrialMetadata format in Trial template
 	TrialTemplateMetaReplaceFormatRegex = "\\$\\{trialSpec\\.(.+?)\\}"
+	// TrialTemplateMetaParseFormatRegex is the regex to parse the index of Annotations and Labels from meta key
+	TrialTemplateMetaParseFormatRegex = "(.+)\\[(.+)]"
 
 	// valid keys of trial metadata which are used to make substitution in Trial template
 	TrialTemplateMetaKeyOfName        = "Name"

--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -137,17 +137,21 @@ const (
 	// LabelTrialTemplateConfigMapValue is the label value for the Trial templates configMap
 	LabelTrialTemplateConfigMapValue = "katib-trial-templates"
 
-	// TrialTemplateReplaceFormat is the format to make substitution in Trial template from Names in TrialParameters
+	// TrialTemplateParamReplaceFormat is the format to make substitution in Trial template from Names in TrialParameters
 	// E.g if Name = learningRate, according value in Trial template must be ${trialParameters.learningRate}
-	TrialTemplateReplaceFormat = "${trialParameters.%v}"
+	TrialTemplateParamReplaceFormat = "${trialParameters.%v}"
 
-	// TrialTemplateReplaceFormatRegex is the regex for Trial template format
-	TrialTemplateReplaceFormatRegex = "\\{trialParameters\\..+?\\}"
+	// TrialTemplateParamReplaceFormatRegex is the regex for Trial template format
+	TrialTemplateParamReplaceFormatRegex = "\\{trialParameters\\..+?\\}"
 
-	// TrialTemplateTrialName is the placeholder of trial name in trial template
-	TrialTemplateTrialName = "Name"
-	// TrialTemplateTrialNamespace is the placeholder of trial's namespace in trial template
-	TrialTemplateTrialNamespace = "Namespace"
+	TrialTemplateMetaReplaceFormat = "${trialSpec.metadata.%v}"
+
+	TrialTemplateMetaReplaceFormatRegex = "\\{trialSpec\\.metadata\\..+?\\}"
+
+	TrialTemplateMetaKeyOfName = "name"
+	TrialTemplateMetaKeyOfNamespace = "namespace"
+	TrialTemplateMetaKeyOfKind = "kind"
+	TrialTemplateMetaKeyOfAPIVersion = "apiVersion"
 
 	// UnavailableMetricValue is the value when metric was not reported or metric value can't be converted to float64
 	UnavailableMetricValue = "unavailable"

--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -144,6 +144,11 @@ const (
 	// TrialTemplateReplaceFormatRegex is the regex for Trial template format
 	TrialTemplateReplaceFormatRegex = "\\{trialParameters\\..+?\\}"
 
+	// TrialTemplateTrialName is the placeholder of trial name in trial template
+	TrialTemplateTrialName = "Name"
+	// TrialTemplateTrialNamespace is the placeholder of trial's namespace in trial template
+	TrialTemplateTrialNamespace = "Namespace"
+
 	// UnavailableMetricValue is the value when metric was not reported or metric value can't be converted to float64
 	UnavailableMetricValue = "unavailable"
 )

--- a/pkg/controller.v1beta1/experiment/experiment_controller_test.go
+++ b/pkg/controller.v1beta1/experiment/experiment_controller_test.go
@@ -201,8 +201,7 @@ func TestReconcileExperiment(t *testing.T) {
 	if err != nil {
 		t.Errorf("ConvertObjectToUnstructured failed: %v", err)
 	}
-	generator.EXPECT().GetRunSpecWithHyperParameters(gomock.Any(), gomock.Any(),
-		gomock.Any(), gomock.Any(), gomock.Any()).Return(
+	generator.EXPECT().GetRunSpecWithHyperParameters(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		returnedUnstructured,
 		nil).AnyTimes()
 

--- a/pkg/controller.v1beta1/experiment/experiment_controller_test.go
+++ b/pkg/controller.v1beta1/experiment/experiment_controller_test.go
@@ -202,7 +202,7 @@ func TestReconcileExperiment(t *testing.T) {
 		t.Errorf("ConvertObjectToUnstructured failed: %v", err)
 	}
 	generator.EXPECT().GetRunSpecWithHyperParameters(gomock.Any(), gomock.Any(),
-		gomock.Any(), gomock.Any()).Return(
+		gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		returnedUnstructured,
 		nil).AnyTimes()
 

--- a/pkg/controller.v1beta1/experiment/experiment_util.go
+++ b/pkg/controller.v1beta1/experiment/experiment_util.go
@@ -2,6 +2,7 @@ package experiment
 
 import (
 	"context"
+	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
@@ -38,7 +39,7 @@ func (r *ReconcileExperiment) createTrialInstance(expInstance *experimentsv1beta
 	hps := trialAssignment.ParameterAssignments
 	trial.Spec.ParameterAssignments = trialAssignment.ParameterAssignments
 
-	runSpec, err := r.GetRunSpecWithHyperParameters(expInstance, trial.Name, trial.Namespace, hps)
+	runSpec, err := r.GetRunSpecWithHyperParameters(expInstance, trial.Name, trial.Namespace, hps, buildTrialMetaForRunSpec(trial))
 	if err != nil {
 		logger.Error(err, "Fail to get RunSpec from experiment", expInstance.Name)
 		return err
@@ -59,6 +60,15 @@ func (r *ReconcileExperiment) createTrialInstance(expInstance *experimentsv1beta
 	}
 	return nil
 
+}
+
+func buildTrialMetaForRunSpec(trial *trialsv1beta1.Trial) map[string]string {
+	return map[string]string{
+		consts.TrialTemplateMetaKeyOfName:       trial.Name,
+		consts.TrialTemplateMetaKeyOfNamespace:  trial.Namespace,
+		consts.TrialTemplateMetaKeyOfKind:       trial.Kind,
+		consts.TrialTemplateMetaKeyOfAPIVersion: trial.APIVersion,
+	}
 }
 
 func needUpdateFinalizers(exp *experimentsv1beta1.Experiment) (bool, []string) {

--- a/pkg/controller.v1beta1/experiment/experiment_util.go
+++ b/pkg/controller.v1beta1/experiment/experiment_util.go
@@ -39,7 +39,7 @@ func (r *ReconcileExperiment) createTrialInstance(expInstance *experimentsv1beta
 	hps := trialAssignment.ParameterAssignments
 	trial.Spec.ParameterAssignments = trialAssignment.ParameterAssignments
 
-	runSpec, err := r.GetRunSpecWithHyperParameters(expInstance, trial.Name, trial.Namespace, hps, buildTrialMetaForRunSpec(trial))
+	runSpec, err := r.GetRunSpecWithHyperParameters(expInstance, trial.Name, trial.Namespace, hps)
 	if err != nil {
 		logger.Error(err, "Fail to get RunSpec from experiment", expInstance.Name)
 		return err

--- a/pkg/controller.v1beta1/experiment/manifest/generator.go
+++ b/pkg/controller.v1beta1/experiment/manifest/generator.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,7 +13,7 @@ import (
 	commonapiv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
 	experimentsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
-	util "github.com/kubeflow/katib/pkg/controller.v1beta1/util"
+	"github.com/kubeflow/katib/pkg/controller.v1beta1/util"
 	"github.com/kubeflow/katib/pkg/util/v1beta1/katibclient"
 	"github.com/kubeflow/katib/pkg/util/v1beta1/katibconfig"
 )
@@ -25,7 +26,7 @@ const (
 type Generator interface {
 	InjectClient(c client.Client)
 	GetTrialTemplate(instance *experimentsv1beta1.Experiment) (string, error)
-	GetRunSpecWithHyperParameters(experiment *experimentsv1beta1.Experiment, trialName, trialNamespace string, assignments []commonapiv1beta1.ParameterAssignment, trialMeta map[string]string) (*unstructured.Unstructured, error)
+	GetRunSpecWithHyperParameters(experiment *experimentsv1beta1.Experiment, trialName, trialNamespace string, assignments []commonapiv1beta1.ParameterAssignment) (*unstructured.Unstructured, error)
 	GetSuggestionConfigData(algorithmName string) (map[string]string, error)
 	GetMetricsCollectorImage(cKind commonapiv1beta1.CollectorKind) (string, error)
 }
@@ -60,21 +61,10 @@ func (g *DefaultGenerator) GetSuggestionConfigData(algorithmName string) (map[st
 }
 
 // GetRunSpecWithHyperParameters returns the specification for trial with hyperparameters.
-func (g *DefaultGenerator) GetRunSpecWithHyperParameters(experiment *experimentsv1beta1.Experiment, trialName, trialNamespace string, assignments []commonapiv1beta1.ParameterAssignment, trialMeta map[string]string) (*unstructured.Unstructured, error) {
-
-	// Get string Trial template from Experiment spec
-	trialTemplate, err := g.GetTrialTemplate(experiment)
-	if err != nil {
-		return nil, err
-	}
+func (g *DefaultGenerator) GetRunSpecWithHyperParameters(experiment *experimentsv1beta1.Experiment, trialName, trialNamespace string, assignments []commonapiv1beta1.ParameterAssignment) (*unstructured.Unstructured, error) {
 
 	// Apply parameters to Trial Template from assignment
-	replacedTemplate, err := g.applyParameters(trialTemplate, experiment.Spec.TrialTemplate.TrialParameters, assignments)
-	if err != nil {
-		return nil, err
-	}
-	// Apply metadata to Trial Template from assignment
-	replacedTemplate, err = g.applyMetadata(replacedTemplate, trialMeta)
+	replacedTemplate, err := g.applyParameters(experiment, trialName, trialNamespace, assignments)
 	if err != nil {
 		return nil, err
 	}
@@ -91,38 +81,93 @@ func (g *DefaultGenerator) GetRunSpecWithHyperParameters(experiment *experiments
 	return runSpec, nil
 }
 
-func (g *DefaultGenerator) applyParameters(trialTemplate string, trialParams []experimentsv1beta1.TrialParameterSpec, assignments []commonapiv1beta1.ParameterAssignment) (string, error) {
-	// Number of parameters must be equal
-	if len(assignments) != len(trialParams) {
-		return "", fmt.Errorf("Number of Trial assignment from Suggestion: %v not equal to number Trial parameters from Experiment: %v", len(assignments), len(trialParams))
+func (g *DefaultGenerator) applyParameters(experiment *experimentsv1beta1.Experiment, trialName, trialNamespace string, assignments []commonapiv1beta1.ParameterAssignment) (string, error) {
+	// Get string Trial template from Experiment spec
+	trialTemplate, err := g.GetTrialTemplate(experiment)
+	if err != nil {
+		return "", err
 	}
+
+	trialSpec := experiment.Spec.TrialTemplate.TrialSpec
+	// If trialSpec is not defined in TrialTemplate, deserialize templateString to fetch it
+	if trialSpec == nil {
+		trialSpec, err = util.ConvertStringToUnstructured(trialTemplate)
+		if err != nil {
+			return "", fmt.Errorf("ConvertStringToUnstructured failed: %v", err)
+		}
+	}
+
 	// Convert parameter assignment to map key = parameter name, value = parameter value
 	assignmentsMap := make(map[string]string)
 	for _, assignment := range assignments {
 		assignmentsMap[assignment.Name] = assignment.Value
 	}
 
-	// Replacing parameters from Trial parameters
-	for _, parameter := range trialParams {
+	placeHolderToValueMap := make(map[string]string)
+	var metaRefKey []string
+	var metaKey, metaIndex string
+	nonMetaParamCount := 0
+	for _, param := range experiment.Spec.TrialTemplate.TrialParameters {
+		metaMatchRegex := regexp.MustCompile(consts.TrialTemplateMetaReplaceFormatRegex)
+		metaRefKey = metaMatchRegex.FindStringSubmatch(param.Reference)
+		// handle trial parameters which consume trial assignments
+		if len(metaRefKey) == 0 {
+			if value, ok := assignmentsMap[param.Reference]; ok {
+				placeHolderToValueMap[param.Name] = value
+				nonMetaParamCount += 1
+				continue
+			} else {
+				return "", fmt.Errorf("illegal reference of trial metadata: %v", param.Reference)
+			}
+		}
 
-		if parameterValue, ok := assignmentsMap[parameter.Reference]; ok {
-			trialTemplate = strings.Replace(trialTemplate, fmt.Sprintf(consts.TrialTemplateParamReplaceFormat, parameter.Name), parameterValue, -1)
+		// handle trial parameters which consume trial meta data
+		// extract index (key) of Labels and Annotations if exists
+		if sub := regexp.MustCompile("(.+)\\[(.+)]").FindStringSubmatch(metaRefKey[1]); len(sub) > 0 {
+			if len(sub) != 3 {
+				return "", fmt.Errorf("illegal reference of trial metadata: %v", param.Reference)
+			}
+			metaKey = sub[1]
+			metaIndex = sub[2]
 		} else {
-			return "", fmt.Errorf("Unable to find parameter: %v in parameter assignment %v", parameter.Reference, assignmentsMap)
+			metaKey = metaRefKey[1]
+			metaIndex = ""
+		}
+		// fetch metadata value
+		switch metaKey {
+		case consts.TrialTemplateMetaKeyOfName:
+			placeHolderToValueMap[param.Name] = trialName
+		case consts.TrialTemplateMetaKeyOfNamespace:
+			placeHolderToValueMap[param.Name] = trialNamespace
+		case consts.TrialTemplateMetaKeyOfKind:
+			placeHolderToValueMap[param.Name] = trialSpec.GetKind()
+		case consts.TrialTemplateMetaKeyOfAPIVersion:
+			placeHolderToValueMap[param.Name] = trialSpec.GetAPIVersion()
+		case consts.TrialTemplateMetaKeyOfAnnotations:
+			if value, ok := trialSpec.GetAnnotations()[metaIndex]; !ok {
+				return "", fmt.Errorf("illegal reference of trial metadata: %v; failed to fetch Annotation: %v", param.Reference, metaIndex)
+			} else {
+				placeHolderToValueMap[param.Name] = value
+			}
+		case consts.TrialTemplateMetaKeyOfLabels:
+			if value, ok := trialSpec.GetLabels()[metaIndex]; !ok {
+				return "", fmt.Errorf("illegal reference of trial metadata: %v; failed to fetch Label: %v", param.Reference, metaIndex)
+			} else {
+				placeHolderToValueMap[param.Name] = value
+			}
+		default:
+			return "", fmt.Errorf("illegal reference of trial metadata: %v", param.Reference)
 		}
 	}
 
-	return trialTemplate, nil
-}
+	// Number of parameters must be equal
+	if len(assignments) != nonMetaParamCount {
+		return "", fmt.Errorf("Number of TrialAssignment: %v != number of nonMetaTrialParameters in TrialSpec: %v", len(assignments), nonMetaParamCount)
+	}
 
-func (g *DefaultGenerator) applyMetadata(trialTemplate string, trialMeta map[string]string) (string, error) {
-	var tempMatchKey string
-	// Inject TrialMeta if needed
-	for key, value := range trialMeta {
-		tempMatchKey = fmt.Sprintf(consts.TrialTemplateMetaReplaceFormat, key)
-		if strings.Contains(trialTemplate, tempMatchKey) {
-			trialTemplate = strings.Replace(trialTemplate, tempMatchKey, value, -1)
-		}
+	// Replacing placeholders with parameter values
+	for placeHolder, paramValue := range placeHolderToValueMap {
+		trialTemplate = strings.Replace(trialTemplate, fmt.Sprintf(consts.TrialTemplateParamReplaceFormat, placeHolder), paramValue, -1)
 	}
 
 	return trialTemplate, nil

--- a/pkg/controller.v1beta1/experiment/manifest/generator_test.go
+++ b/pkg/controller.v1beta1/experiment/manifest/generator_test.go
@@ -125,14 +125,8 @@ func TestGetRunSpecWithHP(t *testing.T) {
 		},
 	}
 
-	mockMetadata := map[string]string{
-		"name":       "trial-name",
-		"namespace":  "trial-namespace",
-		"kind":       "Job",
-		"apiVersion": "batch/v1",
-	}
 	for _, tc := range tcs {
-		actualRunSpec, err := p.GetRunSpecWithHyperParameters(tc.Instance, "trial-name", "trial-namespace", tc.ParameterAssignments, mockMetadata)
+		actualRunSpec, err := p.GetRunSpecWithHyperParameters(tc.Instance, "trial-name", "trial-namespace", tc.ParameterAssignments)
 
 		if tc.Err && err == nil {
 			t.Errorf("Case: %v failed. Expected err, got nil", tc.testDescription)
@@ -309,14 +303,8 @@ spec:
 		},
 	}
 
-	mockMetadata := map[string]string{
-		"name":       "trial-name",
-		"namespace":  "trial-namespace",
-		"kind":       "Job",
-		"apiVersion": "batch/v1",
-	}
 	for _, tc := range tcs {
-		actualRunSpec, err := p.GetRunSpecWithHyperParameters(tc.Instance, "trial-name", "trial-namespace", tc.ParameterAssignments, mockMetadata)
+		actualRunSpec, err := p.GetRunSpecWithHyperParameters(tc.Instance, "trial-name", "trial-namespace", tc.ParameterAssignments)
 		if tc.Err && err == nil {
 			t.Errorf("Case: %v failed. Expected err, got nil", tc.testDescription)
 		} else if !tc.Err {
@@ -350,10 +338,10 @@ func newFakeInstance() *experimentsv1beta1.Experiment {
 								"--num-layers=${trialParameters.numberLayers}",
 							},
 							Env: []v1.EnvVar{
-								{Name: consts.TrialTemplateMetaKeyOfName, Value: "${trialSpec.metadata.name}"},
-								{Name: consts.TrialTemplateMetaKeyOfNamespace, Value: "${trialSpec.metadata.namespace}"},
-								{Name: consts.TrialTemplateMetaKeyOfKind, Value: "${trialSpec.metadata.kind}"},
-								{Name: consts.TrialTemplateMetaKeyOfAPIVersion, Value: "${trialSpec.metadata.apiVersion}"},
+								{Name: consts.TrialTemplateMetaKeyOfName, Value: "${trialParameters.trialName}"},
+								{Name: consts.TrialTemplateMetaKeyOfNamespace, Value: "${trialParameters.trialNamespace}"},
+								{Name: consts.TrialTemplateMetaKeyOfKind, Value: "${trialParameters.jobKind}"},
+								{Name: consts.TrialTemplateMetaKeyOfAPIVersion, Value: "${trialParameters.jobAPIVersion}"},
 							},
 						},
 					},
@@ -379,6 +367,26 @@ func newFakeInstance() *experimentsv1beta1.Experiment {
 						Name:        "numberLayers",
 						Description: "Number of layers",
 						Reference:   "num-layers",
+					},
+					{
+						Name:        "trialName",
+						Description: "name of current trial",
+						Reference:   "${trialSpec.Name}",
+					},
+					{
+						Name:        "trialNamespace",
+						Description: "namespace of current trial",
+						Reference:   "${trialSpec.Namespace}",
+					},
+					{
+						Name:        "jobKind",
+						Description: "job kind of current trial",
+						Reference:   "${trialSpec.Kind}",
+					},
+					{
+						Name:        "jobAPIVersion",
+						Description: "job API Version of current trial",
+						Reference:   "${trialSpec.APIVersion}",
 					},
 				},
 			},

--- a/pkg/controller.v1beta1/experiment/manifest/generator_test.go
+++ b/pkg/controller.v1beta1/experiment/manifest/generator_test.go
@@ -50,6 +50,10 @@ func TestGetRunSpecWithHP(t *testing.T) {
 								"--lr=0.05",
 								"--num-layers=5",
 							},
+							Env: []v1.EnvVar{
+								{Name: "trial_name", Value: "trial-name"},
+								{Name: "trial_ns", Value: "trial-namespace"},
+							},
 						},
 					},
 				},
@@ -329,6 +333,10 @@ func newFakeInstance() *experimentsv1beta1.Experiment {
 								"/opt/mxnet-mnist/mnist.py",
 								"--lr=${trialParameters.learningRate}",
 								"--num-layers=${trialParameters.numberLayers}",
+							},
+							Env: []v1.EnvVar{
+								{Name: "trial_name", Value: "${trialParameters.Name}"},
+								{Name: "trial_ns", Value: "${trialParameters.Namespace}"},
 							},
 						},
 					},

--- a/pkg/mock/v1alpha3/api/manager.go
+++ b/pkg/mock/v1alpha3/api/manager.go
@@ -7,88 +7,88 @@ package mock
 import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
-	v1alpha3 "github.com/kubeflow/katib/pkg/apis/manager/v1alpha3"
+	api_v1_alpha3 "github.com/kubeflow/katib/pkg/apis/manager/v1alpha3"
 	grpc "google.golang.org/grpc"
 	reflect "reflect"
 )
 
-// MockManagerClient is a mock of ManagerClient interface
+// MockManagerClient is a mock of ManagerClient interface.
 type MockManagerClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockManagerClientMockRecorder
 }
 
-// MockManagerClientMockRecorder is the mock recorder for MockManagerClient
+// MockManagerClientMockRecorder is the mock recorder for MockManagerClient.
 type MockManagerClientMockRecorder struct {
 	mock *MockManagerClient
 }
 
-// NewMockManagerClient creates a new mock instance
+// NewMockManagerClient creates a new mock instance.
 func NewMockManagerClient(ctrl *gomock.Controller) *MockManagerClient {
 	mock := &MockManagerClient{ctrl: ctrl}
 	mock.recorder = &MockManagerClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockManagerClient) EXPECT() *MockManagerClientMockRecorder {
 	return m.recorder
 }
 
-// DeleteObservationLog mocks base method
-func (m *MockManagerClient) DeleteObservationLog(arg0 context.Context, arg1 *v1alpha3.DeleteObservationLogRequest, arg2 ...grpc.CallOption) (*v1alpha3.DeleteObservationLogReply, error) {
+// DeleteObservationLog mocks base method.
+func (m *MockManagerClient) DeleteObservationLog(arg0 context.Context, arg1 *api_v1_alpha3.DeleteObservationLogRequest, arg2 ...grpc.CallOption) (*api_v1_alpha3.DeleteObservationLogReply, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "DeleteObservationLog", varargs...)
-	ret0, _ := ret[0].(*v1alpha3.DeleteObservationLogReply)
+	ret0, _ := ret[0].(*api_v1_alpha3.DeleteObservationLogReply)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DeleteObservationLog indicates an expected call of DeleteObservationLog
+// DeleteObservationLog indicates an expected call of DeleteObservationLog.
 func (mr *MockManagerClientMockRecorder) DeleteObservationLog(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObservationLog", reflect.TypeOf((*MockManagerClient)(nil).DeleteObservationLog), varargs...)
 }
 
-// GetObservationLog mocks base method
-func (m *MockManagerClient) GetObservationLog(arg0 context.Context, arg1 *v1alpha3.GetObservationLogRequest, arg2 ...grpc.CallOption) (*v1alpha3.GetObservationLogReply, error) {
+// GetObservationLog mocks base method.
+func (m *MockManagerClient) GetObservationLog(arg0 context.Context, arg1 *api_v1_alpha3.GetObservationLogRequest, arg2 ...grpc.CallOption) (*api_v1_alpha3.GetObservationLogReply, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "GetObservationLog", varargs...)
-	ret0, _ := ret[0].(*v1alpha3.GetObservationLogReply)
+	ret0, _ := ret[0].(*api_v1_alpha3.GetObservationLogReply)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetObservationLog indicates an expected call of GetObservationLog
+// GetObservationLog indicates an expected call of GetObservationLog.
 func (mr *MockManagerClientMockRecorder) GetObservationLog(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObservationLog", reflect.TypeOf((*MockManagerClient)(nil).GetObservationLog), varargs...)
 }
 
-// ReportObservationLog mocks base method
-func (m *MockManagerClient) ReportObservationLog(arg0 context.Context, arg1 *v1alpha3.ReportObservationLogRequest, arg2 ...grpc.CallOption) (*v1alpha3.ReportObservationLogReply, error) {
+// ReportObservationLog mocks base method.
+func (m *MockManagerClient) ReportObservationLog(arg0 context.Context, arg1 *api_v1_alpha3.ReportObservationLogRequest, arg2 ...grpc.CallOption) (*api_v1_alpha3.ReportObservationLogReply, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ReportObservationLog", varargs...)
-	ret0, _ := ret[0].(*v1alpha3.ReportObservationLogReply)
+	ret0, _ := ret[0].(*api_v1_alpha3.ReportObservationLogReply)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ReportObservationLog indicates an expected call of ReportObservationLog
+// ReportObservationLog indicates an expected call of ReportObservationLog.
 func (mr *MockManagerClientMockRecorder) ReportObservationLog(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)

--- a/pkg/mock/v1alpha3/api/suggestion.go
+++ b/pkg/mock/v1alpha3/api/suggestion.go
@@ -7,68 +7,68 @@ package mock
 import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
-	v1alpha3 "github.com/kubeflow/katib/pkg/apis/manager/v1alpha3"
+	api_v1_alpha3 "github.com/kubeflow/katib/pkg/apis/manager/v1alpha3"
 	grpc "google.golang.org/grpc"
 	reflect "reflect"
 )
 
-// MockSuggestionClient is a mock of SuggestionClient interface
+// MockSuggestionClient is a mock of SuggestionClient interface.
 type MockSuggestionClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockSuggestionClientMockRecorder
 }
 
-// MockSuggestionClientMockRecorder is the mock recorder for MockSuggestionClient
+// MockSuggestionClientMockRecorder is the mock recorder for MockSuggestionClient.
 type MockSuggestionClientMockRecorder struct {
 	mock *MockSuggestionClient
 }
 
-// NewMockSuggestionClient creates a new mock instance
+// NewMockSuggestionClient creates a new mock instance.
 func NewMockSuggestionClient(ctrl *gomock.Controller) *MockSuggestionClient {
 	mock := &MockSuggestionClient{ctrl: ctrl}
 	mock.recorder = &MockSuggestionClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSuggestionClient) EXPECT() *MockSuggestionClientMockRecorder {
 	return m.recorder
 }
 
-// GetSuggestions mocks base method
-func (m *MockSuggestionClient) GetSuggestions(arg0 context.Context, arg1 *v1alpha3.GetSuggestionsRequest, arg2 ...grpc.CallOption) (*v1alpha3.GetSuggestionsReply, error) {
+// GetSuggestions mocks base method.
+func (m *MockSuggestionClient) GetSuggestions(arg0 context.Context, arg1 *api_v1_alpha3.GetSuggestionsRequest, arg2 ...grpc.CallOption) (*api_v1_alpha3.GetSuggestionsReply, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "GetSuggestions", varargs...)
-	ret0, _ := ret[0].(*v1alpha3.GetSuggestionsReply)
+	ret0, _ := ret[0].(*api_v1_alpha3.GetSuggestionsReply)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetSuggestions indicates an expected call of GetSuggestions
+// GetSuggestions indicates an expected call of GetSuggestions.
 func (mr *MockSuggestionClientMockRecorder) GetSuggestions(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSuggestions", reflect.TypeOf((*MockSuggestionClient)(nil).GetSuggestions), varargs...)
 }
 
-// ValidateAlgorithmSettings mocks base method
-func (m *MockSuggestionClient) ValidateAlgorithmSettings(arg0 context.Context, arg1 *v1alpha3.ValidateAlgorithmSettingsRequest, arg2 ...grpc.CallOption) (*v1alpha3.ValidateAlgorithmSettingsReply, error) {
+// ValidateAlgorithmSettings mocks base method.
+func (m *MockSuggestionClient) ValidateAlgorithmSettings(arg0 context.Context, arg1 *api_v1_alpha3.ValidateAlgorithmSettingsRequest, arg2 ...grpc.CallOption) (*api_v1_alpha3.ValidateAlgorithmSettingsReply, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ValidateAlgorithmSettings", varargs...)
-	ret0, _ := ret[0].(*v1alpha3.ValidateAlgorithmSettingsReply)
+	ret0, _ := ret[0].(*api_v1_alpha3.ValidateAlgorithmSettingsReply)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ValidateAlgorithmSettings indicates an expected call of ValidateAlgorithmSettings
+// ValidateAlgorithmSettings indicates an expected call of ValidateAlgorithmSettings.
 func (mr *MockSuggestionClientMockRecorder) ValidateAlgorithmSettings(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)

--- a/pkg/mock/v1alpha3/db/db.go
+++ b/pkg/mock/v1alpha3/db/db.go
@@ -6,46 +6,46 @@ package mock
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	v1alpha3 "github.com/kubeflow/katib/pkg/apis/manager/v1alpha3"
+	api_v1_alpha3 "github.com/kubeflow/katib/pkg/apis/manager/v1alpha3"
 	reflect "reflect"
 )
 
-// MockKatibDBInterface is a mock of KatibDBInterface interface
+// MockKatibDBInterface is a mock of KatibDBInterface interface.
 type MockKatibDBInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockKatibDBInterfaceMockRecorder
 }
 
-// MockKatibDBInterfaceMockRecorder is the mock recorder for MockKatibDBInterface
+// MockKatibDBInterfaceMockRecorder is the mock recorder for MockKatibDBInterface.
 type MockKatibDBInterfaceMockRecorder struct {
 	mock *MockKatibDBInterface
 }
 
-// NewMockKatibDBInterface creates a new mock instance
+// NewMockKatibDBInterface creates a new mock instance.
 func NewMockKatibDBInterface(ctrl *gomock.Controller) *MockKatibDBInterface {
 	mock := &MockKatibDBInterface{ctrl: ctrl}
 	mock.recorder = &MockKatibDBInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockKatibDBInterface) EXPECT() *MockKatibDBInterfaceMockRecorder {
 	return m.recorder
 }
 
-// DBInit mocks base method
+// DBInit mocks base method.
 func (m *MockKatibDBInterface) DBInit() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "DBInit")
 }
 
-// DBInit indicates an expected call of DBInit
+// DBInit indicates an expected call of DBInit.
 func (mr *MockKatibDBInterfaceMockRecorder) DBInit() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DBInit", reflect.TypeOf((*MockKatibDBInterface)(nil).DBInit))
 }
 
-// DeleteObservationLog mocks base method
+// DeleteObservationLog mocks base method.
 func (m *MockKatibDBInterface) DeleteObservationLog(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteObservationLog", arg0)
@@ -53,42 +53,42 @@ func (m *MockKatibDBInterface) DeleteObservationLog(arg0 string) error {
 	return ret0
 }
 
-// DeleteObservationLog indicates an expected call of DeleteObservationLog
+// DeleteObservationLog indicates an expected call of DeleteObservationLog.
 func (mr *MockKatibDBInterfaceMockRecorder) DeleteObservationLog(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObservationLog", reflect.TypeOf((*MockKatibDBInterface)(nil).DeleteObservationLog), arg0)
 }
 
-// GetObservationLog mocks base method
-func (m *MockKatibDBInterface) GetObservationLog(arg0, arg1, arg2, arg3 string) (*v1alpha3.ObservationLog, error) {
+// GetObservationLog mocks base method.
+func (m *MockKatibDBInterface) GetObservationLog(arg0, arg1, arg2, arg3 string) (*api_v1_alpha3.ObservationLog, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetObservationLog", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(*v1alpha3.ObservationLog)
+	ret0, _ := ret[0].(*api_v1_alpha3.ObservationLog)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetObservationLog indicates an expected call of GetObservationLog
+// GetObservationLog indicates an expected call of GetObservationLog.
 func (mr *MockKatibDBInterfaceMockRecorder) GetObservationLog(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObservationLog", reflect.TypeOf((*MockKatibDBInterface)(nil).GetObservationLog), arg0, arg1, arg2, arg3)
 }
 
-// RegisterObservationLog mocks base method
-func (m *MockKatibDBInterface) RegisterObservationLog(arg0 string, arg1 *v1alpha3.ObservationLog) error {
+// RegisterObservationLog mocks base method.
+func (m *MockKatibDBInterface) RegisterObservationLog(arg0 string, arg1 *api_v1_alpha3.ObservationLog) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterObservationLog", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// RegisterObservationLog indicates an expected call of RegisterObservationLog
+// RegisterObservationLog indicates an expected call of RegisterObservationLog.
 func (mr *MockKatibDBInterfaceMockRecorder) RegisterObservationLog(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterObservationLog", reflect.TypeOf((*MockKatibDBInterface)(nil).RegisterObservationLog), arg0, arg1)
 }
 
-// SelectOne mocks base method
+// SelectOne mocks base method.
 func (m *MockKatibDBInterface) SelectOne() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SelectOne")
@@ -96,7 +96,7 @@ func (m *MockKatibDBInterface) SelectOne() error {
 	return ret0
 }
 
-// SelectOne indicates an expected call of SelectOne
+// SelectOne indicates an expected call of SelectOne.
 func (mr *MockKatibDBInterfaceMockRecorder) SelectOne() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectOne", reflect.TypeOf((*MockKatibDBInterface)(nil).SelectOne))

--- a/pkg/mock/v1alpha3/experiment/manifest/generator.go
+++ b/pkg/mock/v1alpha3/experiment/manifest/generator.go
@@ -12,30 +12,30 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MockGenerator is a mock of Generator interface
+// MockGenerator is a mock of Generator interface.
 type MockGenerator struct {
 	ctrl     *gomock.Controller
 	recorder *MockGeneratorMockRecorder
 }
 
-// MockGeneratorMockRecorder is the mock recorder for MockGenerator
+// MockGeneratorMockRecorder is the mock recorder for MockGenerator.
 type MockGeneratorMockRecorder struct {
 	mock *MockGenerator
 }
 
-// NewMockGenerator creates a new mock instance
+// NewMockGenerator creates a new mock instance.
 func NewMockGenerator(ctrl *gomock.Controller) *MockGenerator {
 	mock := &MockGenerator{ctrl: ctrl}
 	mock.recorder = &MockGeneratorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockGenerator) EXPECT() *MockGeneratorMockRecorder {
 	return m.recorder
 }
 
-// GetMetricsCollectorImage mocks base method
+// GetMetricsCollectorImage mocks base method.
 func (m *MockGenerator) GetMetricsCollectorImage(arg0 v1alpha3.CollectorKind) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetricsCollectorImage", arg0)
@@ -44,13 +44,13 @@ func (m *MockGenerator) GetMetricsCollectorImage(arg0 v1alpha3.CollectorKind) (s
 	return ret0, ret1
 }
 
-// GetMetricsCollectorImage indicates an expected call of GetMetricsCollectorImage
+// GetMetricsCollectorImage indicates an expected call of GetMetricsCollectorImage.
 func (mr *MockGeneratorMockRecorder) GetMetricsCollectorImage(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricsCollectorImage", reflect.TypeOf((*MockGenerator)(nil).GetMetricsCollectorImage), arg0)
 }
 
-// GetRunSpec mocks base method
+// GetRunSpec mocks base method.
 func (m *MockGenerator) GetRunSpec(arg0 *v1alpha30.Experiment, arg1, arg2, arg3 string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRunSpec", arg0, arg1, arg2, arg3)
@@ -59,13 +59,13 @@ func (m *MockGenerator) GetRunSpec(arg0 *v1alpha30.Experiment, arg1, arg2, arg3 
 	return ret0, ret1
 }
 
-// GetRunSpec indicates an expected call of GetRunSpec
+// GetRunSpec indicates an expected call of GetRunSpec.
 func (mr *MockGeneratorMockRecorder) GetRunSpec(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunSpec", reflect.TypeOf((*MockGenerator)(nil).GetRunSpec), arg0, arg1, arg2, arg3)
 }
 
-// GetRunSpecWithHyperParameters mocks base method
+// GetRunSpecWithHyperParameters mocks base method.
 func (m *MockGenerator) GetRunSpecWithHyperParameters(arg0 *v1alpha30.Experiment, arg1, arg2, arg3 string, arg4 []v1alpha3.ParameterAssignment) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRunSpecWithHyperParameters", arg0, arg1, arg2, arg3, arg4)
@@ -74,13 +74,13 @@ func (m *MockGenerator) GetRunSpecWithHyperParameters(arg0 *v1alpha30.Experiment
 	return ret0, ret1
 }
 
-// GetRunSpecWithHyperParameters indicates an expected call of GetRunSpecWithHyperParameters
+// GetRunSpecWithHyperParameters indicates an expected call of GetRunSpecWithHyperParameters.
 func (mr *MockGeneratorMockRecorder) GetRunSpecWithHyperParameters(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunSpecWithHyperParameters", reflect.TypeOf((*MockGenerator)(nil).GetRunSpecWithHyperParameters), arg0, arg1, arg2, arg3, arg4)
 }
 
-// GetSuggestionConfigData mocks base method
+// GetSuggestionConfigData mocks base method.
 func (m *MockGenerator) GetSuggestionConfigData(arg0 string) (map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSuggestionConfigData", arg0)
@@ -89,19 +89,19 @@ func (m *MockGenerator) GetSuggestionConfigData(arg0 string) (map[string]string,
 	return ret0, ret1
 }
 
-// GetSuggestionConfigData indicates an expected call of GetSuggestionConfigData
+// GetSuggestionConfigData indicates an expected call of GetSuggestionConfigData.
 func (mr *MockGeneratorMockRecorder) GetSuggestionConfigData(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSuggestionConfigData", reflect.TypeOf((*MockGenerator)(nil).GetSuggestionConfigData), arg0)
 }
 
-// InjectClient mocks base method
+// InjectClient mocks base method.
 func (m *MockGenerator) InjectClient(arg0 client.Client) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "InjectClient", arg0)
 }
 
-// InjectClient indicates an expected call of InjectClient
+// InjectClient indicates an expected call of InjectClient.
 func (mr *MockGeneratorMockRecorder) InjectClient(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InjectClient", reflect.TypeOf((*MockGenerator)(nil).InjectClient), arg0)

--- a/pkg/mock/v1alpha3/experiment/suggestion/suggestion.go
+++ b/pkg/mock/v1alpha3/experiment/suggestion/suggestion.go
@@ -11,30 +11,30 @@ import (
 	reflect "reflect"
 )
 
-// MockSuggestion is a mock of Suggestion interface
+// MockSuggestion is a mock of Suggestion interface.
 type MockSuggestion struct {
 	ctrl     *gomock.Controller
 	recorder *MockSuggestionMockRecorder
 }
 
-// MockSuggestionMockRecorder is the mock recorder for MockSuggestion
+// MockSuggestionMockRecorder is the mock recorder for MockSuggestion.
 type MockSuggestionMockRecorder struct {
 	mock *MockSuggestion
 }
 
-// NewMockSuggestion creates a new mock instance
+// NewMockSuggestion creates a new mock instance.
 func NewMockSuggestion(ctrl *gomock.Controller) *MockSuggestion {
 	mock := &MockSuggestion{ctrl: ctrl}
 	mock.recorder = &MockSuggestionMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSuggestion) EXPECT() *MockSuggestionMockRecorder {
 	return m.recorder
 }
 
-// GetOrCreateSuggestion mocks base method
+// GetOrCreateSuggestion mocks base method.
 func (m *MockSuggestion) GetOrCreateSuggestion(arg0 *v1alpha3.Experiment, arg1 int32) (*v1alpha30.Suggestion, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOrCreateSuggestion", arg0, arg1)
@@ -43,13 +43,13 @@ func (m *MockSuggestion) GetOrCreateSuggestion(arg0 *v1alpha3.Experiment, arg1 i
 	return ret0, ret1
 }
 
-// GetOrCreateSuggestion indicates an expected call of GetOrCreateSuggestion
+// GetOrCreateSuggestion indicates an expected call of GetOrCreateSuggestion.
 func (mr *MockSuggestionMockRecorder) GetOrCreateSuggestion(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateSuggestion", reflect.TypeOf((*MockSuggestion)(nil).GetOrCreateSuggestion), arg0, arg1)
 }
 
-// UpdateSuggestion mocks base method
+// UpdateSuggestion mocks base method.
 func (m *MockSuggestion) UpdateSuggestion(arg0 *v1alpha30.Suggestion) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSuggestion", arg0)
@@ -57,13 +57,13 @@ func (m *MockSuggestion) UpdateSuggestion(arg0 *v1alpha30.Suggestion) error {
 	return ret0
 }
 
-// UpdateSuggestion indicates an expected call of UpdateSuggestion
+// UpdateSuggestion indicates an expected call of UpdateSuggestion.
 func (mr *MockSuggestionMockRecorder) UpdateSuggestion(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSuggestion", reflect.TypeOf((*MockSuggestion)(nil).UpdateSuggestion), arg0)
 }
 
-// UpdateSuggestionStatus mocks base method
+// UpdateSuggestionStatus mocks base method.
 func (m *MockSuggestion) UpdateSuggestionStatus(arg0 *v1alpha30.Suggestion) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSuggestionStatus", arg0)
@@ -71,7 +71,7 @@ func (m *MockSuggestion) UpdateSuggestionStatus(arg0 *v1alpha30.Suggestion) erro
 	return ret0
 }
 
-// UpdateSuggestionStatus indicates an expected call of UpdateSuggestionStatus
+// UpdateSuggestionStatus indicates an expected call of UpdateSuggestionStatus.
 func (mr *MockSuggestionMockRecorder) UpdateSuggestionStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSuggestionStatus", reflect.TypeOf((*MockSuggestion)(nil).UpdateSuggestionStatus), arg0)

--- a/pkg/mock/v1alpha3/trial/managerclient/katibmanager.go
+++ b/pkg/mock/v1alpha3/trial/managerclient/katibmanager.go
@@ -7,58 +7,58 @@ package mock
 import (
 	gomock "github.com/golang/mock/gomock"
 	v1alpha3 "github.com/kubeflow/katib/pkg/apis/controller/trials/v1alpha3"
-	v1alpha30 "github.com/kubeflow/katib/pkg/apis/manager/v1alpha3"
+	api_v1_alpha3 "github.com/kubeflow/katib/pkg/apis/manager/v1alpha3"
 	reflect "reflect"
 )
 
-// MockManagerClient is a mock of ManagerClient interface
+// MockManagerClient is a mock of ManagerClient interface.
 type MockManagerClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockManagerClientMockRecorder
 }
 
-// MockManagerClientMockRecorder is the mock recorder for MockManagerClient
+// MockManagerClientMockRecorder is the mock recorder for MockManagerClient.
 type MockManagerClientMockRecorder struct {
 	mock *MockManagerClient
 }
 
-// NewMockManagerClient creates a new mock instance
+// NewMockManagerClient creates a new mock instance.
 func NewMockManagerClient(ctrl *gomock.Controller) *MockManagerClient {
 	mock := &MockManagerClient{ctrl: ctrl}
 	mock.recorder = &MockManagerClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockManagerClient) EXPECT() *MockManagerClientMockRecorder {
 	return m.recorder
 }
 
-// DeleteTrialObservationLog mocks base method
-func (m *MockManagerClient) DeleteTrialObservationLog(arg0 *v1alpha3.Trial) (*v1alpha30.DeleteObservationLogReply, error) {
+// DeleteTrialObservationLog mocks base method.
+func (m *MockManagerClient) DeleteTrialObservationLog(arg0 *v1alpha3.Trial) (*api_v1_alpha3.DeleteObservationLogReply, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteTrialObservationLog", arg0)
-	ret0, _ := ret[0].(*v1alpha30.DeleteObservationLogReply)
+	ret0, _ := ret[0].(*api_v1_alpha3.DeleteObservationLogReply)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DeleteTrialObservationLog indicates an expected call of DeleteTrialObservationLog
+// DeleteTrialObservationLog indicates an expected call of DeleteTrialObservationLog.
 func (mr *MockManagerClientMockRecorder) DeleteTrialObservationLog(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTrialObservationLog", reflect.TypeOf((*MockManagerClient)(nil).DeleteTrialObservationLog), arg0)
 }
 
-// GetTrialObservationLog mocks base method
-func (m *MockManagerClient) GetTrialObservationLog(arg0 *v1alpha3.Trial) (*v1alpha30.GetObservationLogReply, error) {
+// GetTrialObservationLog mocks base method.
+func (m *MockManagerClient) GetTrialObservationLog(arg0 *v1alpha3.Trial) (*api_v1_alpha3.GetObservationLogReply, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTrialObservationLog", arg0)
-	ret0, _ := ret[0].(*v1alpha30.GetObservationLogReply)
+	ret0, _ := ret[0].(*api_v1_alpha3.GetObservationLogReply)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetTrialObservationLog indicates an expected call of GetTrialObservationLog
+// GetTrialObservationLog indicates an expected call of GetTrialObservationLog.
 func (mr *MockManagerClientMockRecorder) GetTrialObservationLog(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrialObservationLog", reflect.TypeOf((*MockManagerClient)(nil).GetTrialObservationLog), arg0)

--- a/pkg/mock/v1alpha3/util/katibclient/katibclient.go
+++ b/pkg/mock/v1alpha3/util/katibclient/katibclient.go
@@ -14,30 +14,30 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MockClient is a mock of Client interface
+// MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient
+// MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance
+// NewMockClient creates a new mock instance.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// CreateExperiment mocks base method
+// CreateExperiment mocks base method.
 func (m *MockClient) CreateExperiment(arg0 *v1alpha3.Experiment, arg1 ...string) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -49,14 +49,14 @@ func (m *MockClient) CreateExperiment(arg0 *v1alpha3.Experiment, arg1 ...string)
 	return ret0
 }
 
-// CreateExperiment indicates an expected call of CreateExperiment
+// CreateExperiment indicates an expected call of CreateExperiment.
 func (mr *MockClientMockRecorder) CreateExperiment(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateExperiment", reflect.TypeOf((*MockClient)(nil).CreateExperiment), varargs...)
 }
 
-// DeleteExperiment mocks base method
+// DeleteExperiment mocks base method.
 func (m *MockClient) DeleteExperiment(arg0 *v1alpha3.Experiment, arg1 ...string) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -68,14 +68,14 @@ func (m *MockClient) DeleteExperiment(arg0 *v1alpha3.Experiment, arg1 ...string)
 	return ret0
 }
 
-// DeleteExperiment indicates an expected call of DeleteExperiment
+// DeleteExperiment indicates an expected call of DeleteExperiment.
 func (mr *MockClientMockRecorder) DeleteExperiment(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExperiment", reflect.TypeOf((*MockClient)(nil).DeleteExperiment), varargs...)
 }
 
-// GetClient mocks base method
+// GetClient mocks base method.
 func (m *MockClient) GetClient() client.Client {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClient")
@@ -83,13 +83,13 @@ func (m *MockClient) GetClient() client.Client {
 	return ret0
 }
 
-// GetClient indicates an expected call of GetClient
+// GetClient indicates an expected call of GetClient.
 func (mr *MockClientMockRecorder) GetClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClient", reflect.TypeOf((*MockClient)(nil).GetClient))
 }
 
-// GetConfigMap mocks base method
+// GetConfigMap mocks base method.
 func (m *MockClient) GetConfigMap(arg0 string, arg1 ...string) (map[string]string, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -102,14 +102,14 @@ func (m *MockClient) GetConfigMap(arg0 string, arg1 ...string) (map[string]strin
 	return ret0, ret1
 }
 
-// GetConfigMap indicates an expected call of GetConfigMap
+// GetConfigMap indicates an expected call of GetConfigMap.
 func (mr *MockClientMockRecorder) GetConfigMap(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigMap", reflect.TypeOf((*MockClient)(nil).GetConfigMap), varargs...)
 }
 
-// GetExperiment mocks base method
+// GetExperiment mocks base method.
 func (m *MockClient) GetExperiment(arg0 string, arg1 ...string) (*v1alpha3.Experiment, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -122,14 +122,14 @@ func (m *MockClient) GetExperiment(arg0 string, arg1 ...string) (*v1alpha3.Exper
 	return ret0, ret1
 }
 
-// GetExperiment indicates an expected call of GetExperiment
+// GetExperiment indicates an expected call of GetExperiment.
 func (mr *MockClientMockRecorder) GetExperiment(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExperiment", reflect.TypeOf((*MockClient)(nil).GetExperiment), varargs...)
 }
 
-// GetExperimentList mocks base method
+// GetExperimentList mocks base method.
 func (m *MockClient) GetExperimentList(arg0 ...string) (*v1alpha3.ExperimentList, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -142,13 +142,13 @@ func (m *MockClient) GetExperimentList(arg0 ...string) (*v1alpha3.ExperimentList
 	return ret0, ret1
 }
 
-// GetExperimentList indicates an expected call of GetExperimentList
+// GetExperimentList indicates an expected call of GetExperimentList.
 func (mr *MockClientMockRecorder) GetExperimentList(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExperimentList", reflect.TypeOf((*MockClient)(nil).GetExperimentList), arg0...)
 }
 
-// GetNamespaceList mocks base method
+// GetNamespaceList mocks base method.
 func (m *MockClient) GetNamespaceList() (*v1.NamespaceList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNamespaceList")
@@ -157,13 +157,13 @@ func (m *MockClient) GetNamespaceList() (*v1.NamespaceList, error) {
 	return ret0, ret1
 }
 
-// GetNamespaceList indicates an expected call of GetNamespaceList
+// GetNamespaceList indicates an expected call of GetNamespaceList.
 func (mr *MockClientMockRecorder) GetNamespaceList() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespaceList", reflect.TypeOf((*MockClient)(nil).GetNamespaceList))
 }
 
-// GetSuggestion mocks base method
+// GetSuggestion mocks base method.
 func (m *MockClient) GetSuggestion(arg0 string, arg1 ...string) (*v1alpha30.Suggestion, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -176,14 +176,14 @@ func (m *MockClient) GetSuggestion(arg0 string, arg1 ...string) (*v1alpha30.Sugg
 	return ret0, ret1
 }
 
-// GetSuggestion indicates an expected call of GetSuggestion
+// GetSuggestion indicates an expected call of GetSuggestion.
 func (mr *MockClientMockRecorder) GetSuggestion(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSuggestion", reflect.TypeOf((*MockClient)(nil).GetSuggestion), varargs...)
 }
 
-// GetTrial mocks base method
+// GetTrial mocks base method.
 func (m *MockClient) GetTrial(arg0 string, arg1 ...string) (*v1alpha31.Trial, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -196,14 +196,14 @@ func (m *MockClient) GetTrial(arg0 string, arg1 ...string) (*v1alpha31.Trial, er
 	return ret0, ret1
 }
 
-// GetTrial indicates an expected call of GetTrial
+// GetTrial indicates an expected call of GetTrial.
 func (mr *MockClientMockRecorder) GetTrial(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrial", reflect.TypeOf((*MockClient)(nil).GetTrial), varargs...)
 }
 
-// GetTrialList mocks base method
+// GetTrialList mocks base method.
 func (m *MockClient) GetTrialList(arg0 string, arg1 ...string) (*v1alpha31.TrialList, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -216,14 +216,14 @@ func (m *MockClient) GetTrialList(arg0 string, arg1 ...string) (*v1alpha31.Trial
 	return ret0, ret1
 }
 
-// GetTrialList indicates an expected call of GetTrialList
+// GetTrialList indicates an expected call of GetTrialList.
 func (mr *MockClientMockRecorder) GetTrialList(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrialList", reflect.TypeOf((*MockClient)(nil).GetTrialList), varargs...)
 }
 
-// GetTrialTemplates mocks base method
+// GetTrialTemplates mocks base method.
 func (m *MockClient) GetTrialTemplates(arg0 ...string) (*v1.ConfigMapList, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -236,25 +236,25 @@ func (m *MockClient) GetTrialTemplates(arg0 ...string) (*v1.ConfigMapList, error
 	return ret0, ret1
 }
 
-// GetTrialTemplates indicates an expected call of GetTrialTemplates
+// GetTrialTemplates indicates an expected call of GetTrialTemplates.
 func (mr *MockClientMockRecorder) GetTrialTemplates(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrialTemplates", reflect.TypeOf((*MockClient)(nil).GetTrialTemplates), arg0...)
 }
 
-// InjectClient mocks base method
+// InjectClient mocks base method.
 func (m *MockClient) InjectClient(arg0 client.Client) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "InjectClient", arg0)
 }
 
-// InjectClient indicates an expected call of InjectClient
+// InjectClient indicates an expected call of InjectClient.
 func (mr *MockClientMockRecorder) InjectClient(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InjectClient", reflect.TypeOf((*MockClient)(nil).InjectClient), arg0)
 }
 
-// UpdateConfigMap mocks base method
+// UpdateConfigMap mocks base method.
 func (m *MockClient) UpdateConfigMap(arg0 *v1.ConfigMap) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateConfigMap", arg0)
@@ -262,13 +262,13 @@ func (m *MockClient) UpdateConfigMap(arg0 *v1.ConfigMap) error {
 	return ret0
 }
 
-// UpdateConfigMap indicates an expected call of UpdateConfigMap
+// UpdateConfigMap indicates an expected call of UpdateConfigMap.
 func (mr *MockClientMockRecorder) UpdateConfigMap(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateConfigMap", reflect.TypeOf((*MockClient)(nil).UpdateConfigMap), arg0)
 }
 
-// UpdateExperiment mocks base method
+// UpdateExperiment mocks base method.
 func (m *MockClient) UpdateExperiment(arg0 *v1alpha3.Experiment, arg1 ...string) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -280,7 +280,7 @@ func (m *MockClient) UpdateExperiment(arg0 *v1alpha3.Experiment, arg1 ...string)
 	return ret0
 }
 
-// UpdateExperiment indicates an expected call of UpdateExperiment
+// UpdateExperiment indicates an expected call of UpdateExperiment.
 func (mr *MockClientMockRecorder) UpdateExperiment(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)

--- a/pkg/mock/v1beta1/api/suggestion.go
+++ b/pkg/mock/v1beta1/api/suggestion.go
@@ -7,68 +7,68 @@ package mock
 import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "github.com/kubeflow/katib/pkg/apis/manager/v1beta1"
+	api_v1_beta1 "github.com/kubeflow/katib/pkg/apis/manager/v1beta1"
 	grpc "google.golang.org/grpc"
 	reflect "reflect"
 )
 
-// MockSuggestionClient is a mock of SuggestionClient interface
+// MockSuggestionClient is a mock of SuggestionClient interface.
 type MockSuggestionClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockSuggestionClientMockRecorder
 }
 
-// MockSuggestionClientMockRecorder is the mock recorder for MockSuggestionClient
+// MockSuggestionClientMockRecorder is the mock recorder for MockSuggestionClient.
 type MockSuggestionClientMockRecorder struct {
 	mock *MockSuggestionClient
 }
 
-// NewMockSuggestionClient creates a new mock instance
+// NewMockSuggestionClient creates a new mock instance.
 func NewMockSuggestionClient(ctrl *gomock.Controller) *MockSuggestionClient {
 	mock := &MockSuggestionClient{ctrl: ctrl}
 	mock.recorder = &MockSuggestionClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSuggestionClient) EXPECT() *MockSuggestionClientMockRecorder {
 	return m.recorder
 }
 
-// GetSuggestions mocks base method
-func (m *MockSuggestionClient) GetSuggestions(arg0 context.Context, arg1 *v1beta1.GetSuggestionsRequest, arg2 ...grpc.CallOption) (*v1beta1.GetSuggestionsReply, error) {
+// GetSuggestions mocks base method.
+func (m *MockSuggestionClient) GetSuggestions(arg0 context.Context, arg1 *api_v1_beta1.GetSuggestionsRequest, arg2 ...grpc.CallOption) (*api_v1_beta1.GetSuggestionsReply, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "GetSuggestions", varargs...)
-	ret0, _ := ret[0].(*v1beta1.GetSuggestionsReply)
+	ret0, _ := ret[0].(*api_v1_beta1.GetSuggestionsReply)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetSuggestions indicates an expected call of GetSuggestions
+// GetSuggestions indicates an expected call of GetSuggestions.
 func (mr *MockSuggestionClientMockRecorder) GetSuggestions(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSuggestions", reflect.TypeOf((*MockSuggestionClient)(nil).GetSuggestions), varargs...)
 }
 
-// ValidateAlgorithmSettings mocks base method
-func (m *MockSuggestionClient) ValidateAlgorithmSettings(arg0 context.Context, arg1 *v1beta1.ValidateAlgorithmSettingsRequest, arg2 ...grpc.CallOption) (*v1beta1.ValidateAlgorithmSettingsReply, error) {
+// ValidateAlgorithmSettings mocks base method.
+func (m *MockSuggestionClient) ValidateAlgorithmSettings(arg0 context.Context, arg1 *api_v1_beta1.ValidateAlgorithmSettingsRequest, arg2 ...grpc.CallOption) (*api_v1_beta1.ValidateAlgorithmSettingsReply, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ValidateAlgorithmSettings", varargs...)
-	ret0, _ := ret[0].(*v1beta1.ValidateAlgorithmSettingsReply)
+	ret0, _ := ret[0].(*api_v1_beta1.ValidateAlgorithmSettingsReply)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ValidateAlgorithmSettings indicates an expected call of ValidateAlgorithmSettings
+// ValidateAlgorithmSettings indicates an expected call of ValidateAlgorithmSettings.
 func (mr *MockSuggestionClientMockRecorder) ValidateAlgorithmSettings(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)

--- a/pkg/mock/v1beta1/db/db.go
+++ b/pkg/mock/v1beta1/db/db.go
@@ -6,46 +6,46 @@ package mock
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "github.com/kubeflow/katib/pkg/apis/manager/v1beta1"
+	api_v1_beta1 "github.com/kubeflow/katib/pkg/apis/manager/v1beta1"
 	reflect "reflect"
 )
 
-// MockKatibDBInterface is a mock of KatibDBInterface interface
+// MockKatibDBInterface is a mock of KatibDBInterface interface.
 type MockKatibDBInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockKatibDBInterfaceMockRecorder
 }
 
-// MockKatibDBInterfaceMockRecorder is the mock recorder for MockKatibDBInterface
+// MockKatibDBInterfaceMockRecorder is the mock recorder for MockKatibDBInterface.
 type MockKatibDBInterfaceMockRecorder struct {
 	mock *MockKatibDBInterface
 }
 
-// NewMockKatibDBInterface creates a new mock instance
+// NewMockKatibDBInterface creates a new mock instance.
 func NewMockKatibDBInterface(ctrl *gomock.Controller) *MockKatibDBInterface {
 	mock := &MockKatibDBInterface{ctrl: ctrl}
 	mock.recorder = &MockKatibDBInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockKatibDBInterface) EXPECT() *MockKatibDBInterfaceMockRecorder {
 	return m.recorder
 }
 
-// DBInit mocks base method
+// DBInit mocks base method.
 func (m *MockKatibDBInterface) DBInit() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "DBInit")
 }
 
-// DBInit indicates an expected call of DBInit
+// DBInit indicates an expected call of DBInit.
 func (mr *MockKatibDBInterfaceMockRecorder) DBInit() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DBInit", reflect.TypeOf((*MockKatibDBInterface)(nil).DBInit))
 }
 
-// DeleteObservationLog mocks base method
+// DeleteObservationLog mocks base method.
 func (m *MockKatibDBInterface) DeleteObservationLog(arg0 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteObservationLog", arg0)
@@ -53,42 +53,42 @@ func (m *MockKatibDBInterface) DeleteObservationLog(arg0 string) error {
 	return ret0
 }
 
-// DeleteObservationLog indicates an expected call of DeleteObservationLog
+// DeleteObservationLog indicates an expected call of DeleteObservationLog.
 func (mr *MockKatibDBInterfaceMockRecorder) DeleteObservationLog(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObservationLog", reflect.TypeOf((*MockKatibDBInterface)(nil).DeleteObservationLog), arg0)
 }
 
-// GetObservationLog mocks base method
-func (m *MockKatibDBInterface) GetObservationLog(arg0, arg1, arg2, arg3 string) (*v1beta1.ObservationLog, error) {
+// GetObservationLog mocks base method.
+func (m *MockKatibDBInterface) GetObservationLog(arg0, arg1, arg2, arg3 string) (*api_v1_beta1.ObservationLog, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetObservationLog", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(*v1beta1.ObservationLog)
+	ret0, _ := ret[0].(*api_v1_beta1.ObservationLog)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetObservationLog indicates an expected call of GetObservationLog
+// GetObservationLog indicates an expected call of GetObservationLog.
 func (mr *MockKatibDBInterfaceMockRecorder) GetObservationLog(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObservationLog", reflect.TypeOf((*MockKatibDBInterface)(nil).GetObservationLog), arg0, arg1, arg2, arg3)
 }
 
-// RegisterObservationLog mocks base method
-func (m *MockKatibDBInterface) RegisterObservationLog(arg0 string, arg1 *v1beta1.ObservationLog) error {
+// RegisterObservationLog mocks base method.
+func (m *MockKatibDBInterface) RegisterObservationLog(arg0 string, arg1 *api_v1_beta1.ObservationLog) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterObservationLog", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// RegisterObservationLog indicates an expected call of RegisterObservationLog
+// RegisterObservationLog indicates an expected call of RegisterObservationLog.
 func (mr *MockKatibDBInterfaceMockRecorder) RegisterObservationLog(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterObservationLog", reflect.TypeOf((*MockKatibDBInterface)(nil).RegisterObservationLog), arg0, arg1)
 }
 
-// SelectOne mocks base method
+// SelectOne mocks base method.
 func (m *MockKatibDBInterface) SelectOne() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SelectOne")
@@ -96,7 +96,7 @@ func (m *MockKatibDBInterface) SelectOne() error {
 	return ret0
 }
 
-// SelectOne indicates an expected call of SelectOne
+// SelectOne indicates an expected call of SelectOne.
 func (mr *MockKatibDBInterfaceMockRecorder) SelectOne() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectOne", reflect.TypeOf((*MockKatibDBInterface)(nil).SelectOne))

--- a/pkg/mock/v1beta1/experiment/manifest/generator.go
+++ b/pkg/mock/v1beta1/experiment/manifest/generator.go
@@ -13,30 +13,30 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MockGenerator is a mock of Generator interface
+// MockGenerator is a mock of Generator interface.
 type MockGenerator struct {
 	ctrl     *gomock.Controller
 	recorder *MockGeneratorMockRecorder
 }
 
-// MockGeneratorMockRecorder is the mock recorder for MockGenerator
+// MockGeneratorMockRecorder is the mock recorder for MockGenerator.
 type MockGeneratorMockRecorder struct {
 	mock *MockGenerator
 }
 
-// NewMockGenerator creates a new mock instance
+// NewMockGenerator creates a new mock instance.
 func NewMockGenerator(ctrl *gomock.Controller) *MockGenerator {
 	mock := &MockGenerator{ctrl: ctrl}
 	mock.recorder = &MockGeneratorMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockGenerator) EXPECT() *MockGeneratorMockRecorder {
 	return m.recorder
 }
 
-// GetMetricsCollectorImage mocks base method
+// GetMetricsCollectorImage mocks base method.
 func (m *MockGenerator) GetMetricsCollectorImage(arg0 v1beta1.CollectorKind) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetricsCollectorImage", arg0)
@@ -45,28 +45,28 @@ func (m *MockGenerator) GetMetricsCollectorImage(arg0 v1beta1.CollectorKind) (st
 	return ret0, ret1
 }
 
-// GetMetricsCollectorImage indicates an expected call of GetMetricsCollectorImage
+// GetMetricsCollectorImage indicates an expected call of GetMetricsCollectorImage.
 func (mr *MockGeneratorMockRecorder) GetMetricsCollectorImage(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricsCollectorImage", reflect.TypeOf((*MockGenerator)(nil).GetMetricsCollectorImage), arg0)
 }
 
-// GetRunSpecWithHyperParameters mocks base method
-func (m *MockGenerator) GetRunSpecWithHyperParameters(arg0 *v1beta10.Experiment, arg1, arg2 string, arg3 []v1beta1.ParameterAssignment) (*unstructured.Unstructured, error) {
+// GetRunSpecWithHyperParameters mocks base method.
+func (m *MockGenerator) GetRunSpecWithHyperParameters(arg0 *v1beta10.Experiment, arg1, arg2 string, arg3 []v1beta1.ParameterAssignment, arg4 map[string]string) (*unstructured.Unstructured, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRunSpecWithHyperParameters", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetRunSpecWithHyperParameters", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*unstructured.Unstructured)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetRunSpecWithHyperParameters indicates an expected call of GetRunSpecWithHyperParameters
-func (mr *MockGeneratorMockRecorder) GetRunSpecWithHyperParameters(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// GetRunSpecWithHyperParameters indicates an expected call of GetRunSpecWithHyperParameters.
+func (mr *MockGeneratorMockRecorder) GetRunSpecWithHyperParameters(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunSpecWithHyperParameters", reflect.TypeOf((*MockGenerator)(nil).GetRunSpecWithHyperParameters), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunSpecWithHyperParameters", reflect.TypeOf((*MockGenerator)(nil).GetRunSpecWithHyperParameters), arg0, arg1, arg2, arg3, arg4)
 }
 
-// GetSuggestionConfigData mocks base method
+// GetSuggestionConfigData mocks base method.
 func (m *MockGenerator) GetSuggestionConfigData(arg0 string) (map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSuggestionConfigData", arg0)
@@ -75,13 +75,13 @@ func (m *MockGenerator) GetSuggestionConfigData(arg0 string) (map[string]string,
 	return ret0, ret1
 }
 
-// GetSuggestionConfigData indicates an expected call of GetSuggestionConfigData
+// GetSuggestionConfigData indicates an expected call of GetSuggestionConfigData.
 func (mr *MockGeneratorMockRecorder) GetSuggestionConfigData(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSuggestionConfigData", reflect.TypeOf((*MockGenerator)(nil).GetSuggestionConfigData), arg0)
 }
 
-// GetTrialTemplate mocks base method
+// GetTrialTemplate mocks base method.
 func (m *MockGenerator) GetTrialTemplate(arg0 *v1beta10.Experiment) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTrialTemplate", arg0)
@@ -90,19 +90,19 @@ func (m *MockGenerator) GetTrialTemplate(arg0 *v1beta10.Experiment) (string, err
 	return ret0, ret1
 }
 
-// GetTrialTemplate indicates an expected call of GetTrialTemplate
+// GetTrialTemplate indicates an expected call of GetTrialTemplate.
 func (mr *MockGeneratorMockRecorder) GetTrialTemplate(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrialTemplate", reflect.TypeOf((*MockGenerator)(nil).GetTrialTemplate), arg0)
 }
 
-// InjectClient mocks base method
+// InjectClient mocks base method.
 func (m *MockGenerator) InjectClient(arg0 client.Client) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "InjectClient", arg0)
 }
 
-// InjectClient indicates an expected call of InjectClient
+// InjectClient indicates an expected call of InjectClient.
 func (mr *MockGeneratorMockRecorder) InjectClient(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InjectClient", reflect.TypeOf((*MockGenerator)(nil).InjectClient), arg0)

--- a/pkg/mock/v1beta1/experiment/manifest/generator.go
+++ b/pkg/mock/v1beta1/experiment/manifest/generator.go
@@ -52,18 +52,18 @@ func (mr *MockGeneratorMockRecorder) GetMetricsCollectorImage(arg0 interface{}) 
 }
 
 // GetRunSpecWithHyperParameters mocks base method.
-func (m *MockGenerator) GetRunSpecWithHyperParameters(arg0 *v1beta10.Experiment, arg1, arg2 string, arg3 []v1beta1.ParameterAssignment, arg4 map[string]string) (*unstructured.Unstructured, error) {
+func (m *MockGenerator) GetRunSpecWithHyperParameters(arg0 *v1beta10.Experiment, arg1, arg2 string, arg3 []v1beta1.ParameterAssignment) (*unstructured.Unstructured, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRunSpecWithHyperParameters", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "GetRunSpecWithHyperParameters", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*unstructured.Unstructured)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRunSpecWithHyperParameters indicates an expected call of GetRunSpecWithHyperParameters.
-func (mr *MockGeneratorMockRecorder) GetRunSpecWithHyperParameters(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockGeneratorMockRecorder) GetRunSpecWithHyperParameters(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunSpecWithHyperParameters", reflect.TypeOf((*MockGenerator)(nil).GetRunSpecWithHyperParameters), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunSpecWithHyperParameters", reflect.TypeOf((*MockGenerator)(nil).GetRunSpecWithHyperParameters), arg0, arg1, arg2, arg3)
 }
 
 // GetSuggestionConfigData mocks base method.

--- a/pkg/mock/v1beta1/experiment/suggestion/suggestion.go
+++ b/pkg/mock/v1beta1/experiment/suggestion/suggestion.go
@@ -11,30 +11,30 @@ import (
 	reflect "reflect"
 )
 
-// MockSuggestion is a mock of Suggestion interface
+// MockSuggestion is a mock of Suggestion interface.
 type MockSuggestion struct {
 	ctrl     *gomock.Controller
 	recorder *MockSuggestionMockRecorder
 }
 
-// MockSuggestionMockRecorder is the mock recorder for MockSuggestion
+// MockSuggestionMockRecorder is the mock recorder for MockSuggestion.
 type MockSuggestionMockRecorder struct {
 	mock *MockSuggestion
 }
 
-// NewMockSuggestion creates a new mock instance
+// NewMockSuggestion creates a new mock instance.
 func NewMockSuggestion(ctrl *gomock.Controller) *MockSuggestion {
 	mock := &MockSuggestion{ctrl: ctrl}
 	mock.recorder = &MockSuggestionMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSuggestion) EXPECT() *MockSuggestionMockRecorder {
 	return m.recorder
 }
 
-// GetOrCreateSuggestion mocks base method
+// GetOrCreateSuggestion mocks base method.
 func (m *MockSuggestion) GetOrCreateSuggestion(arg0 *v1beta1.Experiment, arg1 int32) (*v1beta10.Suggestion, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOrCreateSuggestion", arg0, arg1)
@@ -43,13 +43,13 @@ func (m *MockSuggestion) GetOrCreateSuggestion(arg0 *v1beta1.Experiment, arg1 in
 	return ret0, ret1
 }
 
-// GetOrCreateSuggestion indicates an expected call of GetOrCreateSuggestion
+// GetOrCreateSuggestion indicates an expected call of GetOrCreateSuggestion.
 func (mr *MockSuggestionMockRecorder) GetOrCreateSuggestion(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateSuggestion", reflect.TypeOf((*MockSuggestion)(nil).GetOrCreateSuggestion), arg0, arg1)
 }
 
-// UpdateSuggestion mocks base method
+// UpdateSuggestion mocks base method.
 func (m *MockSuggestion) UpdateSuggestion(arg0 *v1beta10.Suggestion) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSuggestion", arg0)
@@ -57,13 +57,13 @@ func (m *MockSuggestion) UpdateSuggestion(arg0 *v1beta10.Suggestion) error {
 	return ret0
 }
 
-// UpdateSuggestion indicates an expected call of UpdateSuggestion
+// UpdateSuggestion indicates an expected call of UpdateSuggestion.
 func (mr *MockSuggestionMockRecorder) UpdateSuggestion(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSuggestion", reflect.TypeOf((*MockSuggestion)(nil).UpdateSuggestion), arg0)
 }
 
-// UpdateSuggestionStatus mocks base method
+// UpdateSuggestionStatus mocks base method.
 func (m *MockSuggestion) UpdateSuggestionStatus(arg0 *v1beta10.Suggestion) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSuggestionStatus", arg0)
@@ -71,7 +71,7 @@ func (m *MockSuggestion) UpdateSuggestionStatus(arg0 *v1beta10.Suggestion) error
 	return ret0
 }
 
-// UpdateSuggestionStatus indicates an expected call of UpdateSuggestionStatus
+// UpdateSuggestionStatus indicates an expected call of UpdateSuggestionStatus.
 func (mr *MockSuggestionMockRecorder) UpdateSuggestionStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSuggestionStatus", reflect.TypeOf((*MockSuggestion)(nil).UpdateSuggestionStatus), arg0)

--- a/pkg/mock/v1beta1/trial/managerclient/katibmanager.go
+++ b/pkg/mock/v1beta1/trial/managerclient/katibmanager.go
@@ -7,58 +7,58 @@ package mock
 import (
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/kubeflow/katib/pkg/apis/controller/trials/v1beta1"
-	v1beta10 "github.com/kubeflow/katib/pkg/apis/manager/v1beta1"
+	api_v1_beta1 "github.com/kubeflow/katib/pkg/apis/manager/v1beta1"
 	reflect "reflect"
 )
 
-// MockManagerClient is a mock of ManagerClient interface
+// MockManagerClient is a mock of ManagerClient interface.
 type MockManagerClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockManagerClientMockRecorder
 }
 
-// MockManagerClientMockRecorder is the mock recorder for MockManagerClient
+// MockManagerClientMockRecorder is the mock recorder for MockManagerClient.
 type MockManagerClientMockRecorder struct {
 	mock *MockManagerClient
 }
 
-// NewMockManagerClient creates a new mock instance
+// NewMockManagerClient creates a new mock instance.
 func NewMockManagerClient(ctrl *gomock.Controller) *MockManagerClient {
 	mock := &MockManagerClient{ctrl: ctrl}
 	mock.recorder = &MockManagerClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockManagerClient) EXPECT() *MockManagerClientMockRecorder {
 	return m.recorder
 }
 
-// DeleteTrialObservationLog mocks base method
-func (m *MockManagerClient) DeleteTrialObservationLog(arg0 *v1beta1.Trial) (*v1beta10.DeleteObservationLogReply, error) {
+// DeleteTrialObservationLog mocks base method.
+func (m *MockManagerClient) DeleteTrialObservationLog(arg0 *v1beta1.Trial) (*api_v1_beta1.DeleteObservationLogReply, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteTrialObservationLog", arg0)
-	ret0, _ := ret[0].(*v1beta10.DeleteObservationLogReply)
+	ret0, _ := ret[0].(*api_v1_beta1.DeleteObservationLogReply)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DeleteTrialObservationLog indicates an expected call of DeleteTrialObservationLog
+// DeleteTrialObservationLog indicates an expected call of DeleteTrialObservationLog.
 func (mr *MockManagerClientMockRecorder) DeleteTrialObservationLog(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTrialObservationLog", reflect.TypeOf((*MockManagerClient)(nil).DeleteTrialObservationLog), arg0)
 }
 
-// GetTrialObservationLog mocks base method
-func (m *MockManagerClient) GetTrialObservationLog(arg0 *v1beta1.Trial) (*v1beta10.GetObservationLogReply, error) {
+// GetTrialObservationLog mocks base method.
+func (m *MockManagerClient) GetTrialObservationLog(arg0 *v1beta1.Trial) (*api_v1_beta1.GetObservationLogReply, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTrialObservationLog", arg0)
-	ret0, _ := ret[0].(*v1beta10.GetObservationLogReply)
+	ret0, _ := ret[0].(*api_v1_beta1.GetObservationLogReply)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetTrialObservationLog indicates an expected call of GetTrialObservationLog
+// GetTrialObservationLog indicates an expected call of GetTrialObservationLog.
 func (mr *MockManagerClientMockRecorder) GetTrialObservationLog(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrialObservationLog", reflect.TypeOf((*MockManagerClient)(nil).GetTrialObservationLog), arg0)

--- a/pkg/mock/v1beta1/util/katibclient/katibclient.go
+++ b/pkg/mock/v1beta1/util/katibclient/katibclient.go
@@ -15,30 +15,30 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MockClient is a mock of Client interface
+// MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient
+// MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance
+// NewMockClient creates a new mock instance.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// CreateRuntimeObject mocks base method
+// CreateRuntimeObject mocks base method.
 func (m *MockClient) CreateRuntimeObject(arg0 runtime.Object) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRuntimeObject", arg0)
@@ -46,13 +46,13 @@ func (m *MockClient) CreateRuntimeObject(arg0 runtime.Object) error {
 	return ret0
 }
 
-// CreateRuntimeObject indicates an expected call of CreateRuntimeObject
+// CreateRuntimeObject indicates an expected call of CreateRuntimeObject.
 func (mr *MockClientMockRecorder) CreateRuntimeObject(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRuntimeObject", reflect.TypeOf((*MockClient)(nil).CreateRuntimeObject), arg0)
 }
 
-// DeleteRuntimeObject mocks base method
+// DeleteRuntimeObject mocks base method.
 func (m *MockClient) DeleteRuntimeObject(arg0 runtime.Object) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRuntimeObject", arg0)
@@ -60,13 +60,13 @@ func (m *MockClient) DeleteRuntimeObject(arg0 runtime.Object) error {
 	return ret0
 }
 
-// DeleteRuntimeObject indicates an expected call of DeleteRuntimeObject
+// DeleteRuntimeObject indicates an expected call of DeleteRuntimeObject.
 func (mr *MockClientMockRecorder) DeleteRuntimeObject(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRuntimeObject", reflect.TypeOf((*MockClient)(nil).DeleteRuntimeObject), arg0)
 }
 
-// GetClient mocks base method
+// GetClient mocks base method.
 func (m *MockClient) GetClient() client.Client {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClient")
@@ -74,13 +74,13 @@ func (m *MockClient) GetClient() client.Client {
 	return ret0
 }
 
-// GetClient indicates an expected call of GetClient
+// GetClient indicates an expected call of GetClient.
 func (mr *MockClientMockRecorder) GetClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClient", reflect.TypeOf((*MockClient)(nil).GetClient))
 }
 
-// GetConfigMap mocks base method
+// GetConfigMap mocks base method.
 func (m *MockClient) GetConfigMap(arg0 string, arg1 ...string) (map[string]string, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -93,14 +93,14 @@ func (m *MockClient) GetConfigMap(arg0 string, arg1 ...string) (map[string]strin
 	return ret0, ret1
 }
 
-// GetConfigMap indicates an expected call of GetConfigMap
+// GetConfigMap indicates an expected call of GetConfigMap.
 func (mr *MockClientMockRecorder) GetConfigMap(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigMap", reflect.TypeOf((*MockClient)(nil).GetConfigMap), varargs...)
 }
 
-// GetExperiment mocks base method
+// GetExperiment mocks base method.
 func (m *MockClient) GetExperiment(arg0 string, arg1 ...string) (*v1beta1.Experiment, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -113,14 +113,14 @@ func (m *MockClient) GetExperiment(arg0 string, arg1 ...string) (*v1beta1.Experi
 	return ret0, ret1
 }
 
-// GetExperiment indicates an expected call of GetExperiment
+// GetExperiment indicates an expected call of GetExperiment.
 func (mr *MockClientMockRecorder) GetExperiment(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExperiment", reflect.TypeOf((*MockClient)(nil).GetExperiment), varargs...)
 }
 
-// GetExperimentList mocks base method
+// GetExperimentList mocks base method.
 func (m *MockClient) GetExperimentList(arg0 ...string) (*v1beta1.ExperimentList, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -133,13 +133,13 @@ func (m *MockClient) GetExperimentList(arg0 ...string) (*v1beta1.ExperimentList,
 	return ret0, ret1
 }
 
-// GetExperimentList indicates an expected call of GetExperimentList
+// GetExperimentList indicates an expected call of GetExperimentList.
 func (mr *MockClientMockRecorder) GetExperimentList(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExperimentList", reflect.TypeOf((*MockClient)(nil).GetExperimentList), arg0...)
 }
 
-// GetNamespaceList mocks base method
+// GetNamespaceList mocks base method.
 func (m *MockClient) GetNamespaceList() (*v1.NamespaceList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNamespaceList")
@@ -148,13 +148,13 @@ func (m *MockClient) GetNamespaceList() (*v1.NamespaceList, error) {
 	return ret0, ret1
 }
 
-// GetNamespaceList indicates an expected call of GetNamespaceList
+// GetNamespaceList indicates an expected call of GetNamespaceList.
 func (mr *MockClientMockRecorder) GetNamespaceList() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespaceList", reflect.TypeOf((*MockClient)(nil).GetNamespaceList))
 }
 
-// GetSuggestion mocks base method
+// GetSuggestion mocks base method.
 func (m *MockClient) GetSuggestion(arg0 string, arg1 ...string) (*v1beta10.Suggestion, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -167,14 +167,14 @@ func (m *MockClient) GetSuggestion(arg0 string, arg1 ...string) (*v1beta10.Sugge
 	return ret0, ret1
 }
 
-// GetSuggestion indicates an expected call of GetSuggestion
+// GetSuggestion indicates an expected call of GetSuggestion.
 func (mr *MockClientMockRecorder) GetSuggestion(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSuggestion", reflect.TypeOf((*MockClient)(nil).GetSuggestion), varargs...)
 }
 
-// GetTrial mocks base method
+// GetTrial mocks base method.
 func (m *MockClient) GetTrial(arg0 string, arg1 ...string) (*v1beta11.Trial, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -187,14 +187,14 @@ func (m *MockClient) GetTrial(arg0 string, arg1 ...string) (*v1beta11.Trial, err
 	return ret0, ret1
 }
 
-// GetTrial indicates an expected call of GetTrial
+// GetTrial indicates an expected call of GetTrial.
 func (mr *MockClientMockRecorder) GetTrial(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrial", reflect.TypeOf((*MockClient)(nil).GetTrial), varargs...)
 }
 
-// GetTrialList mocks base method
+// GetTrialList mocks base method.
 func (m *MockClient) GetTrialList(arg0 string, arg1 ...string) (*v1beta11.TrialList, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -207,14 +207,14 @@ func (m *MockClient) GetTrialList(arg0 string, arg1 ...string) (*v1beta11.TrialL
 	return ret0, ret1
 }
 
-// GetTrialList indicates an expected call of GetTrialList
+// GetTrialList indicates an expected call of GetTrialList.
 func (mr *MockClientMockRecorder) GetTrialList(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrialList", reflect.TypeOf((*MockClient)(nil).GetTrialList), varargs...)
 }
 
-// GetTrialTemplates mocks base method
+// GetTrialTemplates mocks base method.
 func (m *MockClient) GetTrialTemplates(arg0 ...string) (*v1.ConfigMapList, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -227,25 +227,25 @@ func (m *MockClient) GetTrialTemplates(arg0 ...string) (*v1.ConfigMapList, error
 	return ret0, ret1
 }
 
-// GetTrialTemplates indicates an expected call of GetTrialTemplates
+// GetTrialTemplates indicates an expected call of GetTrialTemplates.
 func (mr *MockClientMockRecorder) GetTrialTemplates(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrialTemplates", reflect.TypeOf((*MockClient)(nil).GetTrialTemplates), arg0...)
 }
 
-// InjectClient mocks base method
+// InjectClient mocks base method.
 func (m *MockClient) InjectClient(arg0 client.Client) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "InjectClient", arg0)
 }
 
-// InjectClient indicates an expected call of InjectClient
+// InjectClient indicates an expected call of InjectClient.
 func (mr *MockClientMockRecorder) InjectClient(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InjectClient", reflect.TypeOf((*MockClient)(nil).InjectClient), arg0)
 }
 
-// UpdateRuntimeObject mocks base method
+// UpdateRuntimeObject mocks base method.
 func (m *MockClient) UpdateRuntimeObject(arg0 runtime.Object) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateRuntimeObject", arg0)
@@ -253,7 +253,7 @@ func (m *MockClient) UpdateRuntimeObject(arg0 runtime.Object) error {
 	return ret0
 }
 
-// UpdateRuntimeObject indicates an expected call of UpdateRuntimeObject
+// UpdateRuntimeObject indicates an expected call of UpdateRuntimeObject.
 func (mr *MockClientMockRecorder) UpdateRuntimeObject(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRuntimeObject", reflect.TypeOf((*MockClient)(nil).UpdateRuntimeObject), arg0)

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -244,22 +244,6 @@ func (g *DefaultValidator) validateTrialTemplate(instance *experimentsv1beta1.Ex
 		return fmt.Errorf("Parameters: %v in spec.trialTemplate not found in spec.trialParameters: %v", notReplacedParams, trialTemplate.TrialParameters)
 	}
 
-	// Build a mock trial meta map, because we can't access `buildTrialMetaForRunSpec` function here
-	mockTrialMeta := map[string]string{
-		consts.TrialTemplateMetaKeyOfName:       "",
-		consts.TrialTemplateMetaKeyOfNamespace:  "",
-		consts.TrialTemplateMetaKeyOfKind:       "",
-		consts.TrialTemplateMetaKeyOfAPIVersion: "",
-	}
-	// Check if Trial template contains invalid reference of trial metadata
-	regex := regexp.MustCompile(consts.TrialTemplateMetaReplaceFormatRegex)
-	for _, repr := range regex.FindAllString(trialTemplateStr, -1) {
-		repr = repr[len("{trialSpec.metadata.") : len(repr)-1]
-		if _, contains := mockTrialMeta[repr]; !contains {
-			return fmt.Errorf("Metadata: found invalid reference of trial metadata %v", repr)
-		}
-	}
-
 	// Check if Trial template can be converted to unstructured
 	runSpec, err := util.ConvertStringToUnstructured(trialTemplateStr)
 	if err != nil {

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -184,6 +184,13 @@ func (g *DefaultValidator) validateTrialTemplate(instance *experimentsv1beta1.Ex
 		return fmt.Errorf("spec.trialTemplate.trialParameters must be specified")
 	}
 
+	// Check if parameter names conflict with preserved names
+	for _, parameter := range trialTemplate.TrialParameters {
+		if parameter.Name == consts.TrialTemplateTrialName || parameter.Name == consts.TrialTemplateTrialNamespace {
+			return fmt.Errorf("Name of trialParameters should not be %s or %s", consts.TrialTemplateTrialName, consts.TrialTemplateTrialNamespace)
+		}
+	}
+
 	// Check if trialSpec or configMap exists
 	if trialTemplate.TrialSource.TrialSpec == nil && trialTemplate.TrialSource.ConfigMap == nil {
 		return fmt.Errorf("spec.trialTemplate.trialSpec or spec.trialTemplate.configMap must be specified")

--- a/pkg/webhook/v1beta1/experiment/validator/validator_test.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	batchv1 "k8s.io/api/batch/v1"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -15,7 +15,7 @@ import (
 	commonv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
 	experimentsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
-	util "github.com/kubeflow/katib/pkg/controller.v1beta1/util"
+	"github.com/kubeflow/katib/pkg/controller.v1beta1/util"
 	manifestmock "github.com/kubeflow/katib/pkg/mock/v1beta1/experiment/manifest"
 )
 
@@ -361,7 +361,7 @@ spec:
 		Err             bool
 		testDescription string
 	}{
-		// TrialParamters is nil
+		// TrialParameters is nil
 		{
 			Instance: func() *experimentsv1beta1.Experiment {
 				i := newFakeInstance()
@@ -370,6 +370,20 @@ spec:
 			}(),
 			Err:             true,
 			testDescription: "Trial parameters is nil",
+		},
+		// TrialParameters should not be equal to preserved trial information
+		{
+			Instance: func() *experimentsv1beta1.Experiment {
+				i := newFakeInstance()
+				trialParameters := append(
+					i.Spec.TrialTemplate.TrialParameters, experimentsv1beta1.TrialParameterSpec{Name: consts.TrialTemplateTrialName})
+				trialParameters = append(
+					trialParameters, experimentsv1beta1.TrialParameterSpec{Name: consts.TrialTemplateTrialNamespace})
+				i.Spec.TrialTemplate.TrialParameters = trialParameters
+				return i
+			}(),
+			Err:             true,
+			testDescription: "TrialParameters should not be equal to preserved trial information",
 		},
 		// TrialSpec and ConfigMap is nil
 		{


### PR DESCRIPTION
After the refactor of trial template rendering in v1beta1, users can only fetch nothing but hyperparameter values. But, in v1alpha3, users can fetch trial name via placeholder (`{{.Trial}}`), which is quite useful in many conditions, such as appending it at the end of model storage url/path to avoid model overwriting.

This PR is trying to bring this feature back through additional trial template transformation, which is specialized for metadata injection. 

cc @andreyvelich @gaocegege  @johnugeorge 