### PR TITLE
Custom CRD: Add primary pod labels

### DIFF
--- a/pkg/apis/controller/experiments/v1beta1/experiment_types.go
+++ b/pkg/apis/controller/experiments/v1beta1/experiment_types.go
@@ -209,7 +209,7 @@ type TrialTemplate struct {
 	TrialParameters []TrialParameterSpec `json:"trialParameters,omitempty"`
 
 	// Labels that determines if pod needs to be injected by Katib sidecar container
-	PrimaryPodLabels map[string]string `json:"PrimaryPodLabels,omitempty"`
+	PrimaryPodLabels map[string]string `json:"primaryPodLabels,omitempty"`
 }
 
 // TrialSource represent the source for trial template

--- a/pkg/apis/controller/experiments/v1beta1/experiment_types.go
+++ b/pkg/apis/controller/experiments/v1beta1/experiment_types.go
@@ -207,6 +207,9 @@ type TrialTemplate struct {
 
 	// List of parameters that are used in trial template
 	TrialParameters []TrialParameterSpec `json:"trialParameters,omitempty"`
+
+	// Labels that determines if pod needs to be injected by Katib sidecar container
+	PrimaryPodLabels map[string]string `json:"PrimaryPodLabels,omitempty"`
 }
 
 // TrialSource represent the source for trial template

--- a/pkg/apis/controller/experiments/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/controller/experiments/v1beta1/zz_generated.deepcopy.go
@@ -431,6 +431,13 @@ func (in *TrialTemplate) DeepCopyInto(out *TrialTemplate) {
 		*out = make([]TrialParameterSpec, len(*in))
 		copy(*out, *in)
 	}
+	if in.PrimaryPodLabels != nil {
+		in, out := &in.PrimaryPodLabels, &out.PrimaryPodLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/controller/trials/v1beta1/trial_types.go
+++ b/pkg/apis/controller/trials/v1beta1/trial_types.go
@@ -39,6 +39,9 @@ type TrialSpec struct {
 
 	// Describes how metrics will be collected
 	MetricsCollector common.MetricsCollectorSpec `json:"metricsCollector,omitempty"`
+
+	// Label that determines if pod needs to be injected by Katib sidecar container
+	PrimaryPodLabels map[string]string `json:"primaryPodLabels,omitempty"`
 }
 
 type TrialStatus struct {

--- a/pkg/apis/controller/trials/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/controller/trials/v1beta1/zz_generated.deepcopy.go
@@ -121,6 +121,13 @@ func (in *TrialSpec) DeepCopyInto(out *TrialSpec) {
 		*out = (*in).DeepCopy()
 	}
 	in.MetricsCollector.DeepCopyInto(&out.MetricsCollector)
+	if in.PrimaryPodLabels != nil {
+		in, out := &in.PrimaryPodLabels, &out.PrimaryPodLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/v1beta1/openapi_generated.go
+++ b/pkg/apis/v1beta1/openapi_generated.go
@@ -1102,6 +1102,20 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								},
 							},
 						},
+						"primaryPodLabels": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Labels that determines if pod needs to be injected by Katib sidecar container",
+								Type:        []string{"object"},
+								AdditionalProperties: &spec.SchemaOrBool{
+									Schema: &spec.Schema{
+										SchemaProps: spec.SchemaProps{
+											Type:   []string{"string"},
+											Format: "",
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -1246,12 +1260,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/kubeflow/katib/pkg/apis/controller/suggestions/v1beta1.SuggestionSpec": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "SuggestionSpec defines the desired state of Suggestion",
+					Description: "SuggestionSpec defines the desired state of suggestion.",
 					Properties: map[string]spec.Schema{
 						"algorithmName": {
 							SchemaProps: spec.SchemaProps{
-								Type:   []string{"string"},
-								Format: "",
+								Description: "Name of the algorithm that suggestion is used.",
+								Type:        []string{"string"},
+								Format:      "",
 							},
 						},
 						"requests": {
@@ -1259,6 +1274,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Description: "Number of suggestions requested",
 								Type:        []string{"integer"},
 								Format:      "int32",
+							},
+						},
+						"resumePolicy": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Describes resuming policy which usually take effect after experiment terminated. Default value is LongRunning.",
+								Type:        []string{"string"},
+								Format:      "",
 							},
 						},
 					},
@@ -1548,6 +1570,20 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							SchemaProps: spec.SchemaProps{
 								Description: "Describes how metrics will be collected",
 								Ref:         ref("github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1.MetricsCollectorSpec"),
+							},
+						},
+						"primaryPodLabels": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Label that determines if pod needs to be injected by Katib sidecar container",
+								Type:        []string{"object"},
+								AdditionalProperties: &spec.SchemaOrBool{
+									Schema: &spec.Schema{
+										SchemaProps: spec.SchemaProps{
+											Type:   []string{"string"},
+											Format: "",
+										},
+									},
+								},
 							},
 						},
 					},

--- a/pkg/apis/v1beta1/swagger.json
+++ b/pkg/apis/v1beta1/swagger.json
@@ -88,18 +88,23 @@
       }
     },
     ".v1beta1.SuggestionSpec": {
-      "description": "SuggestionSpec defines the desired state of Suggestion",
+      "description": "SuggestionSpec defines the desired state of suggestion.",
       "required": [
         "algorithmName"
       ],
       "properties": {
         "algorithmName": {
+          "description": "Name of the algorithm that suggestion is used.",
           "type": "string"
         },
         "requests": {
           "description": "Number of suggestions requested",
           "type": "integer",
           "format": "int32"
+        },
+        "resumePolicy": {
+          "description": "Describes resuming policy which usually take effect after experiment terminated. Default value is LongRunning.",
+          "type": "string"
         }
       }
     },
@@ -260,6 +265,13 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/v1beta1.ParameterAssignment"
+          }
+        },
+        "primaryPodLabels": {
+          "description": "Label that determines if pod needs to be injected by Katib sidecar container",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
           }
         },
         "retainRun": {
@@ -872,6 +884,13 @@
         "configMap": {
           "description": "ConfigMap spec represents a reference to ConfigMap",
           "$ref": "#/definitions/v1beta1.ConfigMapSource"
+        },
+        "primaryPodLabels": {
+          "description": "Labels that determines if pod needs to be injected by Katib sidecar container",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "retain": {
           "description": "Retain indicates that trial resources must be not cleanup",

--- a/pkg/controller.v1beta1/experiment/experiment_util.go
+++ b/pkg/controller.v1beta1/experiment/experiment_util.go
@@ -53,6 +53,10 @@ func (r *ReconcileExperiment) createTrialInstance(expInstance *experimentsv1beta
 		trial.Spec.MetricsCollector = *expInstance.Spec.MetricsCollectorSpec
 	}
 
+	if expInstance.Spec.TrialTemplate.TrialParameters != nil {
+		trial.Spec.PrimaryPodLabels = expInstance.Spec.TrialTemplate.PrimaryPodLabels
+	}
+
 	if err := r.Create(context.TODO(), trial); err != nil {
 		logger.Error(err, "Trial create error", "Trial name", trial.Name)
 		return err

--- a/pkg/webhook/v1beta1/pod/inject_webhook_test.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook_test.go
@@ -540,3 +540,54 @@ func TestIsMasterRole(t *testing.T) {
 		}
 	}
 }
+
+func TestIsPrimaryPod(t *testing.T) {
+	testCases := []struct {
+		podLabels        map[string]string
+		primaryPodLabels map[string]string
+		isPrimary        bool
+		testDescription  string
+	}{
+		{
+			podLabels: map[string]string{
+				"test-key-1": "test-value-1",
+				"test-key-2": "test-value-2",
+				"test-key-3": "test-value-3",
+			},
+			primaryPodLabels: map[string]string{
+				"test-key-1": "test-value-1",
+				"test-key-2": "test-value-2",
+			},
+			isPrimary:       true,
+			testDescription: "Pod contains all labels from primary pod labels",
+		},
+		{
+			podLabels: map[string]string{
+				"test-key-1": "test-value-1",
+			},
+			primaryPodLabels: map[string]string{
+				"test-key-1": "test-value-1",
+				"test-key-2": "test-value-2",
+			},
+			isPrimary:       false,
+			testDescription: "Pod doesn't contain primary label",
+		},
+		{
+			podLabels: map[string]string{
+				"test-key-1": "invalid",
+			},
+			primaryPodLabels: map[string]string{
+				"test-key-1": "test-value-1",
+			},
+			isPrimary:       false,
+			testDescription: "Pod contains label with incorrect value",
+		},
+	}
+
+	for _, tc := range testCases {
+		isPrimary := isPrimaryPod(tc.podLabels, tc.primaryPodLabels)
+		if isPrimary != tc.isPrimary {
+			t.Errorf("Case %v. Expected isPrimary %v, got %v", tc.testDescription, tc.isPrimary, isPrimary)
+		}
+	}
+}

--- a/pkg/webhook/v1beta1/pod/utils.go
+++ b/pkg/webhook/v1beta1/pod/utils.go
@@ -55,6 +55,20 @@ func isMatchGVK(owner metav1.OwnerReference, gvk schema.GroupVersionKind) bool {
 	return true
 }
 
+func isPrimaryPod(podLabels, primaryLabels map[string]string) bool {
+
+	for primaryKey, primaryValue := range primaryLabels {
+		if podValue, ok := podLabels[primaryKey]; ok {
+			if podValue != primaryValue {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
 func isMasterRole(pod *v1.Pod, jobKind string) bool {
 	if labels, ok := jobv1beta1.JobRoleMap[jobKind]; ok {
 		if len(labels) == 0 {

--- a/sdk/python/v1beta1/docs/V1beta1SuggestionSpec.md
+++ b/sdk/python/v1beta1/docs/V1beta1SuggestionSpec.md
@@ -3,8 +3,9 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**algorithm_name** | **str** |  | 
+**algorithm_name** | **str** | Name of the algorithm that suggestion is used. | 
 **requests** | **int** | Number of suggestions requested | [optional] 
+**resume_policy** | **str** | Describes resuming policy which usually take effect after experiment terminated. Default value is LongRunning. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/sdk/python/v1beta1/docs/V1beta1TrialSpec.md
+++ b/sdk/python/v1beta1/docs/V1beta1TrialSpec.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 **metrics_collector** | [**V1beta1MetricsCollectorSpec**](V1beta1MetricsCollectorSpec.md) | Describes how metrics will be collected | [optional] 
 **objective** | [**V1beta1ObjectiveSpec**](V1beta1ObjectiveSpec.md) | Describes the objective of the experiment. | [optional] 
 **parameter_assignments** | [**list[V1beta1ParameterAssignment]**](V1beta1ParameterAssignment.md) | Key-value pairs for hyperparameters and assignment values. | 
+**primary_pod_labels** | **dict(str, str)** | Label that determines if pod needs to be injected by Katib sidecar container | [optional] 
 **retain_run** | **bool** | Whether to retain the trial run object after completed. | [optional] 
 **run_spec** | [**V1UnstructuredUnstructured**](V1UnstructuredUnstructured.md) | Raw text for the trial run spec. This can be any generic Kubernetes runtime object. The trial operator should create the resource as written, and let the corresponding resource controller (e.g. tf-operator) handle the rest. | [optional] 
 

--- a/sdk/python/v1beta1/docs/V1beta1TrialTemplate.md
+++ b/sdk/python/v1beta1/docs/V1beta1TrialTemplate.md
@@ -4,6 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **config_map** | [**V1beta1ConfigMapSource**](V1beta1ConfigMapSource.md) | ConfigMap spec represents a reference to ConfigMap | [optional] 
+**primary_pod_labels** | **dict(str, str)** | Labels that determines if pod needs to be injected by Katib sidecar container | [optional] 
 **retain** | **bool** | Retain indicates that trial resources must be not cleanup | [optional] 
 **trial_parameters** | [**list[V1beta1TrialParameterSpec]**](V1beta1TrialParameterSpec.md) | List of parameters that are used in trial template | [optional] 
 **trial_spec** | [**V1UnstructuredUnstructured**](V1UnstructuredUnstructured.md) | TrialSpec represents trial template in unstructured format | [optional] 

--- a/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_suggestion_spec.py
+++ b/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_suggestion_spec.py
@@ -32,29 +32,35 @@ class V1beta1SuggestionSpec(object):
     """
     swagger_types = {
         'algorithm_name': 'str',
-        'requests': 'int'
+        'requests': 'int',
+        'resume_policy': 'str'
     }
 
     attribute_map = {
         'algorithm_name': 'algorithmName',
-        'requests': 'requests'
+        'requests': 'requests',
+        'resume_policy': 'resumePolicy'
     }
 
-    def __init__(self, algorithm_name=None, requests=None):  # noqa: E501
+    def __init__(self, algorithm_name=None, requests=None, resume_policy=None):  # noqa: E501
         """V1beta1SuggestionSpec - a model defined in Swagger"""  # noqa: E501
 
         self._algorithm_name = None
         self._requests = None
+        self._resume_policy = None
         self.discriminator = None
 
         self.algorithm_name = algorithm_name
         if requests is not None:
             self.requests = requests
+        if resume_policy is not None:
+            self.resume_policy = resume_policy
 
     @property
     def algorithm_name(self):
         """Gets the algorithm_name of this V1beta1SuggestionSpec.  # noqa: E501
 
+        Name of the algorithm that suggestion is used.  # noqa: E501
 
         :return: The algorithm_name of this V1beta1SuggestionSpec.  # noqa: E501
         :rtype: str
@@ -65,6 +71,7 @@ class V1beta1SuggestionSpec(object):
     def algorithm_name(self, algorithm_name):
         """Sets the algorithm_name of this V1beta1SuggestionSpec.
 
+        Name of the algorithm that suggestion is used.  # noqa: E501
 
         :param algorithm_name: The algorithm_name of this V1beta1SuggestionSpec.  # noqa: E501
         :type: str
@@ -96,6 +103,29 @@ class V1beta1SuggestionSpec(object):
         """
 
         self._requests = requests
+
+    @property
+    def resume_policy(self):
+        """Gets the resume_policy of this V1beta1SuggestionSpec.  # noqa: E501
+
+        Describes resuming policy which usually take effect after experiment terminated. Default value is LongRunning.  # noqa: E501
+
+        :return: The resume_policy of this V1beta1SuggestionSpec.  # noqa: E501
+        :rtype: str
+        """
+        return self._resume_policy
+
+    @resume_policy.setter
+    def resume_policy(self, resume_policy):
+        """Sets the resume_policy of this V1beta1SuggestionSpec.
+
+        Describes resuming policy which usually take effect after experiment terminated. Default value is LongRunning.  # noqa: E501
+
+        :param resume_policy: The resume_policy of this V1beta1SuggestionSpec.  # noqa: E501
+        :type: str
+        """
+
+        self._resume_policy = resume_policy
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_trial_spec.py
+++ b/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_trial_spec.py
@@ -39,6 +39,7 @@ class V1beta1TrialSpec(object):
         'metrics_collector': 'V1beta1MetricsCollectorSpec',
         'objective': 'V1beta1ObjectiveSpec',
         'parameter_assignments': 'list[V1beta1ParameterAssignment]',
+        'primary_pod_labels': 'dict(str, str)',
         'retain_run': 'bool',
         'run_spec': 'V1UnstructuredUnstructured'
     }
@@ -47,16 +48,18 @@ class V1beta1TrialSpec(object):
         'metrics_collector': 'metricsCollector',
         'objective': 'objective',
         'parameter_assignments': 'parameterAssignments',
+        'primary_pod_labels': 'primaryPodLabels',
         'retain_run': 'retainRun',
         'run_spec': 'runSpec'
     }
 
-    def __init__(self, metrics_collector=None, objective=None, parameter_assignments=None, retain_run=None, run_spec=None):  # noqa: E501
+    def __init__(self, metrics_collector=None, objective=None, parameter_assignments=None, primary_pod_labels=None, retain_run=None, run_spec=None):  # noqa: E501
         """V1beta1TrialSpec - a model defined in Swagger"""  # noqa: E501
 
         self._metrics_collector = None
         self._objective = None
         self._parameter_assignments = None
+        self._primary_pod_labels = None
         self._retain_run = None
         self._run_spec = None
         self.discriminator = None
@@ -66,6 +69,8 @@ class V1beta1TrialSpec(object):
         if objective is not None:
             self.objective = objective
         self.parameter_assignments = parameter_assignments
+        if primary_pod_labels is not None:
+            self.primary_pod_labels = primary_pod_labels
         if retain_run is not None:
             self.retain_run = retain_run
         if run_spec is not None:
@@ -141,6 +146,29 @@ class V1beta1TrialSpec(object):
             raise ValueError("Invalid value for `parameter_assignments`, must not be `None`")  # noqa: E501
 
         self._parameter_assignments = parameter_assignments
+
+    @property
+    def primary_pod_labels(self):
+        """Gets the primary_pod_labels of this V1beta1TrialSpec.  # noqa: E501
+
+        Label that determines if pod needs to be injected by Katib sidecar container  # noqa: E501
+
+        :return: The primary_pod_labels of this V1beta1TrialSpec.  # noqa: E501
+        :rtype: dict(str, str)
+        """
+        return self._primary_pod_labels
+
+    @primary_pod_labels.setter
+    def primary_pod_labels(self, primary_pod_labels):
+        """Sets the primary_pod_labels of this V1beta1TrialSpec.
+
+        Label that determines if pod needs to be injected by Katib sidecar container  # noqa: E501
+
+        :param primary_pod_labels: The primary_pod_labels of this V1beta1TrialSpec.  # noqa: E501
+        :type: dict(str, str)
+        """
+
+        self._primary_pod_labels = primary_pod_labels
 
     @property
     def retain_run(self):

--- a/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_trial_template.py
+++ b/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_trial_template.py
@@ -36,6 +36,7 @@ class V1beta1TrialTemplate(object):
     """
     swagger_types = {
         'config_map': 'V1beta1ConfigMapSource',
+        'primary_pod_labels': 'dict(str, str)',
         'retain': 'bool',
         'trial_parameters': 'list[V1beta1TrialParameterSpec]',
         'trial_spec': 'V1UnstructuredUnstructured'
@@ -43,15 +44,17 @@ class V1beta1TrialTemplate(object):
 
     attribute_map = {
         'config_map': 'configMap',
+        'primary_pod_labels': 'primaryPodLabels',
         'retain': 'retain',
         'trial_parameters': 'trialParameters',
         'trial_spec': 'trialSpec'
     }
 
-    def __init__(self, config_map=None, retain=None, trial_parameters=None, trial_spec=None):  # noqa: E501
+    def __init__(self, config_map=None, primary_pod_labels=None, retain=None, trial_parameters=None, trial_spec=None):  # noqa: E501
         """V1beta1TrialTemplate - a model defined in Swagger"""  # noqa: E501
 
         self._config_map = None
+        self._primary_pod_labels = None
         self._retain = None
         self._trial_parameters = None
         self._trial_spec = None
@@ -59,6 +62,8 @@ class V1beta1TrialTemplate(object):
 
         if config_map is not None:
             self.config_map = config_map
+        if primary_pod_labels is not None:
+            self.primary_pod_labels = primary_pod_labels
         if retain is not None:
             self.retain = retain
         if trial_parameters is not None:
@@ -88,6 +93,29 @@ class V1beta1TrialTemplate(object):
         """
 
         self._config_map = config_map
+
+    @property
+    def primary_pod_labels(self):
+        """Gets the primary_pod_labels of this V1beta1TrialTemplate.  # noqa: E501
+
+        Labels that determines if pod needs to be injected by Katib sidecar container  # noqa: E501
+
+        :return: The primary_pod_labels of this V1beta1TrialTemplate.  # noqa: E501
+        :rtype: dict(str, str)
+        """
+        return self._primary_pod_labels
+
+    @primary_pod_labels.setter
+    def primary_pod_labels(self, primary_pod_labels):
+        """Sets the primary_pod_labels of this V1beta1TrialTemplate.
+
+        Labels that determines if pod needs to be injected by Katib sidecar container  # noqa: E501
+
+        :param primary_pod_labels: The primary_pod_labels of this V1beta1TrialTemplate.  # noqa: E501
+        :type: dict(str, str)
+        """
+
+        self._primary_pod_labels = primary_pod_labels
 
     @property
     def retain(self):


### PR DESCRIPTION
Related: https://github.com/kubeflow/katib/issues/1214.

I named API: `PrimaryPodLabels` instead of `PrimaryPodLabel` because user can set more than 1 label there.
`PrimaryPodLabels` defines labels that mutated Pod must have.
I didn't remove `isMasterRole` to not brake current test examples.
Later we can update all examples with new APIs and remove redundant code.

Also I generated codegens and SDK.

/assign @gaocegege @johnugeorge @sperlingxx 