### PR TITLE
Resume Experiment from Volume

### DIFF
--- a/examples/v1beta1/resume-experiment/from-volume-resume.yaml
+++ b/examples/v1beta1/resume-experiment/from-volume-resume.yaml
@@ -4,7 +4,7 @@ metadata:
   namespace: kubeflow
   labels:
     controller-tools.k8s.io: "1.0"
-  name: never-resume-example
+  name: from-volume-resume
 spec:
   objective:
     type: maximize
@@ -17,7 +17,7 @@ spec:
   parallelTrialCount: 3
   maxTrialCount: 12
   maxFailedTrialCount: 3
-  resumePolicy: Never
+  resumePolicy: FromVolume
   parameters:
     - name: lr
       parameterType: double

--- a/examples/v1beta1/resume-experiment/never-resume.yaml
+++ b/examples/v1beta1/resume-experiment/never-resume.yaml
@@ -1,0 +1,66 @@
+apiVersion: "kubeflow.org/v1beta1"
+kind: Experiment
+metadata:
+  namespace: kubeflow
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: never-resume
+spec:
+  objective:
+    type: maximize
+    goal: 0.99
+    objectiveMetricName: Validation-accuracy
+    additionalMetricNames:
+      - Train-accuracy
+  algorithm:
+    algorithmName: random
+  parallelTrialCount: 3
+  maxTrialCount: 12
+  maxFailedTrialCount: 3
+  resumePolicy: Never
+  parameters:
+    - name: lr
+      parameterType: double
+      feasibleSpace:
+        min: "0.01"
+        max: "0.03"
+    - name: num-layers
+      parameterType: int
+      feasibleSpace:
+        min: "2"
+        max: "5"
+    - name: optimizer
+      parameterType: categorical
+      feasibleSpace:
+        list:
+          - sgd
+          - adam
+          - ftrl
+  trialTemplate:
+    trialParameters:
+      - name: learningRate
+        description: Learning rate for the training model
+        reference: lr
+      - name: numberLayers
+        description: Number of training model layers
+        reference: num-layers
+      - name: optimizer
+        description: Training model optimizer (sdg, adam or ftrl)
+        reference: optimizer
+    trialSpec:
+      apiVersion: batch/v1
+      kind: Job
+      spec:
+        template:
+          spec:
+            containers:
+              - name: training-container
+                image: docker.io/kubeflowkatib/mxnet-mnist
+                command:
+                  - "python3"
+                  - "/opt/mxnet-mnist/mnist.py"
+                  - "--batch-size=64"
+                  - "--lr=${trialParameters.learningRate}"
+                  - "--num-layers=${trialParameters.numberLayers}"
+                  - "--optimizer=${trialParameters.optimizer}"
+            restartPolicy: Never

--- a/manifests/v1beta1/katib-controller/rbac.yaml
+++ b/manifests/v1beta1/katib-controller/rbac.yaml
@@ -12,6 +12,8 @@ rules:
       - secrets
       - events
       - namespaces
+      - persistentvolumes
+      - persistentvolumeclaims
     verbs:
       - "*"
   - apiGroups:

--- a/pkg/apis/controller/experiments/v1beta1/experiment_types.go
+++ b/pkg/apis/controller/experiments/v1beta1/experiment_types.go
@@ -170,6 +170,7 @@ const (
 	LongRunning ResumePolicyType = "LongRunning"
 	// FromVolume indicates that volume is attached to experiment's
 	// suggestion. Suggestion data can be retained in the volume.
+	// When experiment is succeeded suggestion deployment and service are deleted.
 	FromVolume ResumePolicyType = "FromVolume"
 )
 

--- a/pkg/apis/controller/experiments/v1beta1/experiment_types.go
+++ b/pkg/apis/controller/experiments/v1beta1/experiment_types.go
@@ -157,11 +157,20 @@ const (
 	ExperimentFailed     ExperimentConditionType = "Failed"
 )
 
+// ResumePolicyType describes how the experiment should be resumed.
+// Only one of the following resume policies may be specified.
+// If none of the following policies is specified, the default one is LongRunning.
 type ResumePolicyType string
 
 const (
+	// NeverResume indicates that experiment can't be resumed.
 	NeverResume ResumePolicyType = "Never"
+	// LongRunning indicates that experiment's suggestion resources
+	// (deployment and service) are always running.
 	LongRunning ResumePolicyType = "LongRunning"
+	// FromVolume indicates that volume is attached to experiment's
+	// suggestion. Suggestion data can be retained in the volume.
+	FromVolume ResumePolicyType = "FromVolume"
 )
 
 type ParameterSpec struct {

--- a/pkg/apis/controller/suggestions/v1beta1/suggestion_types.go
+++ b/pkg/apis/controller/suggestions/v1beta1/suggestion_types.go
@@ -21,14 +21,37 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	common "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
+
+	experiment "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
 )
 
-// SuggestionSpec defines the desired state of Suggestion
+// SuggestionSpec defines the desired state of suggestion.
 type SuggestionSpec struct {
+	// Name of the algorithm that suggestion is used.
 	AlgorithmName string `json:"algorithmName"`
 	// Number of suggestions requested
 	Requests int32 `json:"requests,omitempty"`
+	// Describes resuming policy which usually take effect after experiment terminated.
+	// Default value is LongRunning.
+	ResumePolicy experiment.ResumePolicyType `json:"resumePolicy,omitempty"`
+	// // VolumeSpec describes volume that attached to a suggestion deployment
+	// // and where suggestion data can be saved.
+	// VolumeSpec *VolumeSpec `json:"volumeSpec,omitempty"`
 }
+
+// // VolumeSpec represents volume that mounted to a suggestion's container.
+// type VolumeSpec struct {
+// 	// Name of StorageClass to which suggestion's persistent volume belongs.
+// 	// Empty value means that controller creates pv and pvc using hostPath.
+// 	// Value can be set in Katib config.
+// 	StorageClassName string `json:"storageClass,omitempty"`
+// 	// Name of the volume.
+// 	VolumeName string `json:"volumeName,omitempty"`
+// 	// Suggestion's container path where volume is mounted.
+// 	MountPath string `json:"mountPath,omitempty"`
+// 	// Represents the source of a suggestion volume to mount.
+// 	VolumeSource v1.VolumeSource `json:",inline"`
+// }
 
 // SuggestionStatus defines the observed state of Suggestion
 type SuggestionStatus struct {

--- a/pkg/apis/controller/suggestions/v1beta1/suggestion_types.go
+++ b/pkg/apis/controller/suggestions/v1beta1/suggestion_types.go
@@ -34,24 +34,7 @@ type SuggestionSpec struct {
 	// Describes resuming policy which usually take effect after experiment terminated.
 	// Default value is LongRunning.
 	ResumePolicy experiment.ResumePolicyType `json:"resumePolicy,omitempty"`
-	// // VolumeSpec describes volume that attached to a suggestion deployment
-	// // and where suggestion data can be saved.
-	// VolumeSpec *VolumeSpec `json:"volumeSpec,omitempty"`
 }
-
-// // VolumeSpec represents volume that mounted to a suggestion's container.
-// type VolumeSpec struct {
-// 	// Name of StorageClass to which suggestion's persistent volume belongs.
-// 	// Empty value means that controller creates pv and pvc using hostPath.
-// 	// Value can be set in Katib config.
-// 	StorageClassName string `json:"storageClass,omitempty"`
-// 	// Name of the volume.
-// 	VolumeName string `json:"volumeName,omitempty"`
-// 	// Suggestion's container path where volume is mounted.
-// 	MountPath string `json:"mountPath,omitempty"`
-// 	// Represents the source of a suggestion volume to mount.
-// 	VolumeSource v1.VolumeSource `json:",inline"`
-// }
 
 // SuggestionStatus defines the observed state of Suggestion
 type SuggestionStatus struct {

--- a/pkg/apis/controller/suggestions/v1beta1/util.go
+++ b/pkg/apis/controller/suggestions/v1beta1/util.go
@@ -90,26 +90,34 @@ func (suggestion *Suggestion) MarkSuggestionStatusCreated(reason, message string
 	suggestion.setCondition(SuggestionCreated, v1.ConditionTrue, reason, message)
 }
 
+// MarkSuggestionStatusRunning sets suggestion Running status.
 func (suggestion *Suggestion) MarkSuggestionStatusRunning(status v1.ConditionStatus, reason, message string) {
-	//suggestion.removeCondition(SuggestionRestarting)
 	// When suggestion is restrating we need to remove succeeded status from suggestion.
 	// That should happen only when ResumePolicy = FromVolume
 	suggestion.removeCondition(SuggestionSucceeded)
 	suggestion.setCondition(SuggestionRunning, status, reason, message)
 }
 
+// MarkSuggestionStatusSucceeded sets suggestion Succeeded status to true.
+// Suggestion can be succeeded only if ResumeExperiment = Never or ResumeExperiment = FromVolume
 func (suggestion *Suggestion) MarkSuggestionStatusSucceeded(reason, message string) {
+
+	// When suggestion is Succeeded suggestion Running status is false
 	runningCond := getCondition(suggestion, SuggestionRunning)
+	succeededReason := "Suggestion is succeeded"
 	if runningCond != nil {
-		suggestion.setCondition(SuggestionRunning, v1.ConditionFalse, runningCond.Reason, runningCond.Message)
+		msg := "Suggestion is not running"
+		suggestion.setCondition(SuggestionRunning, v1.ConditionFalse, succeededReason, msg)
 	}
-	// When suggestion is Succeeded deployment must be not ready
+
+	// When suggestion is Succeeded suggestion DeploymentReady status is false
 	deploymentReadyCond := getCondition(suggestion, SuggestionDeploymentReady)
 	if deploymentReadyCond != nil {
-		suggestion.setCondition(SuggestionDeploymentReady, v1.ConditionFalse, deploymentReadyCond.Reason, deploymentReadyCond.Message)
+		msg := "Deployment is not ready"
+		suggestion.setCondition(SuggestionDeploymentReady, v1.ConditionFalse, succeededReason, msg)
 	}
-	suggestion.setCondition(SuggestionSucceeded, v1.ConditionTrue, reason, message)
 
+	suggestion.setCondition(SuggestionSucceeded, v1.ConditionTrue, reason, message)
 }
 
 func (suggestion *Suggestion) MarkSuggestionStatusFailed(reason, message string) {

--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -3,6 +3,8 @@ package consts
 import (
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/kubeflow/katib/pkg/util/v1beta1/env"
 )
 

--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -147,6 +147,25 @@ const (
 
 	// UnavailableMetricValue is the value when metric was not reported or metric value can't be converted to float64
 	UnavailableMetricValue = "unavailable"
+
+	// DefaultSuggestionVolumeLocalPathPrefix is the default cluster local path for suggestion volume
+	// Whole local path = /tmp/katib/suggestions/<suggestion-name>-<suggestion-namespace>
+	DefaultSuggestionVolumeLocalPathPrefix = "/tmp/katib/suggestions/"
+
+	// DefaultSuggestionStorageClass is the default value for suggestion's volume storage class
+	DefaultSuggestionStorageClass = "katib-suggestion"
+
+	// DefaultSuggestionVolumeAccessMode is the default value for suggestion's volume access mode
+	DefaultSuggestionVolumeAccessMode = corev1.ReadWriteOnce
+
+	// DefaultSuggestionVolumeStorage is the default value for suggestion's volume storage
+	DefaultSuggestionVolumeStorage = "1Gi"
+
+	// ContainerSuggestionVolumeName is the name of volume that mounted on suggestion container
+	ContainerSuggestionVolumeName = "suggestion-volume"
+
+	// DefaultContainerSuggestionVolumeMountPath is the default mount path in suggestion container
+	DefaultContainerSuggestionVolumeMountPath = "/opt/katib/data"
 )
 
 var (

--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -148,12 +148,12 @@ const (
 	// UnavailableMetricValue is the value when metric was not reported or metric value can't be converted to float64
 	UnavailableMetricValue = "unavailable"
 
-	// DefaultSuggestionVolumeLocalPathPrefix is the default cluster local path for suggestion volume
-	// Whole local path = /tmp/katib/suggestions/<suggestion-name>-<suggestion-namespace>
+	// DefaultSuggestionVolumeLocalPathPrefix is the default cluster local path prefix for suggestion volume
+	// Full local path = /tmp/katib/suggestions/<suggestion-name>-<suggestion-namespace>
 	DefaultSuggestionVolumeLocalPathPrefix = "/tmp/katib/suggestions/"
 
-	// DefaultSuggestionStorageClass is the default value for suggestion's volume storage class
-	DefaultSuggestionStorageClass = "katib-suggestion"
+	// DefaultSuggestionStorageClassName is the default value for suggestion's volume storage class name
+	DefaultSuggestionStorageClassName = "katib-suggestion"
 
 	// DefaultSuggestionVolumeAccessMode is the default value for suggestion's volume access mode
 	DefaultSuggestionVolumeAccessMode = corev1.ReadWriteOnce
@@ -161,7 +161,7 @@ const (
 	// DefaultSuggestionVolumeStorage is the default value for suggestion's volume storage
 	DefaultSuggestionVolumeStorage = "1Gi"
 
-	// ContainerSuggestionVolumeName is the name of volume that mounted on suggestion container
+	// ContainerSuggestionVolumeName is the volume name that mounted on suggestion container
 	ContainerSuggestionVolumeName = "suggestion-volume"
 
 	// DefaultContainerSuggestionVolumeMountPath is the default mount path in suggestion container

--- a/pkg/controller.v1beta1/experiment/experiment_controller.go
+++ b/pkg/controller.v1beta1/experiment/experiment_controller.go
@@ -101,7 +101,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	if err = addWatch(mgr, c); err != nil {
-		log.Error(err, "Trial watch failed")
+		log.Error(err, "addWatch failed")
 		return err
 	}
 

--- a/pkg/controller.v1beta1/experiment/experiment_controller_test.go
+++ b/pkg/controller.v1beta1/experiment/experiment_controller_test.go
@@ -88,7 +88,7 @@ func TestCreateExperiment(t *testing.T) {
 		mgrStopped.Wait()
 	}()
 
-	// Create the Trial object and expect the Reconcile and Deployment to be created
+	// Create the experiment object and expect the Reconcile and Deployment to be created
 	err = c.Create(context.TODO(), instance)
 	// The instance object may not be a valid object because it might be missing some required fields.
 	// Please modify the instance object by adding required fields and then remove the following if statement.
@@ -234,7 +234,7 @@ func TestReconcileExperiment(t *testing.T) {
 		mgrStopped.Wait()
 	}()
 
-	// Create the Trial object and expect the Reconcile and Deployment to be created
+	// Create the Experiment object and expect the Reconcile and Deployment to be created
 	err = c.Create(context.TODO(), instance)
 	// The instance object may not be a valid object because it might be missing some required fields.
 	// Please modify the instance object by adding required fields and then remove the following if statement.

--- a/pkg/controller.v1beta1/experiment/experiment_controller_test.go
+++ b/pkg/controller.v1beta1/experiment/experiment_controller_test.go
@@ -234,7 +234,7 @@ func TestReconcileExperiment(t *testing.T) {
 		mgrStopped.Wait()
 	}()
 
-	// Create the Experiment object and expect the Reconcile and Deployment to be created
+	// Create the experiment object and expect the Reconcile and Deployment to be created
 	err = c.Create(context.TODO(), instance)
 	// The instance object may not be a valid object because it might be missing some required fields.
 	// Please modify the instance object by adding required fields and then remove the following if statement.

--- a/pkg/controller.v1beta1/experiment/experiment_util.go
+++ b/pkg/controller.v1beta1/experiment/experiment_util.go
@@ -155,11 +155,11 @@ func (r *ReconcileExperiment) restartSuggestion(instance *experimentsv1beta1.Exp
 		return err
 	}
 
-	logger.Info("Suggestion is restarting, suggestion status is not running")
+	logger.Info("Suggestion is restarting, suggestion Running status is false")
 	suggestion := original.DeepCopy()
-	reason := "Experiment is restarting, suggestion deployment is not ready"
+	reason := "Experiment is restarting"
 	msg := "Suggestion is not running"
-	// Mark suggestion status not running because deployment is not ready
+	// Mark suggestion status not running because experiment is restarting and suggestion deployment is not ready
 	suggestion.MarkSuggestionStatusRunning(corev1.ConditionFalse, reason, msg)
 
 	if err := r.UpdateSuggestionStatus(suggestion); err != nil {

--- a/pkg/controller.v1beta1/experiment/experiment_util.go
+++ b/pkg/controller.v1beta1/experiment/experiment_util.go
@@ -5,6 +5,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -12,7 +13,6 @@ import (
 	experimentsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
 	suggestionsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/suggestions/v1beta1"
 	trialsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/trials/v1beta1"
-	suggestionController "github.com/kubeflow/katib/pkg/controller.v1beta1/suggestion"
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/util"
 )
 
@@ -103,7 +103,8 @@ func (r *ReconcileExperiment) updateFinalizers(instance *experimentsv1beta1.Expe
 	}
 }
 
-func (r *ReconcileExperiment) terminateSuggestion(instance *experimentsv1beta1.Experiment) error {
+func (r *ReconcileExperiment) cleanupSuggestionResources(instance *experimentsv1beta1.Experiment) error {
+	logger := log.WithValues("Suggestion", types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()})
 	original := &suggestionsv1beta1.Suggestion{}
 	err := r.Get(context.TODO(),
 		types.NamespacedName{Namespace: instance.GetNamespace(), Name: instance.GetName()}, original)
@@ -113,15 +114,53 @@ func (r *ReconcileExperiment) terminateSuggestion(instance *experimentsv1beta1.E
 		}
 		return err
 	}
+
 	// If Suggestion is failed or Suggestion is Succeeded, not needed to terminate Suggestion
 	if original.IsFailed() || original.IsSucceeded() {
 		return nil
 	}
-	log.Info("Start terminating suggestion")
+
+	logger.Info("Start cleanup suggestion resources")
 	suggestion := original.DeepCopy()
-	msg := "Suggestion is succeeded"
-	suggestion.MarkSuggestionStatusSucceeded(suggestionController.SuggestionSucceededReason, msg)
-	log.Info("Mark suggestion succeeded")
+
+	reason := "Experiment is succeeded"
+	// If ResumePolicy = Never, mark suggestion status succeeded, can't be restarted
+	if instance.Spec.ResumePolicy == experimentsv1beta1.NeverResume {
+		msg := "Suggestion is succeeded, can't be restarted"
+		suggestion.MarkSuggestionStatusSucceeded(reason, msg)
+		logger.Info("Mark suggestion succeeded, can't be restarted")
+
+		// If ResumePolicy = FromVolume, mark suggestion status succeeded, can be restarted
+	} else if instance.Spec.ResumePolicy == experimentsv1beta1.FromVolume {
+		msg := "Suggestion is succeeded, suggestion volume is not deleted, can be restarted"
+		suggestion.MarkSuggestionStatusSucceeded(reason, msg)
+		logger.Info("Mark suggestion succeeded, can be restarted")
+	}
+
+	if err := r.UpdateSuggestionStatus(suggestion); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *ReconcileExperiment) restartSuggestion(instance *experimentsv1beta1.Experiment) error {
+	logger := log.WithValues("Suggestion", types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()})
+	original := &suggestionsv1beta1.Suggestion{}
+	err := r.Get(context.TODO(),
+		types.NamespacedName{Namespace: instance.GetNamespace(), Name: instance.GetName()}, original)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	logger.Info("Suggestion is restarting, suggestion status is not running")
+	suggestion := original.DeepCopy()
+	reason := "Experiment is restarting, suggestion deployment is not ready"
+	msg := "Suggestion is not running"
+	// Mark suggestion status not running because deployment is not ready
+	suggestion.MarkSuggestionStatusRunning(corev1.ConditionFalse, reason, msg)
 
 	if err := r.UpdateSuggestionStatus(suggestion); err != nil {
 		return err

--- a/pkg/controller.v1beta1/experiment/suggestion/suggestion.go
+++ b/pkg/controller.v1beta1/experiment/suggestion/suggestion.go
@@ -66,8 +66,24 @@ func (g *General) createSuggestion(instance *experimentsv1beta1.Experiment, sugg
 		Spec: suggestionsv1beta1.SuggestionSpec{
 			AlgorithmName: instance.Spec.Algorithm.AlgorithmName,
 			Requests:      suggestionRequests,
+			ResumePolicy:  instance.Spec.ResumePolicy,
 		},
 	}
+
+	// // If ResumePolicy = FromVolume volume info is attached to suggestion
+	// if instance.Spec.ResumePolicy == experimentsv1beta1.FromVolume {
+	// 	volumeName := instance.Name + "-" + instance.Namespace
+	// 	suggestion.Spec.VolumeSpec = &suggestionsv1beta1.VolumeSpec{
+	// 		StorageClassName: consts.DefaultSuggestionStorageClass,
+	// 		VolumeName:       volumeName,
+	// 		MountPath:        consts.DefaultSuggestionVolumePath,
+	// 		VolumeSource: v1.VolumeSource{
+	// 			PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+	// 				ClaimName: volumeName,
+	// 			},
+	// 		},
+	// 	}
+	// }
 
 	if err := controllerutil.SetControllerReference(instance, suggestion, g.scheme); err != nil {
 		logger.Error(err, "Error in setting controller reference")

--- a/pkg/controller.v1beta1/experiment/suggestion/suggestion.go
+++ b/pkg/controller.v1beta1/experiment/suggestion/suggestion.go
@@ -70,21 +70,6 @@ func (g *General) createSuggestion(instance *experimentsv1beta1.Experiment, sugg
 		},
 	}
 
-	// // If ResumePolicy = FromVolume volume info is attached to suggestion
-	// if instance.Spec.ResumePolicy == experimentsv1beta1.FromVolume {
-	// 	volumeName := instance.Name + "-" + instance.Namespace
-	// 	suggestion.Spec.VolumeSpec = &suggestionsv1beta1.VolumeSpec{
-	// 		StorageClassName: consts.DefaultSuggestionStorageClass,
-	// 		VolumeName:       volumeName,
-	// 		MountPath:        consts.DefaultSuggestionVolumePath,
-	// 		VolumeSource: v1.VolumeSource{
-	// 			PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-	// 				ClaimName: volumeName,
-	// 			},
-	// 		},
-	// 	}
-	// }
-
 	if err := controllerutil.SetControllerReference(instance, suggestion, g.scheme); err != nil {
 		logger.Error(err, "Error in setting controller reference")
 		return err

--- a/pkg/controller.v1beta1/suggestion/composer/composer.go
+++ b/pkg/controller.v1beta1/suggestion/composer/composer.go
@@ -252,12 +252,12 @@ func (g *General) desiredContainer(s *suggestionsv1beta1.Suggestion, suggestionC
 }
 
 // DesiredVolume returns desired PVC and PV for suggestion.
-// If StorageClassName != DefaultSuggestionStorageClass returns only PVC.
+// If StorageClassName != DefaultSuggestionStorageClassName returns only PVC.
 func (g *General) DesiredVolume(s *suggestionsv1beta1.Suggestion) (*corev1.PersistentVolumeClaim, *corev1.PersistentVolume, error) {
 	persistentVolumeName := s.Name + "-" + s.Namespace
 
 	// TODO (andreyvelich): Enable to specify these values from Katib config
-	storageClassName := consts.DefaultSuggestionStorageClass
+	storageClassName := consts.DefaultSuggestionStorageClassName
 	persistentVolumePath := consts.DefaultSuggestionVolumeLocalPathPrefix + persistentVolumeName
 	volumeAccessModes := consts.DefaultSuggestionVolumeAccessMode
 
@@ -291,7 +291,7 @@ func (g *General) DesiredVolume(s *suggestionsv1beta1.Suggestion) (*corev1.Persi
 
 	var pv *corev1.PersistentVolume
 	// Create PV with local hostPath by default
-	if storageClassName == consts.DefaultSuggestionStorageClass {
+	if storageClassName == consts.DefaultSuggestionStorageClassName {
 		localLabel := map[string]string{"type": "local"}
 
 		pv = &corev1.PersistentVolume{
@@ -300,7 +300,7 @@ func (g *General) DesiredVolume(s *suggestionsv1beta1.Suggestion) (*corev1.Persi
 				Labels: localLabel,
 			},
 			Spec: corev1.PersistentVolumeSpec{
-				StorageClassName: consts.DefaultSuggestionStorageClass,
+				StorageClassName: consts.DefaultSuggestionStorageClassName,
 				AccessModes: []corev1.PersistentVolumeAccessMode{
 					volumeAccessModes,
 				},

--- a/pkg/controller.v1beta1/suggestion/composer/composer.go
+++ b/pkg/controller.v1beta1/suggestion/composer/composer.go
@@ -104,7 +104,7 @@ func (g *General) DesiredDeployment(s *suggestionsv1beta1.Suggestion) (*appsv1.D
 				Name: consts.ContainerSuggestionVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: s.Name,
+						ClaimName: util.GetAlgorithmPersistentVolumeClaimName(s),
 					},
 				},
 			},
@@ -254,7 +254,7 @@ func (g *General) desiredContainer(s *suggestionsv1beta1.Suggestion, suggestionC
 // DesiredVolume returns desired PVC and PV for suggestion.
 // If StorageClassName != DefaultSuggestionStorageClassName returns only PVC.
 func (g *General) DesiredVolume(s *suggestionsv1beta1.Suggestion) (*corev1.PersistentVolumeClaim, *corev1.PersistentVolume, error) {
-	persistentVolumeName := s.Name + "-" + s.Namespace
+	persistentVolumeName := util.GetAlgorithmPersistentVolumeName(s)
 
 	// TODO (andreyvelich): Enable to specify these values from Katib config
 	storageClassName := consts.DefaultSuggestionStorageClassName
@@ -268,7 +268,7 @@ func (g *General) DesiredVolume(s *suggestionsv1beta1.Suggestion) (*corev1.Persi
 
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      s.Name,
+			Name:      util.GetAlgorithmPersistentVolumeClaimName(s),
 			Namespace: s.Namespace,
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller.go
@@ -243,7 +243,7 @@ func (r *ReconcileSuggestion) ReconcileSuggestion(instance *suggestionsv1beta1.S
 		client.MatchingLabels(util.TrialLabels(experiment)), trials); err != nil {
 		return err
 	}
-	// TODO (andreyvelich): Do we need to run ValidateAlgorithmSettings when Experiment is restarting?
+	// TODO (andreyvelich): Do we want to run ValidateAlgorithmSettings when Experiment is restarting?
 	// Currently it is running.
 	if !instance.IsRunning() {
 		if err = r.ValidateAlgorithmSettings(instance, experiment); err != nil {

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller.go
@@ -254,8 +254,7 @@ func (r *ReconcileSuggestion) ReconcileSuggestion(instance *suggestionsv1beta1.S
 			return nil
 		}
 		msg := "Suggestion is running"
-		reason := "Experiment is restarting, suggestion deployment is ready"
-		instance.MarkSuggestionStatusRunning(corev1.ConditionTrue, reason, msg)
+		instance.MarkSuggestionStatusRunning(corev1.ConditionTrue, SuggestionRunningReason, msg)
 	}
 	logger.Info("Sync assignments", "suggestions", instance.Spec.Requests)
 	if err = r.SyncAssignments(instance, experiment, trials.Items); err != nil {

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller.go
@@ -243,6 +243,8 @@ func (r *ReconcileSuggestion) ReconcileSuggestion(instance *suggestionsv1beta1.S
 		client.MatchingLabels(util.TrialLabels(experiment)), trials); err != nil {
 		return err
 	}
+	// TODO (andreyvelich): Do we need to run ValidateAlgorithmSettings when Experiment is restarting?
+	// Currently it is running.
 	if !instance.IsRunning() {
 		if err = r.ValidateAlgorithmSettings(instance, experiment); err != nil {
 			logger.Error(err, "Marking suggestion failed as algorithm settings validation failed")

--- a/pkg/controller.v1beta1/util/suggestion.go
+++ b/pkg/controller.v1beta1/util/suggestion.go
@@ -7,11 +7,23 @@ import (
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 )
 
+// GetAlgorithmDeploymentName returns name for the suggestion's deployment
 func GetAlgorithmDeploymentName(s *suggestionsv1beta1.Suggestion) string {
 	return s.Name + "-" + s.Spec.AlgorithmName
 }
 
+// GetAlgorithmServiceName returns name for the suggestion's service
 func GetAlgorithmServiceName(s *suggestionsv1beta1.Suggestion) string {
+	return s.Name + "-" + s.Spec.AlgorithmName
+}
+
+// GetAlgorithmPersistentVolumeName returns name for the suggestion's PV
+func GetAlgorithmPersistentVolumeName(s *suggestionsv1beta1.Suggestion) string {
+	return s.Name + "-" + s.Spec.AlgorithmName + "-" + s.Namespace
+}
+
+// GetAlgorithmPersistentVolumeClaimName returns name for the suggestion's PVC
+func GetAlgorithmPersistentVolumeClaimName(s *suggestionsv1beta1.Suggestion) string {
 	return s.Name + "-" + s.Spec.AlgorithmName
 }
 

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -135,6 +135,7 @@ func (g *DefaultValidator) validateResumePolicy(resume experimentsv1beta1.Resume
 		"":                             "",
 		experimentsv1beta1.NeverResume: "",
 		experimentsv1beta1.LongRunning: "",
+		experimentsv1beta1.FromVolume:  "",
 	}
 	if _, ok := validTypes[resume]; !ok {
 		return fmt.Errorf("invalid ResumePolicyType %s", resume)

--- a/test/scripts/v1beta1/run-never-resume.sh
+++ b/test/scripts/v1beta1/run-never-resume.sh
@@ -54,11 +54,11 @@ cd ${GO_DIR}/test/e2e/v1beta1
 
 echo "Running e2e test for never resume experiment"
 export KUBECONFIG=$HOME/.kube/config
-./run-e2e-experiment ../../../examples/v1beta1/never-resume-example.yaml
+./run-e2e-experiment ../../../examples/v1beta1/resume-experiment/never-resume.yaml
 
-kubectl -n kubeflow describe suggestion never-resume-example
+kubectl -n kubeflow describe suggestion never-resume
 
-kubectl -n kubeflow describe experiment never-resume-example
-kubectl -n kubeflow delete experiment never-resume-example
+kubectl -n kubeflow describe experiment never-resume
+kubectl -n kubeflow delete experiment never-resume
 
 exit 0


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1250.

This is implementation for resuming experiment from the Volume.

Steps:

1. I added new `ResumePolicy=FromVolume` which represents resuming experiment from the volume. 
@gaocegege @johnugeorge @sperlingxx what do you think about the name? Should we rename it to `ResumePolicy=VolumeSource` or think about better name, maybe rename `LongRunning` also? 

2. I added `ResumePolicy` to Suggestion API to understand if controller needs to deploy volume for the Suggestion. 
Do we need to add some volume specification to Suggestion API also. 
For example: StorageClassName, PVC name ?

3. If `ResumePolicy=VolumeSource`, PVC is created. If `StorageClassName=DefaultSuggestionStorageClass`, PV with local cluster path is created also.

4. I didn’t attach Experiment labels to PVC and PV, like we did here: https://github.com/andreyvelich/katib/blob/issue-1250-resume-from-volume/pkg/controller.v1beta1/suggestion/composer/composer.go#L74 (it was done to connect service with deployment). 
Do we want to see these labels in the PVC/PV?
5. Currently, for the PV default cluster local volume path is:  `prefix + <suggestion name>-<suggestion namespace>`. We need to add name and namespace to not conflict with other submitted Experiments in various namespaces.
Prefix can be changed in `katib-config` later.

6. Currently, for suggestion container default path is `/opt/katib/data`. Also can be changed in `katib-config`.

7. PVC name = `<suggestion name>`

8. PV name = `<suggestion name>-<suggestion namespace>`

9. I added [new validation](https://github.com/andreyvelich/katib/blob/issue-1250-resume-from-volume/pkg/webhook/v1beta1/experiment/validation_webhook.go#L94-L110) for the webhook. That is needed to prevent submitting Experiment with the same name, if corresponding PV was not deleted after deleting Experiment. 
We can't `Watch` for the PV, like for the [`PVC`](https://github.com/andreyvelich/katib/blob/issue-1250-resume-from-volume/pkg/controller.v1beta1/suggestion/suggestion_controller.go#L99-L105). And suggestion controller can't be triggered and create PV again, once PV is deleted from the cluster. 

10. I had to change suggestion status workflow to allow resuming experiment from the volume.
This change doesn't affect current workflow for `LongRunning` Suggestion.
For the `ResumePolicy=VolumeSource`:
When User submits Experiment, Suggestion status:

Created (status = True) -> DeploymentReady (status = False) -> DeploymentReady (status = True) -> Running (status = True) -> (experiment is finished) -> Running (status = False) ->  DeploymentReady (status = False) -> Succeeded (status = True) . 

When User restarts Experiment, Suggestion status:

Running (status = True, reason="Experiment is restarting") -> (remove succeeded condition) -> DeploymentReady (status = True) -> Running (status = True, reason="SuggestionRunning")) -> (experiment is finished) -> Running (status = False) ->  DeploymentReady (status = False) -> Succeeded (status = True).

This approach can avoid adding additional condition for Suggestion: `Restarting`.

What do you think @gaocegege @johnugeorge @sperlingxx ?

I still need to make some testing, but this PR is ready for review.
I will add unit test and e2e test in the future PR.

/assign @gaocegege @johnugeorge @sperlingxx 

/cc @jlewi 

