### PR TITLE
Get metrics collector config data refactor

### DIFF
--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -58,43 +58,26 @@ const (
 	// DefaultKatibDBManagerServicePortEnvName is the env name of Katib DB Manager Port
 	DefaultKatibDBManagerServicePortEnvName = "KATIB_DB_MANAGER_SERVICE_PORT"
 
-	// KatibConfigMapName is the config map constants
-	// Configmap name which includes Katib's configuration
+	// KatibConfigMapName is the configmap name which includes Katib's configuration.
 	KatibConfigMapName = "katib-config"
 	// LabelSuggestionTag is the name of suggestion config in configmap.
 	LabelSuggestionTag = "suggestion"
-	// DefaultCPULimit is the default value for CPU Limit
+	// LabelMetricsCollectorSidecar is the name of metrics collector config in configmap.
+	LabelMetricsCollectorSidecar = "metrics-collector-sidecar"
+	// DefaultImagePullPolicy is the default value for image pull policy.
+	DefaultImagePullPolicy = corev1.PullIfNotPresent
+	// DefaultCPULimit is the default value for CPU limit.
 	DefaultCPULimit = "500m"
-	// DefaultCPURequest is the default value for CPU Request
+	// DefaultCPURequest is the default value for CPU request.
 	DefaultCPURequest = "50m"
-	// DefaultMemLimit is the default value for mem Limit
+	// DefaultMemLimit is the default value for memory limit.
 	DefaultMemLimit = "100Mi"
-	// DefaultMemRequest is the default value for mem Request
+	// DefaultMemRequest is the default value for memory request.
 	DefaultMemRequest = "10Mi"
 	// DefaultDiskLimit is the default value for disk limit.
 	DefaultDiskLimit = "5Gi"
 	// DefaultDiskRequest is the default value for disk request.
 	DefaultDiskRequest = "500Mi"
-	// DefaultImagePullPolicy is the default value for image pull policy.
-	DefaultImagePullPolicy = "IfNotPresent"
-	// LabelMetricsCollectorSidecar is the name of metrics collector config in configmap.
-	LabelMetricsCollectorSidecar = "metrics-collector-sidecar"
-	// LabelMetricsCollectorSidecarImage is the name of metrics collector image config in configmap.
-	LabelMetricsCollectorSidecarImage = "image"
-	// LabelMetricsCollectorCPULimitTag is the name of metrics collector CPU Limit config in configmap.
-	LabelMetricsCollectorCPULimitTag = "cpuLimit"
-	// LabelMetricsCollectorCPURequestTag is the name of metrics collector CPU Request config in configmap.
-	LabelMetricsCollectorCPURequestTag = "cpuRequest"
-	// LabelMetricsCollectorMemLimitTag is the name of metrics collector Mem Limit config in configmap.
-	LabelMetricsCollectorMemLimitTag = "memLimit"
-	// LabelMetricsCollectorMemRequestTag is the name of metrics collector Mem Request config in configmap.
-	LabelMetricsCollectorMemRequestTag = "memRequest"
-	// LabelMetricsCollectorDiskLimitTag is the name of metrics collector Disk Limit config in configmap.
-	LabelMetricsCollectorDiskLimitTag = "diskLimit"
-	// LabelMetricsCollectorDiskRequestTag is the name of metrics collector Disk Request config in configmap.
-	LabelMetricsCollectorDiskRequestTag = "diskRequest"
-	// LabelMetricsCollectorImagePullPolicy is the name of metrics collector image pull policy in configmap.
-	LabelMetricsCollectorImagePullPolicy = "imagePullPolicy"
 
 	// ReconcileErrorReason is the reason when there is a reconcile error.
 	ReconcileErrorReason = "ReconcileError"

--- a/pkg/controller.v1beta1/experiment/manifest/generator.go
+++ b/pkg/controller.v1beta1/experiment/manifest/generator.go
@@ -28,7 +28,7 @@ type Generator interface {
 	GetTrialTemplate(instance *experimentsv1beta1.Experiment) (string, error)
 	GetRunSpecWithHyperParameters(experiment *experimentsv1beta1.Experiment, trialName, trialNamespace string, assignments []commonapiv1beta1.ParameterAssignment) (*unstructured.Unstructured, error)
 	GetSuggestionConfigData(algorithmName string) (katibconfig.SuggestionConfig, error)
-	GetMetricsCollectorImage(cKind commonapiv1beta1.CollectorKind) (string, error)
+	GetMetricsCollectorConfigData(cKind commonapiv1beta1.CollectorKind) (katibconfig.MetricsCollectorConfig, error)
 }
 
 // DefaultGenerator is the default implementation of Generator.
@@ -48,14 +48,12 @@ func (g *DefaultGenerator) InjectClient(c client.Client) {
 	g.client.InjectClient(c)
 }
 
-func (g *DefaultGenerator) GetMetricsCollectorImage(cKind commonapiv1beta1.CollectorKind) (string, error) {
-	configData, err := katibconfig.GetMetricsCollectorConfigData(cKind, g.client.GetClient())
-	if err != nil {
-		return "", nil
-	}
-	return configData[consts.LabelMetricsCollectorSidecarImage], nil
+// GetMetricsCollectorConfigData returns metrics collector configuration for a given collector kind.
+func (g *DefaultGenerator) GetMetricsCollectorConfigData(cKind commonapiv1beta1.CollectorKind) (katibconfig.MetricsCollectorConfig, error) {
+	return katibconfig.GetMetricsCollectorConfigData(cKind, g.client.GetClient())
 }
 
+// GetSuggestionConfigData returns suggestion configuration for a given algorithm name.
 func (g *DefaultGenerator) GetSuggestionConfigData(algorithmName string) (katibconfig.SuggestionConfig, error) {
 	return katibconfig.GetSuggestionConfigData(algorithmName, g.client.GetClient())
 }

--- a/pkg/controller.v1beta1/suggestion/composer/composer.go
+++ b/pkg/controller.v1beta1/suggestion/composer/composer.go
@@ -154,18 +154,7 @@ func (g *General) desiredContainer(s *suggestionsv1beta1.Suggestion, suggestionC
 				ContainerPort: consts.DefaultSuggestionPort,
 			},
 		},
-		Resources: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:              suggestionConfigData.Resource.Limits[corev1.ResourceCPU],
-				corev1.ResourceMemory:           suggestionConfigData.Resource.Limits[corev1.ResourceMemory],
-				corev1.ResourceEphemeralStorage: suggestionConfigData.Resource.Limits[corev1.ResourceEphemeralStorage],
-			},
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:              suggestionConfigData.Resource.Requests[corev1.ResourceCPU],
-				corev1.ResourceMemory:           suggestionConfigData.Resource.Requests[corev1.ResourceMemory],
-				corev1.ResourceEphemeralStorage: suggestionConfigData.Resource.Requests[corev1.ResourceEphemeralStorage],
-			},
-		},
+		Resources: suggestionConfigData.Resource,
 	}
 
 	if viper.GetBool(consts.ConfigEnableGRPCProbeInSuggestion) {

--- a/pkg/mock/v1beta1/experiment/manifest/generator.go
+++ b/pkg/mock/v1beta1/experiment/manifest/generator.go
@@ -37,19 +37,19 @@ func (m *MockGenerator) EXPECT() *MockGeneratorMockRecorder {
 	return m.recorder
 }
 
-// GetMetricsCollectorImage mocks base method.
-func (m *MockGenerator) GetMetricsCollectorImage(arg0 v1beta1.CollectorKind) (string, error) {
+// GetMetricsCollectorConfigData mocks base method.
+func (m *MockGenerator) GetMetricsCollectorConfigData(arg0 v1beta1.CollectorKind) (katibconfig.MetricsCollectorConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMetricsCollectorImage", arg0)
-	ret0, _ := ret[0].(string)
+	ret := m.ctrl.Call(m, "GetMetricsCollectorConfigData", arg0)
+	ret0, _ := ret[0].(katibconfig.MetricsCollectorConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetMetricsCollectorImage indicates an expected call of GetMetricsCollectorImage.
-func (mr *MockGeneratorMockRecorder) GetMetricsCollectorImage(arg0 interface{}) *gomock.Call {
+// GetMetricsCollectorConfigData indicates an expected call of GetMetricsCollectorConfigData.
+func (mr *MockGeneratorMockRecorder) GetMetricsCollectorConfigData(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricsCollectorImage", reflect.TypeOf((*MockGenerator)(nil).GetMetricsCollectorImage), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricsCollectorConfigData", reflect.TypeOf((*MockGenerator)(nil).GetMetricsCollectorConfigData), arg0)
 }
 
 // GetRunSpecWithHyperParameters mocks base method.

--- a/pkg/util/v1beta1/katibconfig/config.go
+++ b/pkg/util/v1beta1/katibconfig/config.go
@@ -23,7 +23,8 @@ type SuggestionConfig struct {
 	ServiceAccountName string                      `json:"serviceAccountName"`
 }
 
-type metricsCollectorConfigJSON struct {
+// MetricsCollectorConfig is the JSON metrics collector structure in Katib config
+type MetricsCollectorConfig struct {
 	Image           string                      `json:"image"`
 	ImagePullPolicy corev1.PullPolicy           `json:"imagePullPolicy"`
 	Resource        corev1.ResourceRequirements `json:"resources"`
@@ -44,7 +45,7 @@ func GetSuggestionConfigData(algorithmName string, client client.Client) (Sugges
 	// Try to find suggestion data in config map
 	config, ok := configMap.Data[consts.LabelSuggestionTag]
 	if !ok {
-		return SuggestionConfig{}, errors.New("Failed to find suggestions config in configmap " + consts.KatibConfigMapName)
+		return SuggestionConfig{}, errors.New("Failed to find suggestions config in ConfigMap: " + consts.KatibConfigMapName)
 	}
 
 	// Parse suggestion data to map where key = algorithm name, value = SuggestionConfig
@@ -56,150 +57,123 @@ func GetSuggestionConfigData(algorithmName string, client client.Client) (Sugges
 	// Try to find SuggestionConfig for the algorithm
 	suggestionConfigData, ok = suggestionsConfig[algorithmName]
 	if !ok {
-		return SuggestionConfig{}, errors.New("Failed to find algorithm " + algorithmName + " config in configmap " + consts.KatibConfigMapName)
+		return SuggestionConfig{}, errors.New("Failed to find suggestion config for algorithm: " + algorithmName + " in ConfigMap: " + consts.KatibConfigMapName)
 	}
 
 	// Get image from config
 	image := suggestionConfigData.Image
 	if strings.TrimSpace(image) == "" {
-		return SuggestionConfig{}, errors.New("Required value for image configuration of algorithm name " + algorithmName)
+		return SuggestionConfig{}, errors.New("Required value for image configuration of algorithm name: " + algorithmName)
 	}
 
 	// Get Image Pull Policy
 	imagePullPolicy := suggestionConfigData.ImagePullPolicy
 	if imagePullPolicy != corev1.PullAlways && imagePullPolicy != corev1.PullIfNotPresent && imagePullPolicy != corev1.PullNever {
-		// TODO (andreyvelich): Change it to consts once metrics collector config is refactored
-		suggestionConfigData.ImagePullPolicy = corev1.PullIfNotPresent
+		suggestionConfigData.ImagePullPolicy = consts.DefaultImagePullPolicy
 	}
 
-	// If requests are empty create new map
-	if len(suggestionConfigData.Resource.Requests) == 0 {
-		suggestionConfigData.Resource.Requests = make(map[corev1.ResourceName]resource.Quantity)
-	}
-
-	// Get CPU, Memory and Disk Requests from config
-	cpuRequest := suggestionConfigData.Resource.Requests[corev1.ResourceCPU]
-	memRequest := suggestionConfigData.Resource.Requests[corev1.ResourceMemory]
-	diskRequest := suggestionConfigData.Resource.Requests[corev1.ResourceEphemeralStorage]
-
-	// If resource is empty set default value for CPU, Memory, Disk
-	if cpuRequest.IsZero() {
-		defaultCPURequest, _ := resource.ParseQuantity(consts.DefaultCPURequest)
-		suggestionConfigData.Resource.Requests[corev1.ResourceCPU] = defaultCPURequest
-	}
-	if memRequest.IsZero() {
-		defaultMemRequest, _ := resource.ParseQuantity(consts.DefaultMemRequest)
-		suggestionConfigData.Resource.Requests[corev1.ResourceMemory] = defaultMemRequest
-	}
-	if diskRequest.IsZero() {
-		defaultDiskRequest, _ := resource.ParseQuantity(consts.DefaultDiskRequest)
-		suggestionConfigData.Resource.Requests[corev1.ResourceEphemeralStorage] = defaultDiskRequest
-	}
-
-	// If limits are empty create new map
-	if len(suggestionConfigData.Resource.Limits) == 0 {
-		suggestionConfigData.Resource.Limits = make(map[corev1.ResourceName]resource.Quantity)
-	}
-
-	// Get CPU, Memory and Disk Limits from config
-	cpuLimit := suggestionConfigData.Resource.Limits[corev1.ResourceCPU]
-	memLimit := suggestionConfigData.Resource.Limits[corev1.ResourceMemory]
-	diskLimit := suggestionConfigData.Resource.Limits[corev1.ResourceEphemeralStorage]
-
-	// If limit is empty set default value for CPU, Memory, Disk
-	if cpuLimit.IsZero() {
-		defaultCPULimit, _ := resource.ParseQuantity(consts.DefaultCPULimit)
-		suggestionConfigData.Resource.Limits[corev1.ResourceCPU] = defaultCPULimit
-	}
-	if memLimit.IsZero() {
-		defaultMemLimit, _ := resource.ParseQuantity(consts.DefaultMemLimit)
-		suggestionConfigData.Resource.Limits[corev1.ResourceMemory] = defaultMemLimit
-	}
-	if diskLimit.IsZero() {
-		defaultDiskLimit, _ := resource.ParseQuantity(consts.DefaultDiskLimit)
-		suggestionConfigData.Resource.Limits[corev1.ResourceEphemeralStorage] = defaultDiskLimit
-	}
+	// Set resource requirements for suggestion
+	suggestionConfigData.Resource = setResourceRequirements(suggestionConfigData.Resource)
 
 	return suggestionConfigData, nil
 }
 
-// GetMetricsCollectorConfigData gets the config data for the given kind.
-func GetMetricsCollectorConfigData(cKind common.CollectorKind, client client.Client) (map[string]string, error) {
+// GetMetricsCollectorConfigData gets the config data for the given collector kind.
+func GetMetricsCollectorConfigData(cKind common.CollectorKind, client client.Client) (MetricsCollectorConfig, error) {
 	configMap := &corev1.ConfigMap{}
-	metricsCollectorConfigData := map[string]string{}
+	metricsCollectorConfigData := MetricsCollectorConfig{}
 	err := client.Get(
 		context.TODO(),
 		apitypes.NamespacedName{Name: consts.KatibConfigMapName, Namespace: consts.DefaultKatibNamespace},
 		configMap)
 	if err != nil {
-		return metricsCollectorConfigData, err
+		return MetricsCollectorConfig{}, err
 	}
-	// Get the config with name metrics-collector-sidecar.
-	if config, ok := configMap.Data[consts.LabelMetricsCollectorSidecar]; ok {
-		kind := string(cKind)
-		mcsConfig := map[string]metricsCollectorConfigJSON{}
-		if err := json.Unmarshal([]byte(config), &mcsConfig); err != nil {
-			return metricsCollectorConfigData, err
-		}
-		// Get the config for the given cKind.
-		if metricsCollectorConfig, ok := mcsConfig[kind]; ok {
-			image := metricsCollectorConfig.Image
-			// If the image is not empty, we set it into result.
-			if strings.TrimSpace(image) != "" {
-				metricsCollectorConfigData[consts.LabelMetricsCollectorSidecarImage] = image
-			} else {
-				return metricsCollectorConfigData, errors.New("Required value for " + consts.LabelMetricsCollectorSidecarImage + "configuration of metricsCollector kind " + kind)
-			}
 
-			// Get Image Pull Policy
-			imagePullPolicy := metricsCollectorConfig.ImagePullPolicy
-			if imagePullPolicy == corev1.PullAlways || imagePullPolicy == corev1.PullIfNotPresent || imagePullPolicy == corev1.PullNever {
-				metricsCollectorConfigData[consts.LabelMetricsCollectorImagePullPolicy] = string(imagePullPolicy)
-			} else {
-				metricsCollectorConfigData[consts.LabelMetricsCollectorImagePullPolicy] = consts.DefaultImagePullPolicy
-			}
-
-			// Set default values for CPU, Memory and Disk
-			metricsCollectorConfigData[consts.LabelMetricsCollectorCPURequestTag] = consts.DefaultCPURequest
-			metricsCollectorConfigData[consts.LabelMetricsCollectorMemRequestTag] = consts.DefaultMemRequest
-			metricsCollectorConfigData[consts.LabelMetricsCollectorDiskRequestTag] = consts.DefaultDiskRequest
-			metricsCollectorConfigData[consts.LabelMetricsCollectorCPULimitTag] = consts.DefaultCPULimit
-			metricsCollectorConfigData[consts.LabelMetricsCollectorMemLimitTag] = consts.DefaultMemLimit
-			metricsCollectorConfigData[consts.LabelMetricsCollectorDiskLimitTag] = consts.DefaultDiskLimit
-
-			// Get CPU, Memory and Disk Requests from config
-			cpuRequest := metricsCollectorConfig.Resource.Requests[corev1.ResourceCPU]
-			memRequest := metricsCollectorConfig.Resource.Requests[corev1.ResourceMemory]
-			diskRequest := metricsCollectorConfig.Resource.Requests[corev1.ResourceEphemeralStorage]
-			if !cpuRequest.IsZero() {
-				metricsCollectorConfigData[consts.LabelMetricsCollectorCPURequestTag] = cpuRequest.String()
-			}
-			if !memRequest.IsZero() {
-				metricsCollectorConfigData[consts.LabelMetricsCollectorMemRequestTag] = memRequest.String()
-			}
-			if !diskRequest.IsZero() {
-				metricsCollectorConfigData[consts.LabelMetricsCollectorDiskRequestTag] = diskRequest.String()
-			}
-
-			// Get CPU, Memory and Disk Limits from config
-			cpuLimit := metricsCollectorConfig.Resource.Limits[corev1.ResourceCPU]
-			memLimit := metricsCollectorConfig.Resource.Limits[corev1.ResourceMemory]
-			diskLimit := metricsCollectorConfig.Resource.Limits[corev1.ResourceEphemeralStorage]
-			if !cpuLimit.IsZero() {
-				metricsCollectorConfigData[consts.LabelMetricsCollectorCPULimitTag] = cpuLimit.String()
-			}
-			if !memLimit.IsZero() {
-				metricsCollectorConfigData[consts.LabelMetricsCollectorMemLimitTag] = memLimit.String()
-			}
-			if !diskLimit.IsZero() {
-				metricsCollectorConfigData[consts.LabelMetricsCollectorDiskLimitTag] = diskLimit.String()
-			}
-
-		} else {
-			return metricsCollectorConfigData, errors.New("Cannot support metricsCollector injection for kind " + kind)
-		}
-	} else {
-		return metricsCollectorConfigData, errors.New("Failed to find metrics collector configuration in configmap " + consts.KatibConfigMapName)
+	// Try to find metrics collector data in config map
+	config, ok := configMap.Data[consts.LabelMetricsCollectorSidecar]
+	if !ok {
+		return MetricsCollectorConfig{}, errors.New("Failed to find metrics collector config in ConfigMap: " + consts.KatibConfigMapName)
 	}
+	// Parse metrics collector data to map where key = collector kind, value = MetricsCollectorConfig
+	kind := string(cKind)
+	mcsConfig := map[string]MetricsCollectorConfig{}
+	if err := json.Unmarshal([]byte(config), &mcsConfig); err != nil {
+		return MetricsCollectorConfig{}, err
+	}
+
+	// Try to find MetricsCollectorConfig for the collector kind
+	metricsCollectorConfigData, ok = mcsConfig[kind]
+	if !ok {
+		return MetricsCollectorConfig{}, errors.New("Failed to find metrics collector config for kind: " + kind + " in ConfigMap: " + consts.KatibConfigMapName)
+	}
+
+	// Get image from config
+	image := metricsCollectorConfigData.Image
+	if strings.TrimSpace(image) == "" {
+		return MetricsCollectorConfig{}, errors.New("Required value for image configuration of metrics collector kind: " + kind)
+	}
+
+	// Get Image Pull Policy
+	imagePullPolicy := metricsCollectorConfigData.ImagePullPolicy
+	if imagePullPolicy != corev1.PullAlways && imagePullPolicy != corev1.PullIfNotPresent && imagePullPolicy != corev1.PullNever {
+		metricsCollectorConfigData.ImagePullPolicy = consts.DefaultImagePullPolicy
+	}
+
+	// Set resource requirements for metrics collector
+	metricsCollectorConfigData.Resource = setResourceRequirements(metricsCollectorConfigData.Resource)
+
 	return metricsCollectorConfigData, nil
+}
+
+func setResourceRequirements(configResource corev1.ResourceRequirements) corev1.ResourceRequirements {
+
+	// If requests are empty create new map
+	if len(configResource.Requests) == 0 {
+		configResource.Requests = make(map[corev1.ResourceName]resource.Quantity)
+	}
+
+	// Get CPU, Memory and Disk Requests from config
+	cpuRequest := configResource.Requests[corev1.ResourceCPU]
+	memRequest := configResource.Requests[corev1.ResourceMemory]
+	diskRequest := configResource.Requests[corev1.ResourceEphemeralStorage]
+
+	// If resource is empty set default value for CPU, Memory, Disk
+	if cpuRequest.IsZero() {
+		defaultCPURequest, _ := resource.ParseQuantity(consts.DefaultCPURequest)
+		configResource.Requests[corev1.ResourceCPU] = defaultCPURequest
+	}
+	if memRequest.IsZero() {
+		defaultMemRequest, _ := resource.ParseQuantity(consts.DefaultMemRequest)
+		configResource.Requests[corev1.ResourceMemory] = defaultMemRequest
+	}
+	if diskRequest.IsZero() {
+		defaultDiskRequest, _ := resource.ParseQuantity(consts.DefaultDiskRequest)
+		configResource.Requests[corev1.ResourceEphemeralStorage] = defaultDiskRequest
+	}
+
+	// If limits are empty create new map
+	if len(configResource.Limits) == 0 {
+		configResource.Limits = make(map[corev1.ResourceName]resource.Quantity)
+	}
+
+	// Get CPU, Memory and Disk Limits from config
+	cpuLimit := configResource.Limits[corev1.ResourceCPU]
+	memLimit := configResource.Limits[corev1.ResourceMemory]
+	diskLimit := configResource.Limits[corev1.ResourceEphemeralStorage]
+
+	// If limit is empty set default value for CPU, Memory, Disk
+	if cpuLimit.IsZero() {
+		defaultCPULimit, _ := resource.ParseQuantity(consts.DefaultCPULimit)
+		configResource.Limits[corev1.ResourceCPU] = defaultCPULimit
+	}
+	if memLimit.IsZero() {
+		defaultMemLimit, _ := resource.ParseQuantity(consts.DefaultMemLimit)
+		configResource.Limits[corev1.ResourceMemory] = defaultMemLimit
+	}
+	if diskLimit.IsZero() {
+		defaultDiskLimit, _ := resource.ParseQuantity(consts.DefaultDiskLimit)
+		configResource.Limits[corev1.ResourceEphemeralStorage] = defaultDiskLimit
+	}
+	return configResource
 }

--- a/pkg/webhook/v1beta1/experiment/validation_webhook.go
+++ b/pkg/webhook/v1beta1/experiment/validation_webhook.go
@@ -25,6 +25,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
@@ -32,7 +33,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
 
 	experimentsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
+	suggestionsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/suggestions/v1beta1"
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/experiment/manifest"
+	"github.com/kubeflow/katib/pkg/controller.v1beta1/util"
 	"github.com/kubeflow/katib/pkg/webhook/v1beta1/common"
 	"github.com/kubeflow/katib/pkg/webhook/v1beta1/experiment/validator"
 )
@@ -96,9 +99,20 @@ func (v *experimentValidator) Handle(ctx context.Context, req types.Request) typ
 	// We unable to watch for the PV events in controller.
 	// Webhook forbids experiment creation until coresponding PV will be deleted.
 	if inst.Spec.ResumePolicy == experimentsv1beta1.FromVolume && oldInst == nil {
-		foundPV := &v1.PersistentVolume{}
-		PVName := inst.Name + "-" + inst.Namespace
-		err := v.client.Get(context.TODO(), ktypes.NamespacedName{Name: PVName}, foundPV)
+		// Create suggestion with name, namespace and algorithm name to get appropriate PV
+		suggestion := &suggestionsv1beta1.Suggestion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      inst.Name,
+				Namespace: inst.Namespace,
+			},
+			Spec: suggestionsv1beta1.SuggestionSpec{
+				AlgorithmName: inst.Spec.Algorithm.AlgorithmName,
+			},
+		}
+
+		// Get PV name from Suggestion
+		PVName := util.GetAlgorithmPersistentVolumeName(suggestion)
+		err := v.client.Get(context.TODO(), ktypes.NamespacedName{Name: PVName}, &v1.PersistentVolume{})
 		if !errors.IsNotFound(err) {
 			returnError := fmt.Errorf("Cannot create the Experiment: %v in namespace: %v, PV: %v is not deleted", inst.Name, inst.Namespace, PVName)
 			if err != nil {

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -351,8 +351,8 @@ func (g *DefaultValidator) validateMetricsCollector(inst *experimentsv1beta1.Exp
 		if mcKind != mc {
 			continue
 		}
-		if _, err := g.GetMetricsCollectorImage(mcKind); err != nil {
-			return fmt.Errorf("GetMetricsCollectorImage failed: %v.", err)
+		if _, err := g.GetMetricsCollectorConfigData(mcKind); err != nil {
+			return fmt.Errorf("GetMetricsCollectorConfigData failed: %v", err)
 		}
 		break
 	}

--- a/pkg/webhook/v1beta1/experiment/validator/validator_test.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator_test.go
@@ -32,10 +32,12 @@ func TestValidateExperiment(t *testing.T) {
 
 	suggestionConfigData := katibconfig.SuggestionConfig{}
 	suggestionConfigData.Image = "algorithmImage"
+	metricsCollectorConfigData := katibconfig.MetricsCollectorConfig{}
+	metricsCollectorConfigData.Image = "metricsCollectorImage"
 	fakeNegativeInt := int32(-1)
 
 	p.EXPECT().GetSuggestionConfigData(gomock.Any()).Return(suggestionConfigData, nil).AnyTimes()
-	p.EXPECT().GetMetricsCollectorImage(gomock.Any()).Return("metricsCollectorImage", nil).AnyTimes()
+	p.EXPECT().GetMetricsCollectorConfigData(gomock.Any()).Return(metricsCollectorConfigData, nil).AnyTimes()
 
 	batchJobStr := convertBatchJobToString(newFakeBatchJob())
 	p.EXPECT().GetTrialTemplate(gomock.Any()).Return(batchJobStr, nil).AnyTimes()

--- a/pkg/webhook/v1beta1/pod/inject_webhook.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook.go
@@ -26,7 +26,6 @@ import (
 	"github.com/spf13/viper"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -184,58 +183,12 @@ func (s *sidecarInjector) getMetricsCollectorContainer(trial *trialsv1beta1.Tria
 	args := getMetricsCollectorArgs(trial.Name, metricName, mc)
 	sidecarContainerName := getSidecarContainerName(trial.Spec.MetricsCollector.Collector.Kind)
 
-	// Get metricsCollector data from config
-	metricsCollectorContainerImage := metricsCollectorConfigData[consts.LabelMetricsCollectorSidecarImage]
-	metricsCollectorImagePullPolicy := metricsCollectorConfigData[consts.LabelMetricsCollectorImagePullPolicy]
-	metricsCollectorCPULimit := metricsCollectorConfigData[consts.LabelMetricsCollectorCPULimitTag]
-	metricsCollectorCPURequest := metricsCollectorConfigData[consts.LabelMetricsCollectorCPURequestTag]
-	metricsCollectorMemLimit := metricsCollectorConfigData[consts.LabelMetricsCollectorMemLimitTag]
-	metricsCollectorMemRequest := metricsCollectorConfigData[consts.LabelMetricsCollectorMemRequestTag]
-	metricsCollectorDiskLimit := metricsCollectorConfigData[consts.LabelMetricsCollectorDiskLimitTag]
-	metricsCollectorDiskRequest := metricsCollectorConfigData[consts.LabelMetricsCollectorDiskRequestTag]
-
-	cpuLimitQuantity, err := resource.ParseQuantity(metricsCollectorCPULimit)
-	if err != nil {
-		return nil, err
-	}
-	cpuRequestQuantity, err := resource.ParseQuantity(metricsCollectorCPURequest)
-	if err != nil {
-		return nil, err
-	}
-	memLimitQuantity, err := resource.ParseQuantity(metricsCollectorMemLimit)
-	if err != nil {
-		return nil, err
-	}
-	memRequestQuantity, err := resource.ParseQuantity(metricsCollectorMemRequest)
-	if err != nil {
-		return nil, err
-	}
-	diskLimitQuantity, err := resource.ParseQuantity(metricsCollectorDiskLimit)
-	if err != nil {
-		return nil, err
-	}
-	diskRequestQuantity, err := resource.ParseQuantity(metricsCollectorDiskRequest)
-	if err != nil {
-		return nil, err
-	}
-
 	injectContainer := v1.Container{
 		Name:            sidecarContainerName,
-		Image:           metricsCollectorContainerImage,
+		Image:           metricsCollectorConfigData.Image,
 		Args:            args,
-		ImagePullPolicy: v1.PullPolicy(metricsCollectorImagePullPolicy),
-		Resources: v1.ResourceRequirements{
-			Limits: v1.ResourceList{
-				v1.ResourceCPU:              cpuLimitQuantity,
-				v1.ResourceMemory:           memLimitQuantity,
-				v1.ResourceEphemeralStorage: diskLimitQuantity,
-			},
-			Requests: v1.ResourceList{
-				v1.ResourceCPU:              cpuRequestQuantity,
-				v1.ResourceMemory:           memRequestQuantity,
-				v1.ResourceEphemeralStorage: diskRequestQuantity,
-			},
-		},
+		ImagePullPolicy: metricsCollectorConfigData.ImagePullPolicy,
+		Resources:       metricsCollectorConfigData.Resource,
 	}
 
 	// Inject the security context when the flag is enabled.


### PR DESCRIPTION
I changed metrics collector config parser to be consistent with suggestion config (See PR: https://github.com/kubeflow/katib/pull/1282).

Validation for metrics collector config checks if `GetMetricsCollectorConfigData` doesn't return error for the appropriate collector kind.

As well, I fixed name for the PV, when we check if PV exists.

/assign @gaocegege @johnugeorge 