### PR TITLE
Support volume settings in Katib config

### DIFF
--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -32,6 +32,8 @@ const (
 
 	// ContainerSuggestion is the container name in Suggestion.
 	ContainerSuggestion = "suggestion"
+	// ContainerSuggestionVolumeName is the volume name that mounted on suggestion container
+	ContainerSuggestionVolumeName = "suggestion-volume"
 
 	// DefaultSuggestionPort is the default port of suggestion service.
 	DefaultSuggestionPort = 6789
@@ -78,6 +80,22 @@ const (
 	DefaultDiskLimit = "5Gi"
 	// DefaultDiskRequest is the default value for disk request.
 	DefaultDiskRequest = "500Mi"
+
+	// DefaultContainerSuggestionVolumeMountPath is the default mount path in suggestion container
+	DefaultContainerSuggestionVolumeMountPath = "/opt/katib/data"
+
+	// DefaultSuggestionStorageClassName is the default value for suggestion's volume storage class name
+	DefaultSuggestionStorageClassName = "katib-suggestion"
+
+	// DefaultSuggestionVolumeStorage is the default value for suggestion's volume storage
+	DefaultSuggestionVolumeStorage = "1Gi"
+
+	// DefaultSuggestionVolumeAccessMode is the default value for suggestion's volume access mode
+	DefaultSuggestionVolumeAccessMode = corev1.ReadWriteOnce
+
+	// DefaultSuggestionVolumeLocalPathPrefix is the default cluster local path prefix for suggestion volume
+	// Full default local path = /tmp/katib/suggestions/<suggestion-name>-<suggestion-algorithm>-<suggestion-namespace>
+	DefaultSuggestionVolumeLocalPathPrefix = "/tmp/katib/suggestions/"
 
 	// ReconcileErrorReason is the reason when there is a reconcile error.
 	ReconcileErrorReason = "ReconcileError"
@@ -127,25 +145,6 @@ const (
 
 	// UnavailableMetricValue is the value when metric was not reported or metric value can't be converted to float64
 	UnavailableMetricValue = "unavailable"
-
-	// DefaultSuggestionVolumeLocalPathPrefix is the default cluster local path prefix for suggestion volume
-	// Full local path = /tmp/katib/suggestions/<suggestion-name>-<suggestion-namespace>
-	DefaultSuggestionVolumeLocalPathPrefix = "/tmp/katib/suggestions/"
-
-	// DefaultSuggestionStorageClassName is the default value for suggestion's volume storage class name
-	DefaultSuggestionStorageClassName = "katib-suggestion"
-
-	// DefaultSuggestionVolumeAccessMode is the default value for suggestion's volume access mode
-	DefaultSuggestionVolumeAccessMode = corev1.ReadWriteOnce
-
-	// DefaultSuggestionVolumeStorage is the default value for suggestion's volume storage
-	DefaultSuggestionVolumeStorage = "1Gi"
-
-	// ContainerSuggestionVolumeName is the volume name that mounted on suggestion container
-	ContainerSuggestionVolumeName = "suggestion-volume"
-
-	// DefaultContainerSuggestionVolumeMountPath is the default mount path in suggestion container
-	DefaultContainerSuggestionVolumeMountPath = "/opt/katib/data"
 )
 
 var (

--- a/pkg/util/v1beta1/katibconfig/config.go
+++ b/pkg/util/v1beta1/katibconfig/config.go
@@ -134,6 +134,11 @@ func GetSuggestionConfigData(algorithmName string, client client.Client) (Sugges
 			}
 		}
 
+		// Set default local path if it is empty
+		if pvSpec.PersistentVolumeSource.HostPath != nil && pvSpec.PersistentVolumeSource.HostPath.Path == "" {
+			pvSpec.PersistentVolumeSource.HostPath.Path = consts.DefaultSuggestionVolumeLocalPathPrefix
+		}
+
 		// Set default capacity
 		if len(pvSpec.Capacity) == 0 {
 			pvSpec.Capacity = make(map[corev1.ResourceName]resource.Quantity)

--- a/pkg/util/v1beta1/katibconfig/config.go
+++ b/pkg/util/v1beta1/katibconfig/config.go
@@ -17,10 +17,13 @@ import (
 
 // SuggestionConfig is the JSON suggestion structure in Katib config
 type SuggestionConfig struct {
-	Image              string                      `json:"image"`
-	ImagePullPolicy    corev1.PullPolicy           `json:"imagePullPolicy"`
-	Resource           corev1.ResourceRequirements `json:"resources"`
-	ServiceAccountName string                      `json:"serviceAccountName"`
+	Image                     string                           `json:"image"`
+	ImagePullPolicy           corev1.PullPolicy                `json:"imagePullPolicy"`
+	Resource                  corev1.ResourceRequirements      `json:"resources"`
+	ServiceAccountName        string                           `json:"serviceAccountName"`
+	VolumeMountPath           string                           `json:"volumeMountPath"`
+	PersistentVolumeClaimSpec corev1.PersistentVolumeClaimSpec `json:"persistentVolumeClaimSpec"`
+	PersistentVolumeSpec      corev1.PersistentVolumeSpec      `json:"persistentVolumeSpec"`
 }
 
 // MetricsCollectorConfig is the JSON metrics collector structure in Katib config
@@ -74,6 +77,73 @@ func GetSuggestionConfigData(algorithmName string, client client.Client) (Sugges
 
 	// Set resource requirements for suggestion
 	suggestionConfigData.Resource = setResourceRequirements(suggestionConfigData.Resource)
+
+	// Set default suggestion container volume mount path
+	if suggestionConfigData.VolumeMountPath == "" {
+		suggestionConfigData.VolumeMountPath = consts.DefaultContainerSuggestionVolumeMountPath
+	}
+
+	// Get persistent volume claim spec from config
+	pvcSpec := suggestionConfigData.PersistentVolumeClaimSpec
+
+	// Set default storage class
+	defaultStorageClassName := consts.DefaultSuggestionStorageClassName
+	if pvcSpec.StorageClassName == nil {
+		pvcSpec.StorageClassName = &defaultStorageClassName
+	}
+
+	// Set default access modes
+	if len(pvcSpec.AccessModes) == 0 {
+		pvcSpec.AccessModes = []corev1.PersistentVolumeAccessMode{
+			consts.DefaultSuggestionVolumeAccessMode,
+		}
+	}
+
+	// Set default resources
+	defaultVolumeStorage, _ := resource.ParseQuantity(consts.DefaultSuggestionVolumeStorage)
+	if len(pvcSpec.Resources.Requests) == 0 {
+
+		pvcSpec.Resources.Requests = make(map[corev1.ResourceName]resource.Quantity)
+		pvcSpec.Resources.Requests[corev1.ResourceStorage] = defaultVolumeStorage
+	}
+
+	// Set pvc back for suggestion config
+	suggestionConfigData.PersistentVolumeClaimSpec = pvcSpec
+
+	// Get pv from config only if pvc storage class name = DefaultSuggestionStorageClassName
+	if *pvcSpec.StorageClassName == consts.DefaultSuggestionStorageClassName {
+		pvSpec := suggestionConfigData.PersistentVolumeSpec
+
+		// Set default storage class
+		pvSpec.StorageClassName = defaultStorageClassName
+
+		// Set default access modes
+		if len(pvSpec.AccessModes) == 0 {
+			pvSpec.AccessModes = []corev1.PersistentVolumeAccessMode{
+				consts.DefaultSuggestionVolumeAccessMode,
+			}
+		}
+
+		// Set default pv source.
+		// In composer we add name, algorithm and namespace to host path.
+		if pvSpec.PersistentVolumeSource == (corev1.PersistentVolumeSource{}) {
+			pvSpec.PersistentVolumeSource = corev1.PersistentVolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: consts.DefaultSuggestionVolumeLocalPathPrefix,
+				},
+			}
+		}
+
+		// Set default capacity
+		if len(pvSpec.Capacity) == 0 {
+			pvSpec.Capacity = make(map[corev1.ResourceName]resource.Quantity)
+			pvSpec.Capacity[corev1.ResourceStorage] = defaultVolumeStorage
+		}
+
+		// Set pv back for suggestion config
+		suggestionConfigData.PersistentVolumeSpec = pvSpec
+
+	}
 
 	return suggestionConfigData, nil
 }


### PR DESCRIPTION
I added possibilities to set PVC and PV specification from Katib config.

By default PVC uses `katib-suggestion` storage class name.
If PVC is created with this StorageClass, controller also deploys PV for the suggestion with settings from Katib config.
User can change `HostPath`, but if `HostPath` is `/tmp/katib/suggestions/` we added:
`/tmp/katib/suggestions/<suggestion-name>-<suggestion-algorithm>-<suggestion-namespace>` to the `HostPath`.

/assign @johnugeorge @gaocegege @sperlingxx 