### PR TITLE
Add status to experiment CRD manifest

### DIFF
--- a/manifests/v1beta1/katib-controller/crd-experiment.yaml
+++ b/manifests/v1beta1/katib-controller/crd-experiment.yaml
@@ -7,6 +7,9 @@ spec:
     - JSONPath: .status.conditions[-1:].type
       name: Status
       type: string
+    - JSONPath: .status.conditions[-1:].status
+      name: Status
+      type: string
     - JSONPath: .metadata.creationTimestamp
       name: Age
       type: date


### PR DESCRIPTION
I added `status` to `additionalPrinterColumns` for Experiments CRD, like we did with Trials and Suggestions CR.

/assign @gaocegege @johnugeorge 