### PR TITLE
Fix restart check in controller for completed experiments

### DIFF
--- a/pkg/controller.v1beta1/experiment/experiment_controller.go
+++ b/pkg/controller.v1beta1/experiment/experiment_controller.go
@@ -198,7 +198,7 @@ func (r *ReconcileExperiment) Reconcile(request reconcile.Request) (reconcile.Re
 				return reconcile.Result{}, err
 			}
 		}
-		// Check if max trials is reconfigured
+		// Check if experiment is restartable and max trials is reconfigured
 		// That means experiment is restarting
 		if (util.IsCompletedExperimentRestartable(instance) &&
 			instance.Spec.MaxTrialCount != nil &&

--- a/pkg/controller.v1beta1/experiment/experiment_controller.go
+++ b/pkg/controller.v1beta1/experiment/experiment_controller.go
@@ -200,7 +200,8 @@ func (r *ReconcileExperiment) Reconcile(request reconcile.Request) (reconcile.Re
 		}
 		// Check if max trials is reconfigured
 		// That means experiment is restarting
-		if (instance.Spec.MaxTrialCount != nil &&
+		if (util.IsCompletedExperimentRestartable(instance) &&
+			instance.Spec.MaxTrialCount != nil &&
 			*instance.Spec.MaxTrialCount > instance.Status.Trials) ||
 			(instance.Spec.MaxTrialCount == nil && instance.Status.Trials != 0) {
 			logger.Info("Experiment is restarting",


### PR DESCRIPTION
We should check that Experiment is restartable in controller as well as in validation webhook.
For example, when Experiment is completed because optimal Trial was found, restart Experiment should not be triggered.

/assign @gaocegege @sperlingxx @johnugeorge 
