### PR TITLE
Verify that Trials were successfully deleted

### DIFF
--- a/pkg/apis/controller/suggestions/v1beta1/util.go
+++ b/pkg/apis/controller/suggestions/v1beta1/util.go
@@ -5,6 +5,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// SuggestionRestartReason is the reason for suggestion status when experiment is restarting
+	SuggestionRestartReason = "Experiment is restarting"
+)
+
 func getCondition(suggestion *Suggestion, condType SuggestionConditionType) *SuggestionCondition {
 	if suggestion.Status.Conditions != nil {
 		for _, condition := range suggestion.Status.Conditions {
@@ -64,10 +69,10 @@ func (suggestion *Suggestion) IsRunning() bool {
 	return hasCondition(suggestion, SuggestionRunning)
 }
 
-// IsNotRunning returns true if suggestion running status is false
-func (suggestion *Suggestion) IsNotRunning() bool {
+// IsRestarting returns true if suggestion running status is false and reason = SuggestionRestartReason
+func (suggestion *Suggestion) IsRestarting() bool {
 	cond := getCondition(suggestion, SuggestionRunning)
-	if cond != nil && cond.Status == v1.ConditionFalse {
+	if cond != nil && cond.Status == v1.ConditionFalse && cond.Reason == SuggestionRestartReason {
 		return true
 	}
 	return false

--- a/pkg/apis/controller/suggestions/v1beta1/util.go
+++ b/pkg/apis/controller/suggestions/v1beta1/util.go
@@ -64,6 +64,15 @@ func (suggestion *Suggestion) IsRunning() bool {
 	return hasCondition(suggestion, SuggestionRunning)
 }
 
+// IsNotRunning returns true if suggestion running status is false
+func (suggestion *Suggestion) IsNotRunning() bool {
+	cond := getCondition(suggestion, SuggestionRunning)
+	if cond != nil && cond.Status == v1.ConditionFalse {
+		return true
+	}
+	return false
+}
+
 func (suggestion *Suggestion) IsDeploymentReady() bool {
 	return hasCondition(suggestion, SuggestionDeploymentReady)
 }

--- a/pkg/controller.v1beta1/experiment/experiment_controller.go
+++ b/pkg/controller.v1beta1/experiment/experiment_controller.go
@@ -430,10 +430,17 @@ func (r *ReconcileExperiment) deleteTrials(instance *experimentsv1beta1.Experime
 			newTrialAssignment = append(newTrialAssignment, ta)
 		}
 	}
-	suggestion.Status.Suggestions = newTrialAssignment
-	suggestion.Status.SuggestionCount = int32(len(newTrialAssignment))
+
+	// Update suggestion spec first.
+	// If Requests <= SuggestionCount suggestion controller returns nil.
+	suggestion.Spec.Requests = int32(len(newTrialAssignment))
+	if err := r.UpdateSuggestion(suggestion); err != nil {
+		return err
+	}
 
 	// Update suggestion status
+	suggestion.Status.Suggestions = newTrialAssignment
+	suggestion.Status.SuggestionCount = int32(len(newTrialAssignment))
 	if err := r.UpdateSuggestionStatus(suggestion); err != nil {
 		return err
 	}

--- a/pkg/controller.v1beta1/experiment/experiment_controller_test.go
+++ b/pkg/controller.v1beta1/experiment/experiment_controller_test.go
@@ -102,6 +102,7 @@ func TestReconcile(t *testing.T) {
 		Suggestion: mockSuggestion,
 		Generator:  mockGenerator,
 		collector:  experimentUtil.NewExpsCollector(mgr.GetCache(), prometheus.NewRegistry()),
+		recorder:   mgr.GetRecorder(ControllerName),
 	}
 	r.updateStatusHandler = func(instance *experimentsv1beta1.Experiment) error {
 		var err error = errors.NewBadRequest("fake-error")

--- a/pkg/controller.v1beta1/experiment/experiment_controller_test.go
+++ b/pkg/controller.v1beta1/experiment/experiment_controller_test.go
@@ -145,21 +145,20 @@ func TestReconcile(t *testing.T) {
 
 	mockSuggestion.EXPECT().UpdateSuggestion(gomock.Any()).Return(nil).AnyTimes()
 
-	reason := "Experiment is succeeded"
+	reasonRestart := "Experiment is succeeded"
 	msgRestartNo := "Suggestion is succeeded, can't be restarted"
-	suggestionRestartNo.MarkSuggestionStatusSucceeded(reason, msgRestartNo)
+	suggestionRestartNo.MarkSuggestionStatusSucceeded(reasonRestart, msgRestartNo)
 
 	suggestionRestartYes := newFakeSuggestion()
 	suggestionRestartYes.Spec.ResumePolicy = experimentsv1beta1.FromVolume
 
 	msgRestartYes := "Suggestion is succeeded, suggestion volume is not deleted, can be restarted"
-	suggestionRestartYes.MarkSuggestionStatusSucceeded(reason, msgRestartYes)
+	suggestionRestartYes.MarkSuggestionStatusSucceeded(reasonRestart, msgRestartYes)
 
 	suggestionRestarting := newFakeSuggestion()
 
-	reason = "Experiment is restarting"
 	msgRestarting := "Suggestion is not running"
-	suggestionRestarting.MarkSuggestionStatusRunning(corev1.ConditionFalse, reason, msgRestarting)
+	suggestionRestarting.MarkSuggestionStatusRunning(corev1.ConditionFalse, suggestionsv1beta1.SuggestionRestartReason, msgRestarting)
 
 	// Manually update suggestion status after UpdateSuggestionStatus is called
 	// Call when Trials are being deleted
@@ -182,7 +181,7 @@ func TestReconcile(t *testing.T) {
 			suggestion := &suggestionsv1beta1.Suggestion{}
 			for err != nil {
 				c.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: experimentName}, suggestion)
-				suggestion.MarkSuggestionStatusSucceeded(reason, msgRestartNo)
+				suggestion.MarkSuggestionStatusSucceeded(reasonRestart, msgRestartNo)
 				err = c.Status().Update(context.TODO(), suggestion)
 			}
 		})
@@ -194,7 +193,7 @@ func TestReconcile(t *testing.T) {
 			suggestion := &suggestionsv1beta1.Suggestion{}
 			for err != nil {
 				c.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: experimentName}, suggestion)
-				suggestion.MarkSuggestionStatusSucceeded(reason, msgRestartYes)
+				suggestion.MarkSuggestionStatusSucceeded(reasonRestart, msgRestartYes)
 				err = c.Status().Update(context.TODO(), suggestion)
 			}
 		})
@@ -206,7 +205,7 @@ func TestReconcile(t *testing.T) {
 			var err error = errors.NewBadRequest("fake-error")
 			for err != nil {
 				c.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: experimentName}, suggestion)
-				suggestion.MarkSuggestionStatusRunning(corev1.ConditionFalse, reason, msgRestarting)
+				suggestion.MarkSuggestionStatusRunning(corev1.ConditionFalse, suggestionsv1beta1.SuggestionRestartReason, msgRestarting)
 				err = c.Status().Update(context.TODO(), suggestion)
 			}
 		})

--- a/pkg/controller.v1beta1/experiment/experiment_util.go
+++ b/pkg/controller.v1beta1/experiment/experiment_util.go
@@ -115,8 +115,8 @@ func (r *ReconcileExperiment) cleanupSuggestionResources(instance *experimentsv1
 		return err
 	}
 
-	// If Suggestion is completed or Suggestion running status is false not needed to terminate Suggestion
-	if original.IsCompleted() || original.IsNotRunning() {
+	// If Suggestion is completed or Suggestion restarting not needed to terminate Suggestion
+	if original.IsCompleted() || original.IsRestarting() {
 		return nil
 	}
 
@@ -154,17 +154,16 @@ func (r *ReconcileExperiment) restartSuggestion(instance *experimentsv1beta1.Exp
 		}
 		return err
 	}
-	// If Suggestion running status is false not needed to restart Suggestion
-	if original.IsNotRunning() {
+	// If Suggestion is restarting not needed to restart Suggestion
+	if original.IsRestarting() {
 		return nil
 	}
 
 	logger.Info("Suggestion is restarting, suggestion Running status is false")
 	suggestion := original.DeepCopy()
-	reason := "Experiment is restarting"
 	msg := "Suggestion is not running"
 	// Mark suggestion status not running because experiment is restarting and suggestion deployment is not ready
-	suggestion.MarkSuggestionStatusRunning(corev1.ConditionFalse, reason, msg)
+	suggestion.MarkSuggestionStatusRunning(corev1.ConditionFalse, suggestionsv1beta1.SuggestionRestartReason, msg)
 
 	if err := r.UpdateSuggestionStatus(suggestion); err != nil {
 		return err

--- a/pkg/controller.v1beta1/experiment/experiment_util.go
+++ b/pkg/controller.v1beta1/experiment/experiment_util.go
@@ -115,7 +115,7 @@ func (r *ReconcileExperiment) cleanupSuggestionResources(instance *experimentsv1
 		return err
 	}
 
-	// If Suggestion is completed or Suggestion restarting not needed to terminate Suggestion
+	// If Suggestion is completed or Suggestion is restarting not needed to terminate Suggestion
 	if original.IsCompleted() || original.IsRestarting() {
 		return nil
 	}

--- a/pkg/controller.v1beta1/experiment/experiment_util.go
+++ b/pkg/controller.v1beta1/experiment/experiment_util.go
@@ -115,8 +115,8 @@ func (r *ReconcileExperiment) cleanupSuggestionResources(instance *experimentsv1
 		return err
 	}
 
-	// If Suggestion is failed or Suggestion is Succeeded, not needed to terminate Suggestion
-	if original.IsFailed() || original.IsSucceeded() {
+	// If Suggestion is completed or Suggestion running status is false not needed to terminate Suggestion
+	if original.IsCompleted() || original.IsNotRunning() {
 		return nil
 	}
 
@@ -153,6 +153,10 @@ func (r *ReconcileExperiment) restartSuggestion(instance *experimentsv1beta1.Exp
 			return nil
 		}
 		return err
+	}
+	// If Suggestion running status is false, not needed to restart Suggestion
+	if original.IsNotRunning() {
+		return nil
 	}
 
 	logger.Info("Suggestion is restarting, suggestion Running status is false")

--- a/pkg/controller.v1beta1/experiment/experiment_util.go
+++ b/pkg/controller.v1beta1/experiment/experiment_util.go
@@ -154,7 +154,7 @@ func (r *ReconcileExperiment) restartSuggestion(instance *experimentsv1beta1.Exp
 		}
 		return err
 	}
-	// If Suggestion running status is false, not needed to restart Suggestion
+	// If Suggestion running status is false not needed to restart Suggestion
 	if original.IsNotRunning() {
 		return nil
 	}

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller.go
@@ -256,7 +256,8 @@ func (r *ReconcileSuggestion) ReconcileSuggestion(instance *suggestionsv1beta1.S
 		msg := "Suggestion is running"
 		instance.MarkSuggestionStatusRunning(corev1.ConditionTrue, SuggestionRunningReason, msg)
 	}
-	logger.Info("Sync assignments", "suggestions", instance.Spec.Requests)
+	logger.Info("Sync assignments", "Suggestion Requests", instance.Spec.Requests,
+		"Suggestion Count", instance.Status.SuggestionCount)
 	if err = r.SyncAssignments(instance, experiment, trials.Items); err != nil {
 		return err
 	}

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller_test.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller_test.go
@@ -80,6 +80,7 @@ func TestReconcile(t *testing.T) {
 		scheme:           mgr.GetScheme(),
 		SuggestionClient: mockSuggestionClient,
 		Composer:         composer.New(mgr),
+		recorder:         mgr.GetRecorder(ControllerName),
 	}
 
 	recFn := SetupTestReconcile(r)

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller_test.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller_test.go
@@ -127,13 +127,13 @@ func TestReconcile(t *testing.T) {
 	configMap := newKatibConfigMapInstance()
 
 	// Test 1 - Regural suggestion run
-	// Create the suggestion object and expect the service, deployment, pvc and pv is created
+	// Create the suggestion and expect the service, deployment, pvc and pv is created
 	g.Expect(c.Create(context.TODO(), instance)).NotTo(gomega.HaveOccurred())
 	// Create ConfigMap with suggestion data
 	g.Expect(c.Create(context.TODO(), configMap)).NotTo(gomega.HaveOccurred())
-	// Create experiment object
+	// Create experiment
 	g.Expect(c.Create(context.TODO(), experiment)).NotTo(gomega.HaveOccurred())
-	// Create trial object
+	// Create trial
 	g.Expect(c.Create(context.TODO(), trial)).NotTo(gomega.HaveOccurred())
 
 	suggestionDeploy := &appsv1.Deployment{}
@@ -195,11 +195,10 @@ func TestReconcile(t *testing.T) {
 			errors.IsNotFound(c.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: resourceName}, &corev1.Service{}))
 	}, timeout).Should(gomega.BeTrue())
 
-	// Delete the suggestion object
-	g.Expect(c.Delete(context.TODO(), instance)).NotTo(gomega.HaveOccurred())
-
 	// Expect that suggestion is deleted
 	g.Eventually(func() bool {
+		// Delete the suggestion
+		c.Delete(context.TODO(), instance)
 		return errors.IsNotFound(c.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: suggestionName}, &suggestionsv1beta1.Suggestion{}))
 	}, timeout).Should(gomega.BeTrue())
 
@@ -231,13 +230,13 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
-	// Test 2 - Update status for empty experiment object
+	// Test 2 - Update status for empty experiment
 	g.Expect(r.updateStatus(&suggestionsv1beta1.Suggestion{}, oldS)).To(gomega.HaveOccurred())
 
 	// Test 3 - Update status condition
 	g.Expect(r.updateStatusCondition(newS, oldS)).NotTo(gomega.HaveOccurred())
 
-	// Test 4 - Update status condition for empty experiment object
+	// Test 4 - Update status condition for empty experiment
 	g.Expect(r.updateStatusCondition(&suggestionsv1beta1.Suggestion{}, oldS)).To(gomega.HaveOccurred())
 
 }

--- a/test/e2e/v1beta1/resume-e2e-experiment.go
+++ b/test/e2e/v1beta1/resume-e2e-experiment.go
@@ -90,7 +90,7 @@ func main() {
 		if err != nil {
 			log.Fatal("Get Experiment error ", err)
 		}
-		if exp.IsRunning() && exp.Status.Trials > exp.Status.TrialsSucceeded {
+		if exp.IsRunning() {
 			log.Printf("Experiment %v started running with %v MaxTrialCount", exp.Name, maxtrials)
 			break
 		}

--- a/test/e2e/v1beta1/resume-e2e-experiment.go
+++ b/test/e2e/v1beta1/resume-e2e-experiment.go
@@ -90,7 +90,7 @@ func main() {
 		if err != nil {
 			log.Fatal("Get Experiment error ", err)
 		}
-		if exp.IsRunning() && exp.Status.Trials == maxtrials {
+		if exp.IsRunning() && exp.Status.Trials > exp.Status.TrialsSucceeded {
 			log.Printf("Experiment %v started running with %v MaxTrialCount", exp.Name, maxtrials)
 			break
 		}

--- a/test/e2e/v1beta1/run-e2e-experiment.go
+++ b/test/e2e/v1beta1/run-e2e-experiment.go
@@ -158,17 +158,19 @@ func main() {
 
 		namespacedName := types.NamespacedName{Name: controllerUtil.GetAlgorithmServiceName(sug), Namespace: sug.Namespace}
 		err := kclient.GetClient().Get(context.TODO(), namespacedName, &corev1.Service{})
-		if err == nil || !errors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
+			log.Printf("Suggestion service %v has been deleted", controllerUtil.GetAlgorithmServiceName(sug))
+		} else {
 			log.Fatalf("Suggestion service is still alive while ResumePolicy = %v", exp.Spec.ResumePolicy)
 		}
-		log.Printf("Suggestion service %v has been deleted", controllerUtil.GetAlgorithmServiceName(sug))
 
 		namespacedName = types.NamespacedName{Name: controllerUtil.GetAlgorithmDeploymentName(sug), Namespace: sug.Namespace}
 		err = kclient.GetClient().Get(context.TODO(), namespacedName, &appsv1.Deployment{})
-		if err == nil || !errors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
+			log.Printf("Suggestion deployment %v has been deleted", controllerUtil.GetAlgorithmDeploymentName(sug))
+		} else {
 			log.Fatalf("Suggestion deployment is still alive while ResumePolicy = %v", exp.Spec.ResumePolicy)
 		}
-		log.Printf("Suggestion deployment %v has been deleted", controllerUtil.GetAlgorithmDeploymentName(sug))
 
 		if exp.Spec.ResumePolicy == experimentsv1beta1.FromVolume {
 			namespacedName = types.NamespacedName{Name: controllerUtil.GetAlgorithmPersistentVolumeClaimName(sug), Namespace: sug.Namespace}

--- a/test/scripts/v1beta1/run-from-volume.sh
+++ b/test/scripts/v1beta1/run-from-volume.sh
@@ -59,6 +59,10 @@ export KUBECONFIG=$HOME/.kube/config
 kubectl -n kubeflow describe suggestion from-volume-resume
 kubectl -n kubeflow describe experiment from-volume-resume
 
+echo "Available volumes"
+kubectl get pvc -n kubeflow
+kubectl get pv
+
 echo "Resuming the completed experiment with resume from volume"
 ./resume-e2e-experiment ../../../examples/v1beta1/resume-experiment/from-volume-resume.yaml
 


### PR DESCRIPTION
When I tried to update `parallelTrialCount` to less value, I got errors in controller.

In `deleteTrials` we should verify that Trials were successfully deleted before running reconcile loop again and update suggestion `requests` and `status.suggestions`.

Otherwise, [`updateTrialsSummary`](https://github.com/andreyvelich/katib/blob/04d78c24e47c6fe951099c5e5353bc79ecadc5af/pkg/controller.v1beta1/experiment/util/status_util.go#L55) is resynchronized with Trial list and `addCount` for [`ReconcileSuggestion`](https://github.com/andreyvelich/katib/blob/04d78c24e47c6fe951099c5e5353bc79ecadc5af/pkg/controller.v1beta1/experiment/experiment_controller.go#L458) is incorrect.

/assign @gaocegege @johnugeorge 