### PR TITLE
Validate restart Experiment parameters

### DIFF
--- a/pkg/controller.v1beta1/experiment/util/status_util.go
+++ b/pkg/controller.v1beta1/experiment/util/status_util.go
@@ -225,6 +225,8 @@ func UpdateExperimentStatusCondition(collector *ExperimentsCollector, instance *
 }
 
 // IsCompletedExperimentRestartable returns whether experiment is restartable or not
+// Experiment is restartable only if it is in succeeded state by reaching max trials and
+// ResumePolicy = LongRunning or ResumePolicy = FromVolume
 func IsCompletedExperimentRestartable(instance *experimentsv1beta1.Experiment) bool {
 	if instance.IsSucceeded() && instance.IsCompletedReason(ExperimentMaxTrialsReachedReason) &&
 		(instance.Spec.ResumePolicy == experimentsv1beta1.LongRunning || instance.Spec.ResumePolicy == experimentsv1beta1.FromVolume) {

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -65,9 +65,7 @@ func (g *DefaultValidator) ValidateExperiment(instance, oldInst *experimentsv1be
 		// We should validate restart only if appropriate fields are changed.
 		// Otherwise check below is triggered when experiment is deleted.
 		isRestarting := false
-		if *oldInst.Spec.MaxFailedTrialCount != *instance.Spec.MaxFailedTrialCount ||
-			*oldInst.Spec.MaxTrialCount != *instance.Spec.MaxTrialCount ||
-			*oldInst.Spec.ParallelTrialCount != *instance.Spec.ParallelTrialCount {
+		if !equality.Semantic.DeepEqual(instance.Spec, oldInst.Spec) {
 			isRestarting = true
 		}
 

--- a/pkg/webhook/v1beta1/experiment/validator/validator_test.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator_test.go
@@ -154,6 +154,8 @@ func TestValidateExperiment(t *testing.T) {
 				i.Status = experimentsv1beta1.ExperimentStatus{
 					Trials: *i.Spec.MaxTrialCount,
 				}
+				var failed int32 = 2
+				i.Spec.MaxFailedTrialCount = &failed
 				return i
 			}(),
 			testDescription: "Resume experiment with MaxTrialCount <= Status.Trials",

--- a/pkg/webhook/v1beta1/experiment/validator/validator_test.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator_test.go
@@ -14,7 +14,9 @@ import (
 
 	commonv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
 	experimentsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
+	experimentutil "github.com/kubeflow/katib/pkg/controller.v1beta1/experiment/util"
 	util "github.com/kubeflow/katib/pkg/controller.v1beta1/util"
+
 	manifestmock "github.com/kubeflow/katib/pkg/mock/v1beta1/experiment/manifest"
 	"github.com/kubeflow/katib/pkg/util/v1beta1/katibconfig"
 )
@@ -126,12 +128,35 @@ func TestValidateExperiment(t *testing.T) {
 			Err:             true,
 			testDescription: "Parallel trial count is negative",
 		},
-		// Valid Resume Experiment
+		// Validate Resume Experiment
 		{
 			Instance:        newFakeInstance(),
 			Err:             false,
 			oldInstance:     newFakeInstance(),
 			testDescription: "Run validator to correct resume experiment",
+		},
+		{
+			Instance: newFakeInstance(),
+			Err:      true,
+			oldInstance: func() *experimentsv1beta1.Experiment {
+				i := newFakeInstance()
+				i.MarkExperimentStatusSucceeded(experimentutil.ExperimentMaxTrialsReachedReason, "Experiment is succeeded")
+				i.Spec.ResumePolicy = experimentsv1beta1.NeverResume
+				return i
+			}(),
+			testDescription: "Resume succeeded experiment with ResumePolicy = NeverResume",
+		},
+		{
+			Instance: newFakeInstance(),
+			Err:      true,
+			oldInstance: func() *experimentsv1beta1.Experiment {
+				i := newFakeInstance()
+				i.Status = experimentsv1beta1.ExperimentStatus{
+					Trials: *i.Spec.MaxTrialCount,
+				}
+				return i
+			}(),
+			testDescription: "Resume experiment with MaxTrialCount <= Status.Trials",
 		},
 		{
 			Instance: newFakeInstance(),
@@ -152,6 +177,7 @@ func TestValidateExperiment(t *testing.T) {
 			Err:             true,
 			testDescription: "Invalid resume policy",
 		},
+		// Validate NAS Config
 		{
 			Instance: func() *experimentsv1beta1.Experiment {
 				i := newFakeInstance()
@@ -939,12 +965,15 @@ func TestValidateMetricsCollector(t *testing.T) {
 
 func newFakeInstance() *experimentsv1beta1.Experiment {
 	goal := 0.11
+	var maxTrialCount int32 = 6
+
 	return &experimentsv1beta1.Experiment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "fake",
 			Namespace: "fakens",
 		},
 		Spec: experimentsv1beta1.ExperimentSpec{
+			MaxTrialCount: &maxTrialCount,
 			MetricsCollectorSpec: &commonv1beta1.MetricsCollectorSpec{
 				Collector: &commonv1beta1.CollectorSpec{
 					Kind: commonv1beta1.StdOutCollector,


### PR DESCRIPTION
I added validation for restarting experiment in the webhook.
After that, user can see if restart experiment is possible or not.

/assign @sperlingxx @johnugeorge @gaocegege 