### PR TITLE
Add e2e test for DARTS

### DIFF
--- a/examples/v1beta1/nas/darts-cnn-cifar10/model.py
+++ b/examples/v1beta1/nas/darts-cnn-cifar10/model.py
@@ -68,7 +68,6 @@ class NetworkCNN(nn.Module):
         self.num_layers = num_layers
         self.criterion = criterion
 
-        # TODO: Algorithm settings?
         self.num_nodes = num_nodes
         self.stem_multiplier = stem_multiplier
 

--- a/examples/v1beta1/nas/darts-example-cpu.yaml
+++ b/examples/v1beta1/nas/darts-example-cpu.yaml
@@ -1,0 +1,69 @@
+apiVersion: "kubeflow.org/v1beta1"
+kind: Experiment
+metadata:
+  namespace: kubeflow
+  name: darts-example-cpu
+spec:
+  parallelTrialCount: 1
+  maxTrialCount: 1
+  maxFailedTrialCount: 1
+  objective:
+    type: maximize
+    objectiveMetricName: Best-Genotype
+  metricsCollectorSpec:
+    collector:
+      kind: StdOut
+    source:
+      filter:
+        metricsFormat:
+          - "([\\w-]+)=(Genotype.*)"
+  algorithm:
+    algorithmName: darts
+    algorithmSettings:
+      - name: num_epochs
+        value: "1"
+      - name: num_nodes
+        value: "1"
+      - name: init_channels
+        value: "1"
+      - name: stem_multiplier
+        value: "1"
+  nasConfig:
+    graphConfig:
+      numLayers: 1
+    operations:
+      - operationType: max_pooling
+        parameters:
+          - name: filter_size
+            parameterType: categorical
+            feasibleSpace:
+              list:
+                - "3"
+  trialTemplate:
+    trialParameters:
+      - name: algorithmSettings
+        description: Algorithm settings of DARTS Experiment
+        reference: algorithm-settings
+      - name: searchSpace
+        description: Search Space of DARTS Experiment
+        reference: search-space
+      - name: numberLayers
+        description: Number of Neural Network layers
+        reference: num-layers
+    trialSpec:
+      apiVersion: batch/v1
+      kind: Job
+      spec:
+        template:
+          spec:
+            containers:
+              - name: training-container
+                image: docker.io/kubeflowkatib/darts-cnn-cifar10
+                imagePullPolicy: Always
+                command:
+                  - python3
+                  - run_trial.py
+                  - --algorithm-settings="${trialParameters.algorithmSettings}"
+                  - --search-space="${trialParameters.searchSpace}"
+                  - --num-layers="${trialParameters.numberLayers}"
+            restartPolicy: Never

--- a/pkg/suggestion/v1beta1/nas/darts/service.py
+++ b/pkg/suggestion/v1beta1/nas/darts/service.py
@@ -95,7 +95,6 @@ def get_search_space(operations):
     return search_space
 
 
-# TODO: Add more algorithm settings
 def get_algorithm_settings(settings_raw):
 
     algorithm_settings_default = {

--- a/test/e2e/v1beta1/run-e2e-experiment.go
+++ b/test/e2e/v1beta1/run-e2e-experiment.go
@@ -65,9 +65,10 @@ func main() {
 	if err != nil {
 		log.Fatal("NewClient for Katib failed: ", err)
 	}
-	if exp.Spec.Algorithm.AlgorithmName != "hyperband" {
+	if exp.Spec.Algorithm.AlgorithmName != "hyperband" && exp.Spec.Algorithm.AlgorithmName != "darts" {
 		// Hyperband will validate the parallel trial count,
 		// thus we should not change it.
+		// Not necessary to test parallel Trials for Darts
 		var maxtrials int32 = 3
 		var paralleltrials int32 = 2
 		exp.Spec.MaxTrialCount = &maxtrials

--- a/test/scripts/v1beta1/run-suggestion-darts.sh
+++ b/test/scripts/v1beta1/run-suggestion-darts.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This shell script is used to build a cluster and create a namespace from our
+# argo workflow
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME}"
+ZONE="${GCP_ZONE}"
+PROJECT="${GCP_PROJECT}"
+GO_DIR=${GOPATH}/src/github.com/${REPO_OWNER}/${REPO_NAME}
+
+echo "Activating service-account"
+gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+
+echo "Configuring kubectl"
+
+echo "CLUSTER_NAME: ${CLUSTER_NAME}"
+echo "ZONE: ${GCP_ZONE}"
+echo "PROJECT: ${GCP_PROJECT}"
+
+gcloud --project ${PROJECT} container clusters get-credentials ${CLUSTER_NAME} \
+  --zone ${ZONE}
+kubectl config set-context $(kubectl config current-context) --namespace=default
+USER=$(gcloud config get-value account)
+
+echo "All Katib components are running."
+kubectl version
+kubectl cluster-info
+echo "Katib deployments"
+kubectl -n kubeflow get deploy
+echo "Katib services"
+kubectl -n kubeflow get svc
+echo "Katib pods"
+kubectl -n kubeflow get pod
+
+cd ${GO_DIR}/test/e2e/v1beta1
+
+echo "Running e2e DARTS experiment"
+export KUBECONFIG=$HOME/.kube/config
+./run-e2e-experiment ../../../examples/v1beta1/nas/darts-example-cpu.yaml
+kubectl -n kubeflow describe experiment darts-example-cpu
+kubectl -n kubeflow delete experiment darts-example-cpu
+
+exit 0

--- a/test/workflows/components/workflows-v1beta1.libsonnet
+++ b/test/workflows/components/workflows-v1beta1.libsonnet
@@ -321,6 +321,10 @@
                     name: "run-never-resume-e2e-tests",
                     template: "run-never-resume-e2e-tests",
                   },
+                  {
+                    name: "run-darts-e2e-tests",
+                    template: "run-darts-e2e-tests",
+                  },
                 ],
               ],
             },
@@ -403,6 +407,9 @@
             $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTemplate("run-never-resume-e2e-tests", testWorkerImage, [
               "test/scripts/v1beta1/run-never-resume.sh",
             ]),  // run never resume suggestion test
+            $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTemplate("run-darts-e2e-tests", testWorkerImage, [
+              "test/scripts/v1beta1/run-suggestion-darts.sh",
+            ]),  // run darts algorithm
             $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTemplate("create-pr-symlink", testWorkerImage, [
               "python",
               "-m",


### PR DESCRIPTION
I added e2e test for DARTS for v1beta1.
This example should be run fast on CPU because it has only 1 operation, 1 layer, 1 darts node and parameters for stem layer are minimal.

/assign @gaocegege @johnugeorge 