### PR TITLE
Log update object status error

### DIFF
--- a/pkg/controller.v1beta1/experiment/experiment_controller.go
+++ b/pkg/controller.v1beta1/experiment/experiment_controller.go
@@ -249,7 +249,7 @@ func (r *ReconcileExperiment) Reconcile(request reconcile.Request) (reconcile.Re
 		//assuming that only status change
 		err = r.updateStatusHandler(instance)
 		if err != nil {
-			logger.Info("Update experiment instance status failed, reconcile requeued", "err", err)
+			logger.Info("Update experiment instance status failed, reconciler requeued", "err", err)
 			return reconcile.Result{
 				Requeue: true,
 			}, nil

--- a/pkg/controller.v1beta1/experiment/experiment_controller.go
+++ b/pkg/controller.v1beta1/experiment/experiment_controller.go
@@ -249,8 +249,10 @@ func (r *ReconcileExperiment) Reconcile(request reconcile.Request) (reconcile.Re
 		//assuming that only status change
 		err = r.updateStatusHandler(instance)
 		if err != nil {
-			logger.Error(err, "Update experiment instance status error")
-			return reconcile.Result{}, err
+			logger.Info("Update experiment instance status failed, reconcile requeued", "err", err)
+			return reconcile.Result{
+				Requeue: true,
+			}, nil
 		}
 	}
 

--- a/pkg/controller.v1beta1/experiment/experiment_controller_test.go
+++ b/pkg/controller.v1beta1/experiment/experiment_controller_test.go
@@ -268,17 +268,16 @@ func TestReconcile(t *testing.T) {
 	}, timeout).Should(gomega.BeTrue())
 
 	// Manually update experiment status to failed to make experiment completed
-	// Expect that experiment is updated
-	g.Eventually(func() error {
-		experiment = &experimentsv1beta1.Experiment{}
-		c.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: experimentName}, experiment)
-		experiment.MarkExperimentStatusFailed(experimentUtil.ExperimentMaxTrialsReachedReason, "Experiment is failed")
-		return c.Status().Update(context.TODO(), experiment)
-	}, timeout).ShouldNot(gomega.HaveOccurred())
-
 	// Expect that suggestion with ResumePolicy = NeverResume is succeeded
 	// UpdateSuggestionStatus with restartNoCall call
 	g.Eventually(func() bool {
+		// Update experiment
+		experiment = &experimentsv1beta1.Experiment{}
+		c.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: experimentName}, experiment)
+		experiment.MarkExperimentStatusFailed(experimentUtil.ExperimentMaxTrialsReachedReason, "Experiment is failed")
+		c.Status().Update(context.TODO(), experiment)
+
+		// Get Suggestion
 		suggestion := &suggestionsv1beta1.Suggestion{}
 		c.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: experimentName}, suggestion)
 		return suggestion.IsSucceeded()

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller.go
@@ -178,7 +178,7 @@ func (r *ReconcileSuggestion) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	if err := r.updateStatus(instance, oldS); err != nil {
-		logger.Info("Update suggestion instance status failed, reconcile requeued", "err", err)
+		logger.Info("Update suggestion instance status failed, reconciler requeued", "err", err)
 		return reconcile.Result{
 			Requeue: true,
 		}, nil

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller.go
@@ -178,7 +178,10 @@ func (r *ReconcileSuggestion) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	if err := r.updateStatus(instance, oldS); err != nil {
-		return reconcile.Result{}, err
+		logger.Info("Update suggestion instance status failed, reconcile requeued", "err", err)
+		return reconcile.Result{
+			Requeue: true,
+		}, nil
 	}
 	return reconcile.Result{}, nil
 }

--- a/pkg/controller.v1beta1/trial/trial_controller.go
+++ b/pkg/controller.v1beta1/trial/trial_controller.go
@@ -193,7 +193,7 @@ func (r *ReconcileTrial) Reconcile(request reconcile.Request) (reconcile.Result,
 		//assuming that only status change
 		err = r.updateStatusHandler(instance)
 		if err != nil {
-			logger.Info("Update trial instance status failed, reconcile requeued", "err", err)
+			logger.Info("Update trial instance status failed, reconciler requeued", "err", err)
 			return reconcile.Result{
 				Requeue: true,
 			}, nil

--- a/pkg/controller.v1beta1/trial/trial_controller.go
+++ b/pkg/controller.v1beta1/trial/trial_controller.go
@@ -193,8 +193,10 @@ func (r *ReconcileTrial) Reconcile(request reconcile.Request) (reconcile.Result,
 		//assuming that only status change
 		err = r.updateStatusHandler(instance)
 		if err != nil {
-			logger.Error(err, "Update trial instance status error")
-			return reconcile.Result{}, err
+			logger.Info("Update trial instance status failed, reconcile requeued", "err", err)
+			return reconcile.Result{
+				Requeue: true,
+			}, nil
 		}
 	}
 

--- a/pkg/webhook/v1beta1/pod/inject_webhook.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook.go
@@ -161,8 +161,7 @@ func (s *sidecarInjector) Mutate(pod *v1.Pod, namespace string) (*v1.Pod, error)
 			return nil, err
 		}
 	}
-
-	log.Info("Inject metrics collector sidecar container", "Pod", pod.Name, "Trial", trialName)
+	log.Info("Inject metrics collector sidecar container", "Pod Generate Name", mutatedPod.GenerateName, "Trial", trialName)
 	return mutatedPod, nil
 }
 


### PR DESCRIPTION
See comment: https://github.com/kubeflow/katib/pull/1281#issuecomment-666016563.
I changed error to log message to improve controller logging.
If `UpdateStatus` fails, we print the error and requeued reconciler.

As well, I noticed that `pod.Name` is not printed in inject webhook.
That is happening because object name is generated after Mutation unless appropriate controller has not set name explicitly (See comment: https://github.com/kubernetes/kubernetes/issues/46107#issuecomment-537592278.
I changed it to `GenerateName` instead.

/assign @gaocegege @johnugeorge 