### PR TITLE
Add FPGA accelerated examples

### DIFF
--- a/examples/v1alpha3/fpga/README.md
+++ b/examples/v1alpha3/fpga/README.md
@@ -1,0 +1,1 @@
+see [v1beta1/fpga](../../v1beta1/fpga)

--- a/examples/v1alpha3/fpga/xgboost-example.yaml
+++ b/examples/v1alpha3/fpga/xgboost-example.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: kubeflow.org/v1alpha3
+kind: Experiment
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: xgb-svhn-fpga
+  namespace: kubeflow
+spec:
+  algorithm:
+    algorithmName: random
+  maxFailedTrialCount: 3
+  maxTrialCount: 10
+  metricsCollectorSpec:
+    collector:
+      kind: StdOut
+  objective:
+    additionalMetricNames:
+      - time
+    goal: 0.99
+    objectiveMetricName: accuracy
+    type: maximize
+  parallelTrialCount: 1
+  parameters:
+    - feasibleSpace:
+        min: "0.00"
+        max: "0.05"
+      name: alpha
+      parameterType: double
+    - feasibleSpace:
+        min: "0.1"
+        max: "0.4"
+      name: eta
+      parameterType: double
+    - feasibleSpace:
+        min: "0.6"
+        max: "1.0"
+      name: subsample
+      parameterType: double
+  trialTemplate:
+    goTemplate:
+      rawTemplate: |-
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: {{.Trial}}
+          namespace: {{.NameSpace}}
+        spec:
+          template:
+            spec:
+              containers:
+                - name: {{.Trial}}
+                  image: "docker.io/inaccel/jupyter:lab"
+                  command:
+                    - python3
+                    - XGBoost/parameter-tuning.py
+                  args:
+                    - "--name=SVHN"
+                    - "--test-size=0.35"
+                    - "--tree-method=fpga_exact"
+                    - "--bitstream=https://store.inaccel.com/artifactory/bitstreams/xilinx/aws-vu9p-f1/dynamic_5.0/com/inaccel/xgboost/0.1/2exact"
+                    - "--max-depth=10"
+                    {{- with .HyperParameters}}
+                    {{- range .}}
+                    - "--{{.Name}}={{.Value}}"
+                    {{- end}}
+                    {{- end}}
+                  resources:
+                    limits:
+                      xilinx/aws-vu9p-f1: 1
+              restartPolicy: Never

--- a/examples/v1alpha3/fpga/xgboost-example.yaml
+++ b/examples/v1alpha3/fpga/xgboost-example.yaml
@@ -11,9 +11,6 @@ spec:
     algorithmName: random
   maxFailedTrialCount: 3
   maxTrialCount: 10
-  metricsCollectorSpec:
-    collector:
-      kind: StdOut
   objective:
     additionalMetricNames:
       - time

--- a/examples/v1beta1/README.md
+++ b/examples/v1beta1/README.md
@@ -383,3 +383,9 @@ gcr.io/kubeflow-ci/pytorch-dist-mnist-test
 ```
 gcr.io/kubeflow-ci/tf-mnist-with-summaries
 ```
+
+- FPGA XGBoost Parameter Tuning example, [source](https://github.com/inaccel/jupyter/blob/master/lab/dot/XGBoost/parameter-tuning.py)
+
+```
+docker.io/inaccel/jupyter:lab
+```

--- a/examples/v1beta1/fpga/README.md
+++ b/examples/v1beta1/fpga/README.md
@@ -1,0 +1,70 @@
+# FPGA support for your Katib Experiments
+
+Let's spawn [F1 instances](https://aws.amazon.com/ec2/instance-types/f1) and
+accelerate time-consuming Katib experiments on AWS, with zero FPGA knowledge!
+
+If you want to read more about provisioning FPGA resources and deploying
+accelerated applications (e.g. Kubeflow Pipelines) on any Kubernetes cluster,
+visit the [InAccel](https://docs.inaccel.com) documentation.
+
+## EKS*-optimized AMI with FPGA support
+
+**For development and testing purposes you can still [deploy Kubeflow Katib
+using Minikube](https://kubeflow.org/docs/started/workstation/minikube-linux) in
+a single AMI instance. In production environments, Amazon's managed Kubernetes
+service ([EKS](https://aws.amazon.com/eks)) is recommended.*
+
+The InAccel EKS-optimized FPGA AMI is built on top of the standard [Amazon
+EKS-optimized Linux AMI](https://aws.amazon.com/marketplace/pp/B07GRMYQR5), and
+is configured to serve as an optional image for Amazon EKS worker nodes to
+support FPGA based workloads.
+
+In addition to the standard Amazon EKS-optimized AMI configuration, the FPGA AMI
+includes the following:
+
+* Xilinx FPGA drivers
+* InAccel runtime (as the default runtime)
+
+The AMI IDs for the latest InAccel EKS-optimized FPGA AMI are shown in the
+following table.
+
+| AWS Region                          | Kubernetes version 1.17.7 | Kubernetes version 1.16.12 |
+| ----------------------------------- | ------------------------- | -------------------------- |
+| US East (N. Virginia) (`us-east-1`) | `ami-0c4e0b85781a9dde3`   | `ami-0519d9b242546530a`    |
+
+> **Note**: The EKS-optimized FPGA AMI also supports non-FPGA instance types.
+
+## Enabling FPGA based workloads
+
+The following section describes how to run a workload on an FPGA based instance
+with the InAccel EKS-optimized FPGA AMI.
+
+After your FPGA worker nodes join your cluster, you must apply the [InAccel FPGA
+Operator](https://hub.helm.sh/charts/inaccel/fpga-operator) for Kubernetes, as a
+Helm app on your cluster, with the following command.
+
+```sh
+helm repo add inaccel https://setup.inaccel.com/helm
+
+helm install inaccel inaccel/fpga-operator --set license=...
+```
+
+Get your free Community Edition [license](https://inaccel.com/license), if it's
+the first time that you use InAccel toolset.
+
+You can verify that your nodes have available FPGAs with the following command:
+
+```sh
+kubectl get nodes -o custom-columns=NAME:metadata.name,FPGAS:.status.capacity.xilinx/aws-vu9p-f1
+```
+
+## Experiment
+
+You can submit a new accelerated Experiment and check your Experiment results
+using the Web UI, as usual.
+
+#### XGBoost Parameter Tuning [[source](https://github.com/inaccel/jupyter/blob/master/lab/dot/XGBoost/parameter-tuning.py)]
+
+```sh
+kubectl apply -f xgboost-example.yaml
+```

--- a/examples/v1beta1/fpga/xgboost-example.yaml
+++ b/examples/v1beta1/fpga/xgboost-example.yaml
@@ -40,13 +40,13 @@ spec:
   trialTemplate:
     trialParameters:
       - name: alpha
-        description: "L1 regularization term on weights"
+        description: L1 regularization term on weights
         reference: alpha
       - name: eta
-        description: "Step size shrinkage used in update to prevent overfitting"
+        description: Step size shrinkage used in update to prevent overfitting
         reference: eta
       - name: subsample
-        description: "Subsample ratio of the training instances"
+        description: Subsample ratio of the training instances
         reference: subsample
     trialSpec:
       apiVersion: batch/v1

--- a/examples/v1beta1/fpga/xgboost-example.yaml
+++ b/examples/v1beta1/fpga/xgboost-example.yaml
@@ -11,9 +11,6 @@ spec:
     algorithmName: random
   maxFailedTrialCount: 3
   maxTrialCount: 10
-  metricsCollectorSpec:
-    collector:
-      kind: StdOut
   objective:
     additionalMetricNames:
       - time

--- a/examples/v1beta1/fpga/xgboost-example.yaml
+++ b/examples/v1beta1/fpga/xgboost-example.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: kubeflow.org/v1beta1
+kind: Experiment
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: xgb-svhn-fpga
+  namespace: kubeflow
+spec:
+  algorithm:
+    algorithmName: random
+  maxFailedTrialCount: 3
+  maxTrialCount: 10
+  metricsCollectorSpec:
+    collector:
+      kind: StdOut
+  objective:
+    additionalMetricNames:
+      - time
+    goal: 0.99
+    objectiveMetricName: accuracy
+    type: maximize
+  parallelTrialCount: 1
+  parameters:
+    - feasibleSpace:
+        min: "0.00"
+        max: "0.05"
+      name: alpha
+      parameterType: double
+    - feasibleSpace:
+        min: "0.1"
+        max: "0.4"
+      name: eta
+      parameterType: double
+    - feasibleSpace:
+        min: "0.6"
+        max: "1.0"
+      name: subsample
+      parameterType: double
+  trialTemplate:
+    trialParameters:
+      - name: alpha
+        description: "L1 regularization term on weights"
+        reference: alpha
+      - name: eta
+        description: "Step size shrinkage used in update to prevent overfitting"
+        reference: eta
+      - name: subsample
+        description: "Subsample ratio of the training instances"
+        reference: subsample
+    trialSpec:
+      apiVersion: batch/v1
+      kind: Job
+      spec:
+        template:
+          spec:
+            containers:
+              - name: training-container
+                image: "docker.io/inaccel/jupyter:lab"
+                command:
+                  - python3
+                  - XGBoost/parameter-tuning.py
+                args:
+                  - "--name=SVHN"
+                  - "--test-size=0.35"
+                  - "--tree-method=fpga_exact"
+                  - "--bitstream=https://store.inaccel.com/artifactory/bitstreams/xilinx/aws-vu9p-f1/dynamic_5.0/com/inaccel/xgboost/0.1/2exact"
+                  - "--max-depth=10"
+                  - "--alpha=${trialParameters.alpha}"
+                  - "--eta=${trialParameters.eta}"
+                  - "--subsample=${trialParameters.subsample}"
+                resources:
+                  limits:
+                    xilinx/aws-vu9p-f1: 1
+            restartPolicy: Never


### PR DESCRIPTION
**What this PR does / why we need it**:

* Provides instructions on how to accelerate Katib Experiments on AWS F1 instances.
* Includes an accelerated XGBoost Parameter Tuning example.