### PR TITLE
Custom CRD: Add primary container name

### DIFF
--- a/pkg/apis/controller/experiments/v1beta1/experiment_types.go
+++ b/pkg/apis/controller/experiments/v1beta1/experiment_types.go
@@ -210,6 +210,8 @@ type TrialTemplate struct {
 
 	// Labels that determines if pod needs to be injected by Katib sidecar container
 	PrimaryPodLabels map[string]string `json:"primaryPodLabels,omitempty"`
+	// Name of training container where actual model training is running
+	PrimaryContainerName string `json:"primaryContainerName,omitempty"`
 }
 
 // TrialSource represent the source for trial template

--- a/pkg/apis/controller/experiments/v1beta1/experiment_types.go
+++ b/pkg/apis/controller/experiments/v1beta1/experiment_types.go
@@ -210,6 +210,7 @@ type TrialTemplate struct {
 
 	// Labels that determines if pod needs to be injected by Katib sidecar container
 	PrimaryPodLabels map[string]string `json:"primaryPodLabels,omitempty"`
+
 	// Name of training container where actual model training is running
 	PrimaryContainerName string `json:"primaryContainerName,omitempty"`
 }

--- a/pkg/apis/controller/trials/v1beta1/trial_types.go
+++ b/pkg/apis/controller/trials/v1beta1/trial_types.go
@@ -40,8 +40,13 @@ type TrialSpec struct {
 	// Describes how metrics will be collected
 	MetricsCollector common.MetricsCollectorSpec `json:"metricsCollector,omitempty"`
 
+<<<<<<< HEAD
 	// Label that determines if pod needs to be injected by Katib sidecar container
 	PrimaryPodLabels map[string]string `json:"primaryPodLabels,omitempty"`
+=======
+	// Name of training container where actual model training is running
+	PrimaryContainerName string `json:"primaryContainerName,omitempty"`
+>>>>>>> Add primary container name
 }
 
 type TrialStatus struct {

--- a/pkg/apis/controller/trials/v1beta1/trial_types.go
+++ b/pkg/apis/controller/trials/v1beta1/trial_types.go
@@ -42,6 +42,7 @@ type TrialSpec struct {
 
 	// Label that determines if pod needs to be injected by Katib sidecar container
 	PrimaryPodLabels map[string]string `json:"primaryPodLabels,omitempty"`
+
 	// Name of training container where actual model training is running
 	PrimaryContainerName string `json:"primaryContainerName,omitempty"`
 }

--- a/pkg/apis/controller/trials/v1beta1/trial_types.go
+++ b/pkg/apis/controller/trials/v1beta1/trial_types.go
@@ -40,13 +40,10 @@ type TrialSpec struct {
 	// Describes how metrics will be collected
 	MetricsCollector common.MetricsCollectorSpec `json:"metricsCollector,omitempty"`
 
-<<<<<<< HEAD
 	// Label that determines if pod needs to be injected by Katib sidecar container
 	PrimaryPodLabels map[string]string `json:"primaryPodLabels,omitempty"`
-=======
 	// Name of training container where actual model training is running
 	PrimaryContainerName string `json:"primaryContainerName,omitempty"`
->>>>>>> Add primary container name
 }
 
 type TrialStatus struct {

--- a/pkg/apis/v1beta1/openapi_generated.go
+++ b/pkg/apis/v1beta1/openapi_generated.go
@@ -1102,6 +1102,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								},
 							},
 						},
+<<<<<<< HEAD
 						"primaryPodLabels": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Labels that determines if pod needs to be injected by Katib sidecar container",
@@ -1114,6 +1115,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 										},
 									},
 								},
+=======
+						"primaryContainerName": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Name of training container where actual model training is running",
+								Type:        []string{"string"},
+								Format:      "",
+>>>>>>> Add primary container name
 							},
 						},
 					},
@@ -1572,6 +1580,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Ref:         ref("github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1.MetricsCollectorSpec"),
 							},
 						},
+<<<<<<< HEAD
 						"primaryPodLabels": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Label that determines if pod needs to be injected by Katib sidecar container",
@@ -1584,6 +1593,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 										},
 									},
 								},
+=======
+						"primaryContainerName": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Name of training container where actual model training is running",
+								Type:        []string{"string"},
+								Format:      "",
+>>>>>>> Add primary container name
 							},
 						},
 					},

--- a/pkg/apis/v1beta1/openapi_generated.go
+++ b/pkg/apis/v1beta1/openapi_generated.go
@@ -1102,26 +1102,11 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								},
 							},
 						},
-<<<<<<< HEAD
-						"primaryPodLabels": {
-							SchemaProps: spec.SchemaProps{
-								Description: "Labels that determines if pod needs to be injected by Katib sidecar container",
-								Type:        []string{"object"},
-								AdditionalProperties: &spec.SchemaOrBool{
-									Schema: &spec.Schema{
-										SchemaProps: spec.SchemaProps{
-											Type:   []string{"string"},
-											Format: "",
-										},
-									},
-								},
-=======
 						"primaryContainerName": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Name of training container where actual model training is running",
 								Type:        []string{"string"},
 								Format:      "",
->>>>>>> Add primary container name
 							},
 						},
 					},

--- a/pkg/apis/v1beta1/openapi_generated.go
+++ b/pkg/apis/v1beta1/openapi_generated.go
@@ -1102,6 +1102,20 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								},
 							},
 						},
+						"primaryPodLabels": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Labels that determines if pod needs to be injected by Katib sidecar container",
+								Type:        []string{"object"},
+								AdditionalProperties: &spec.SchemaOrBool{
+									Schema: &spec.Schema{
+										SchemaProps: spec.SchemaProps{
+											Type:   []string{"string"},
+											Format: "",
+										},
+									},
+								},
+							},
+						},
 						"primaryContainerName": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Name of training container where actual model training is running",
@@ -1565,7 +1579,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Ref:         ref("github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1.MetricsCollectorSpec"),
 							},
 						},
-<<<<<<< HEAD
 						"primaryPodLabels": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Label that determines if pod needs to be injected by Katib sidecar container",
@@ -1578,13 +1591,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 										},
 									},
 								},
-=======
+							},
+						},
 						"primaryContainerName": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Name of training container where actual model training is running",
 								Type:        []string{"string"},
 								Format:      "",
->>>>>>> Add primary container name
 							},
 						},
 					},

--- a/pkg/apis/v1beta1/swagger.json
+++ b/pkg/apis/v1beta1/swagger.json
@@ -267,12 +267,18 @@
             "$ref": "#/definitions/v1beta1.ParameterAssignment"
           }
         },
+<<<<<<< HEAD
         "primaryPodLabels": {
           "description": "Label that determines if pod needs to be injected by Katib sidecar container",
           "type": "object",
           "additionalProperties": {
             "type": "string"
           }
+=======
+        "primaryContainerName": {
+          "description": "Name of training container where actual model training is running",
+          "type": "string"
+>>>>>>> Add primary container name
         },
         "retainRun": {
           "description": "Whether to retain the trial run object after completed.",
@@ -885,12 +891,18 @@
           "description": "ConfigMap spec represents a reference to ConfigMap",
           "$ref": "#/definitions/v1beta1.ConfigMapSource"
         },
+<<<<<<< HEAD
         "primaryPodLabels": {
           "description": "Labels that determines if pod needs to be injected by Katib sidecar container",
           "type": "object",
           "additionalProperties": {
             "type": "string"
           }
+=======
+        "primaryContainerName": {
+          "description": "Name of training container where actual model training is running",
+          "type": "string"
+>>>>>>> Add primary container name
         },
         "retain": {
           "description": "Retain indicates that trial resources must be not cleanup",

--- a/pkg/apis/v1beta1/swagger.json
+++ b/pkg/apis/v1beta1/swagger.json
@@ -31,7 +31,10 @@
     },
     ".v1beta1.SuggestionCondition": {
       "description": "SuggestionCondition describes the state of the Suggestion at a certain point.",
-      "required": ["type", "status"],
+      "required": [
+        "type",
+        "status"
+      ],
       "properties": {
         "lastTransitionTime": {
           "description": "Last time the condition transitioned from one status to another.",
@@ -61,7 +64,9 @@
     },
     ".v1beta1.SuggestionList": {
       "description": "SuggestionList contains a list of Suggestion",
-      "required": ["items"],
+      "required": [
+        "items"
+      ],
       "properties": {
         "apiVersion": {
           "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -84,7 +89,9 @@
     },
     ".v1beta1.SuggestionSpec": {
       "description": "SuggestionSpec defines the desired state of suggestion.",
-      "required": ["algorithmName"],
+      "required": [
+        "algorithmName"
+      ],
       "properties": {
         "algorithmName": {
           "description": "Name of the algorithm that suggestion is used.",
@@ -184,7 +191,10 @@
     },
     ".v1beta1.TrialCondition": {
       "description": "TrialCondition describes the state of the trial at a certain point.",
-      "required": ["type", "status"],
+      "required": [
+        "type",
+        "status"
+      ],
       "properties": {
         "lastTransitionTime": {
           "description": "Last time the condition transitioned from one status to another.",
@@ -214,7 +224,9 @@
     },
     ".v1beta1.TrialList": {
       "description": "TrialList contains a list of Trials",
-      "required": ["items"],
+      "required": [
+        "items"
+      ],
       "properties": {
         "apiVersion": {
           "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -236,7 +248,9 @@
       }
     },
     ".v1beta1.TrialSpec": {
-      "required": ["parameterAssignments"],
+      "required": [
+        "parameterAssignments"
+      ],
       "properties": {
         "metricsCollector": {
           "description": "Describes how metrics will be collected",
@@ -256,6 +270,13 @@
         "primaryContainerName": {
           "description": "Name of training container where actual model training is running",
           "type": "string"
+        },
+        "primaryPodLabels": {
+          "description": "Label that determines if pod needs to be injected by Katib sidecar container",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "retainRun": {
           "description": "Whether to retain the trial run object after completed.",
@@ -322,7 +343,9 @@
       }
     },
     "v1beta1.CollectorSpec": {
-      "required": ["kind"],
+      "required": [
+        "kind"
+      ],
       "properties": {
         "customCollector": {
           "description": "When kind is \"customCollector\", this field will be used",
@@ -361,7 +384,9 @@
       }
     },
     "v1beta1.EarlyStoppingSpec": {
-      "required": ["earlyStoppingSettings"],
+      "required": [
+        "earlyStoppingSettings"
+      ],
       "properties": {
         "earlyStoppingAlgorithmName": {
           "type": "string"
@@ -398,7 +423,10 @@
     },
     "v1beta1.ExperimentCondition": {
       "description": "ExperimentCondition describes the state of the experiment at a certain point.",
-      "required": ["type", "status"],
+      "required": [
+        "type",
+        "status"
+      ],
       "properties": {
         "lastTransitionTime": {
           "description": "Last time the condition transitioned from one status to another.",
@@ -428,7 +456,9 @@
     },
     "v1beta1.ExperimentList": {
       "description": "ExperimentList contains a list of Experiments",
-      "required": ["items"],
+      "required": [
+        "items"
+      ],
       "properties": {
         "apiVersion": {
           "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -732,7 +762,9 @@
       }
     },
     "v1beta1.Observation": {
-      "required": ["metrics"],
+      "required": [
+        "metrics"
+      ],
       "properties": {
         "metrics": {
           "description": "Key-value pairs for metric names and values",
@@ -759,7 +791,10 @@
     },
     "v1beta1.OptimalTrial": {
       "description": "OptimalTrial is the metrics and assignments of the best trial.",
-      "required": ["bestTrialName", "parameterAssignments"],
+      "required": [
+        "bestTrialName",
+        "parameterAssignments"
+      ],
       "properties": {
         "bestTrialName": {
           "description": "BestTrialName is the name of the best trial.",
@@ -857,6 +892,13 @@
         "primaryContainerName": {
           "description": "Name of training container where actual model training is running",
           "type": "string"
+        },
+        "primaryPodLabels": {
+          "description": "Labels that determines if pod needs to be injected by Katib sidecar container",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "retain": {
           "description": "Retain indicates that trial resources must be not cleanup",

--- a/pkg/apis/v1beta1/swagger.json
+++ b/pkg/apis/v1beta1/swagger.json
@@ -31,10 +31,7 @@
     },
     ".v1beta1.SuggestionCondition": {
       "description": "SuggestionCondition describes the state of the Suggestion at a certain point.",
-      "required": [
-        "type",
-        "status"
-      ],
+      "required": ["type", "status"],
       "properties": {
         "lastTransitionTime": {
           "description": "Last time the condition transitioned from one status to another.",
@@ -64,9 +61,7 @@
     },
     ".v1beta1.SuggestionList": {
       "description": "SuggestionList contains a list of Suggestion",
-      "required": [
-        "items"
-      ],
+      "required": ["items"],
       "properties": {
         "apiVersion": {
           "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -89,9 +84,7 @@
     },
     ".v1beta1.SuggestionSpec": {
       "description": "SuggestionSpec defines the desired state of suggestion.",
-      "required": [
-        "algorithmName"
-      ],
+      "required": ["algorithmName"],
       "properties": {
         "algorithmName": {
           "description": "Name of the algorithm that suggestion is used.",
@@ -191,10 +184,7 @@
     },
     ".v1beta1.TrialCondition": {
       "description": "TrialCondition describes the state of the trial at a certain point.",
-      "required": [
-        "type",
-        "status"
-      ],
+      "required": ["type", "status"],
       "properties": {
         "lastTransitionTime": {
           "description": "Last time the condition transitioned from one status to another.",
@@ -224,9 +214,7 @@
     },
     ".v1beta1.TrialList": {
       "description": "TrialList contains a list of Trials",
-      "required": [
-        "items"
-      ],
+      "required": ["items"],
       "properties": {
         "apiVersion": {
           "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -248,9 +236,7 @@
       }
     },
     ".v1beta1.TrialSpec": {
-      "required": [
-        "parameterAssignments"
-      ],
+      "required": ["parameterAssignments"],
       "properties": {
         "metricsCollector": {
           "description": "Describes how metrics will be collected",
@@ -267,18 +253,9 @@
             "$ref": "#/definitions/v1beta1.ParameterAssignment"
           }
         },
-<<<<<<< HEAD
-        "primaryPodLabels": {
-          "description": "Label that determines if pod needs to be injected by Katib sidecar container",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-=======
         "primaryContainerName": {
           "description": "Name of training container where actual model training is running",
           "type": "string"
->>>>>>> Add primary container name
         },
         "retainRun": {
           "description": "Whether to retain the trial run object after completed.",
@@ -345,9 +322,7 @@
       }
     },
     "v1beta1.CollectorSpec": {
-      "required": [
-        "kind"
-      ],
+      "required": ["kind"],
       "properties": {
         "customCollector": {
           "description": "When kind is \"customCollector\", this field will be used",
@@ -386,9 +361,7 @@
       }
     },
     "v1beta1.EarlyStoppingSpec": {
-      "required": [
-        "earlyStoppingSettings"
-      ],
+      "required": ["earlyStoppingSettings"],
       "properties": {
         "earlyStoppingAlgorithmName": {
           "type": "string"
@@ -425,10 +398,7 @@
     },
     "v1beta1.ExperimentCondition": {
       "description": "ExperimentCondition describes the state of the experiment at a certain point.",
-      "required": [
-        "type",
-        "status"
-      ],
+      "required": ["type", "status"],
       "properties": {
         "lastTransitionTime": {
           "description": "Last time the condition transitioned from one status to another.",
@@ -458,9 +428,7 @@
     },
     "v1beta1.ExperimentList": {
       "description": "ExperimentList contains a list of Experiments",
-      "required": [
-        "items"
-      ],
+      "required": ["items"],
       "properties": {
         "apiVersion": {
           "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -764,9 +732,7 @@
       }
     },
     "v1beta1.Observation": {
-      "required": [
-        "metrics"
-      ],
+      "required": ["metrics"],
       "properties": {
         "metrics": {
           "description": "Key-value pairs for metric names and values",
@@ -793,10 +759,7 @@
     },
     "v1beta1.OptimalTrial": {
       "description": "OptimalTrial is the metrics and assignments of the best trial.",
-      "required": [
-        "bestTrialName",
-        "parameterAssignments"
-      ],
+      "required": ["bestTrialName", "parameterAssignments"],
       "properties": {
         "bestTrialName": {
           "description": "BestTrialName is the name of the best trial.",
@@ -891,18 +854,9 @@
           "description": "ConfigMap spec represents a reference to ConfigMap",
           "$ref": "#/definitions/v1beta1.ConfigMapSource"
         },
-<<<<<<< HEAD
-        "primaryPodLabels": {
-          "description": "Labels that determines if pod needs to be injected by Katib sidecar container",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-=======
         "primaryContainerName": {
           "description": "Name of training container where actual model training is running",
           "type": "string"
->>>>>>> Add primary container name
         },
         "retain": {
           "description": "Retain indicates that trial resources must be not cleanup",

--- a/pkg/controller.v1beta1/experiment/experiment_util.go
+++ b/pkg/controller.v1beta1/experiment/experiment_util.go
@@ -53,8 +53,13 @@ func (r *ReconcileExperiment) createTrialInstance(expInstance *experimentsv1beta
 		trial.Spec.MetricsCollector = *expInstance.Spec.MetricsCollectorSpec
 	}
 
+<<<<<<< HEAD
 	if expInstance.Spec.TrialTemplate.TrialParameters != nil {
 		trial.Spec.PrimaryPodLabels = expInstance.Spec.TrialTemplate.PrimaryPodLabels
+=======
+	if expInstance.Spec.TrialTemplate.PrimaryContainerName != "" {
+		trial.Spec.PrimaryContainerName = expInstance.Spec.TrialTemplate.PrimaryContainerName
+>>>>>>> Add primary container name
 	}
 
 	if err := r.Create(context.TODO(), trial); err != nil {

--- a/pkg/controller.v1beta1/experiment/experiment_util.go
+++ b/pkg/controller.v1beta1/experiment/experiment_util.go
@@ -53,13 +53,11 @@ func (r *ReconcileExperiment) createTrialInstance(expInstance *experimentsv1beta
 		trial.Spec.MetricsCollector = *expInstance.Spec.MetricsCollectorSpec
 	}
 
-<<<<<<< HEAD
-	if expInstance.Spec.TrialTemplate.TrialParameters != nil {
+	if expInstance.Spec.TrialTemplate.PrimaryPodLabels != nil {
 		trial.Spec.PrimaryPodLabels = expInstance.Spec.TrialTemplate.PrimaryPodLabels
-=======
+	}
 	if expInstance.Spec.TrialTemplate.PrimaryContainerName != "" {
 		trial.Spec.PrimaryContainerName = expInstance.Spec.TrialTemplate.PrimaryContainerName
->>>>>>> Add primary container name
 	}
 
 	if err := r.Create(context.TODO(), trial); err != nil {

--- a/pkg/webhook/v1beta1/pod/inject_webhook.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook.go
@@ -174,25 +174,17 @@ func (s *sidecarInjector) Mutate(pod *v1.Pod, namespace string) (*v1.Pod, error)
 		}
 	}
 	if needWrapWorkerContainer(trial.Spec.MetricsCollector) {
-<<<<<<< HEAD
-		if err = wrapWorkerContainer(mutatedPod, namespace, jobKind, mountPath, pathKind, trial.Spec.MetricsCollector); err != nil {
-			return nil, err
-		}
-	}
-	log.Info("Inject metrics collector sidecar container", "Pod Generate Name", mutatedPod.GenerateName, "Trial", jobName)
-=======
-		if err = wrapWorkerContainer(mutatedPod, namespace, kind, mountPath, pathKind, trial); err != nil {
+		if err = wrapWorkerContainer(mutatedPod, namespace, jobKind, mountPath, pathKind, trial); err != nil {
 			return nil, err
 		}
 	}
 
 	// For Job kind mutated pod has only generate name
 	if mutatedPod.Name != "" {
-		log.Info("Inject metrics collector sidecar container", "Pod Name", mutatedPod.Name, "Trial", trialName)
+		log.Info("Inject metrics collector sidecar container", "Pod Name", mutatedPod.Name, "Trial", jobName)
 	} else {
-		log.Info("Inject metrics collector sidecar container", "Pod Generate Name", mutatedPod.GenerateName, "Trial", trialName)
+		log.Info("Inject metrics collector sidecar container", "Pod Generate Name", mutatedPod.GenerateName, "Trial", jobName)
 	}
->>>>>>> Add primary container name
 	return mutatedPod, nil
 }
 
@@ -232,7 +224,6 @@ func (s *sidecarInjector) getMetricsCollectorContainer(trial *trialsv1beta1.Tria
 	return &injectContainer, nil
 }
 
-<<<<<<< HEAD
 func (s *sidecarInjector) getKatibJob(object *unstructured.Unstructured, namespace string) (string, string, error) {
 	owners := object.GetOwnerReferences()
 	// jobKind and jobName points to the object kind and name that Trial is created
@@ -244,65 +235,6 @@ func (s *sidecarInjector) getKatibJob(object *unstructured.Unstructured, namespa
 		if owner.Kind == TrialKind && owner.APIVersion == TrialAPIVersion {
 			jobKind = object.GetKind()
 			jobName = object.GetName()
-=======
-func getMetricsCollectorArgs(trialName, metricName string, mc common.MetricsCollectorSpec) []string {
-	args := []string{"-t", trialName, "-m", metricName, "-s", katibmanagerv1beta1.GetDBManagerAddr()}
-	if mountPath, _ := getMountPath(mc); mountPath != "" {
-		args = append(args, "-path", mountPath)
-	}
-	if mc.Source != nil && mc.Source.Filter != nil && len(mc.Source.Filter.MetricsFormat) > 0 {
-		args = append(args, "-f", strings.Join(mc.Source.Filter.MetricsFormat, ";"))
-	}
-	return args
-}
-
-func getMountPath(mc common.MetricsCollectorSpec) (string, common.FileSystemKind) {
-	if mc.Collector.Kind == common.StdOutCollector {
-		return common.DefaultFilePath, common.FileKind
-	} else if mc.Collector.Kind == common.FileCollector {
-		return mc.Source.FileSystemPath.Path, common.FileKind
-	} else if mc.Collector.Kind == common.TfEventCollector {
-		return mc.Source.FileSystemPath.Path, common.DirectoryKind
-	} else if mc.Collector.Kind == common.CustomCollector {
-		if mc.Source == nil || mc.Source.FileSystemPath == nil {
-			return "", common.InvalidKind
-		}
-		return mc.Source.FileSystemPath.Path, mc.Source.FileSystemPath.Kind
-	} else {
-		return "", common.InvalidKind
-	}
-}
-
-func needWrapWorkerContainer(mc common.MetricsCollectorSpec) bool {
-	mcKind := mc.Collector.Kind
-	for _, kind := range NeedWrapWorkerMetricsCollecterList {
-		if mcKind == kind {
-			return true
-		}
-	}
-	return false
-}
-
-func wrapWorkerContainer(
-	pod *v1.Pod, namespace, jobKind, metricsFile string,
-	pathKind common.FileSystemKind,
-	trial *trialsv1beta1.Trial) error {
-	index := -1
-	for i, c := range pod.Spec.Containers {
-		if trial.Spec.PrimaryContainerName != "" && c.Name == trial.Spec.PrimaryContainerName {
-			index = i
-			break
-			// TODO (andreyvelich): This can be deleted after switch to custom CRD
-		} else if trial.Spec.PrimaryContainerName == "" {
-			jobProvider, err := jobv1beta1.New(jobKind)
-			if err != nil {
-				return err
-			}
-			if jobProvider.IsTrainingContainer(i, c) {
-				index = i
-				break
-			}
->>>>>>> Add primary container name
 		}
 	}
 	// If Trial is not found in object owners search for nested owners
@@ -316,7 +248,6 @@ func wrapWorkerContainer(
 			if err != nil {
 				return "", "", err
 			}
-<<<<<<< HEAD
 			gvk := schema.GroupVersionKind{
 				Group:   gv.Group,
 				Version: gv.Version,
@@ -327,58 +258,6 @@ func wrapWorkerContainer(
 			// Get nested object from cluster.
 			// Nested object namespace must be equal to object namespace
 			err = s.client.Get(context.TODO(), apitypes.NamespacedName{Name: owners[i].Name, Namespace: namespace}, nestedJob)
-=======
-		}
-		mc := trial.Spec.MetricsCollector
-		if mc.Collector.Kind == common.StdOutCollector {
-			redirectStr := fmt.Sprintf("1>%s 2>&1", metricsFile)
-			args = append(args, redirectStr)
-		}
-		args = append(args, "&&", getMarkCompletedCommand(metricsFile, pathKind))
-		argsStr := strings.Join(args, " ")
-		c := &pod.Spec.Containers[index]
-		c.Command = command
-		c.Args = []string{argsStr}
-	} else {
-		return fmt.Errorf("Unable to find primary container %v in mutated pod containers %v",
-			trial.Spec.PrimaryContainerName, pod.Spec.Containers)
-	}
-	return nil
-}
-
-func getMarkCompletedCommand(mountPath string, pathKind common.FileSystemKind) string {
-	dir := mountPath
-	if pathKind == common.FileKind {
-		dir = filepath.Dir(mountPath)
-	}
-	// $$ is process id in shell
-	pidFile := filepath.Join(dir, "$$$$.pid")
-	return fmt.Sprintf("echo %s > %s", mccommon.TrainingCompleted, pidFile)
-}
-
-func mutateVolume(pod *v1.Pod, jobKind, mountPath, sidecarContainerName string, pathKind common.FileSystemKind) error {
-	metricsVol := v1.Volume{
-		Name: common.MetricsVolume,
-		VolumeSource: v1.VolumeSource{
-			EmptyDir: &v1.EmptyDirVolumeSource{},
-		},
-	}
-	dir := mountPath
-	if pathKind == common.FileKind {
-		dir = filepath.Dir(mountPath)
-	}
-	vm := v1.VolumeMount{
-		Name:      metricsVol.Name,
-		MountPath: dir,
-	}
-	indexList := []int{}
-	for i, c := range pod.Spec.Containers {
-		shouldMount := false
-		if c.Name == sidecarContainerName {
-			shouldMount = true
-		} else {
-			jobProvider, err := jobv1beta1.New(jobKind)
->>>>>>> Add primary container name
 			if err != nil {
 				return "", "", err
 			}

--- a/pkg/webhook/v1beta1/pod/inject_webhook.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook.go
@@ -174,11 +174,25 @@ func (s *sidecarInjector) Mutate(pod *v1.Pod, namespace string) (*v1.Pod, error)
 		}
 	}
 	if needWrapWorkerContainer(trial.Spec.MetricsCollector) {
+<<<<<<< HEAD
 		if err = wrapWorkerContainer(mutatedPod, namespace, jobKind, mountPath, pathKind, trial.Spec.MetricsCollector); err != nil {
 			return nil, err
 		}
 	}
 	log.Info("Inject metrics collector sidecar container", "Pod Generate Name", mutatedPod.GenerateName, "Trial", jobName)
+=======
+		if err = wrapWorkerContainer(mutatedPod, namespace, kind, mountPath, pathKind, trial); err != nil {
+			return nil, err
+		}
+	}
+
+	// For Job kind mutated pod has only generate name
+	if mutatedPod.Name != "" {
+		log.Info("Inject metrics collector sidecar container", "Pod Name", mutatedPod.Name, "Trial", trialName)
+	} else {
+		log.Info("Inject metrics collector sidecar container", "Pod Generate Name", mutatedPod.GenerateName, "Trial", trialName)
+	}
+>>>>>>> Add primary container name
 	return mutatedPod, nil
 }
 
@@ -218,6 +232,7 @@ func (s *sidecarInjector) getMetricsCollectorContainer(trial *trialsv1beta1.Tria
 	return &injectContainer, nil
 }
 
+<<<<<<< HEAD
 func (s *sidecarInjector) getKatibJob(object *unstructured.Unstructured, namespace string) (string, string, error) {
 	owners := object.GetOwnerReferences()
 	// jobKind and jobName points to the object kind and name that Trial is created
@@ -229,6 +244,65 @@ func (s *sidecarInjector) getKatibJob(object *unstructured.Unstructured, namespa
 		if owner.Kind == TrialKind && owner.APIVersion == TrialAPIVersion {
 			jobKind = object.GetKind()
 			jobName = object.GetName()
+=======
+func getMetricsCollectorArgs(trialName, metricName string, mc common.MetricsCollectorSpec) []string {
+	args := []string{"-t", trialName, "-m", metricName, "-s", katibmanagerv1beta1.GetDBManagerAddr()}
+	if mountPath, _ := getMountPath(mc); mountPath != "" {
+		args = append(args, "-path", mountPath)
+	}
+	if mc.Source != nil && mc.Source.Filter != nil && len(mc.Source.Filter.MetricsFormat) > 0 {
+		args = append(args, "-f", strings.Join(mc.Source.Filter.MetricsFormat, ";"))
+	}
+	return args
+}
+
+func getMountPath(mc common.MetricsCollectorSpec) (string, common.FileSystemKind) {
+	if mc.Collector.Kind == common.StdOutCollector {
+		return common.DefaultFilePath, common.FileKind
+	} else if mc.Collector.Kind == common.FileCollector {
+		return mc.Source.FileSystemPath.Path, common.FileKind
+	} else if mc.Collector.Kind == common.TfEventCollector {
+		return mc.Source.FileSystemPath.Path, common.DirectoryKind
+	} else if mc.Collector.Kind == common.CustomCollector {
+		if mc.Source == nil || mc.Source.FileSystemPath == nil {
+			return "", common.InvalidKind
+		}
+		return mc.Source.FileSystemPath.Path, mc.Source.FileSystemPath.Kind
+	} else {
+		return "", common.InvalidKind
+	}
+}
+
+func needWrapWorkerContainer(mc common.MetricsCollectorSpec) bool {
+	mcKind := mc.Collector.Kind
+	for _, kind := range NeedWrapWorkerMetricsCollecterList {
+		if mcKind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func wrapWorkerContainer(
+	pod *v1.Pod, namespace, jobKind, metricsFile string,
+	pathKind common.FileSystemKind,
+	trial *trialsv1beta1.Trial) error {
+	index := -1
+	for i, c := range pod.Spec.Containers {
+		if trial.Spec.PrimaryContainerName != "" && c.Name == trial.Spec.PrimaryContainerName {
+			index = i
+			break
+			// TODO (andreyvelich): This can be deleted after switch to custom CRD
+		} else if trial.Spec.PrimaryContainerName == "" {
+			jobProvider, err := jobv1beta1.New(jobKind)
+			if err != nil {
+				return err
+			}
+			if jobProvider.IsTrainingContainer(i, c) {
+				index = i
+				break
+			}
+>>>>>>> Add primary container name
 		}
 	}
 	// If Trial is not found in object owners search for nested owners
@@ -242,6 +316,7 @@ func (s *sidecarInjector) getKatibJob(object *unstructured.Unstructured, namespa
 			if err != nil {
 				return "", "", err
 			}
+<<<<<<< HEAD
 			gvk := schema.GroupVersionKind{
 				Group:   gv.Group,
 				Version: gv.Version,
@@ -252,6 +327,58 @@ func (s *sidecarInjector) getKatibJob(object *unstructured.Unstructured, namespa
 			// Get nested object from cluster.
 			// Nested object namespace must be equal to object namespace
 			err = s.client.Get(context.TODO(), apitypes.NamespacedName{Name: owners[i].Name, Namespace: namespace}, nestedJob)
+=======
+		}
+		mc := trial.Spec.MetricsCollector
+		if mc.Collector.Kind == common.StdOutCollector {
+			redirectStr := fmt.Sprintf("1>%s 2>&1", metricsFile)
+			args = append(args, redirectStr)
+		}
+		args = append(args, "&&", getMarkCompletedCommand(metricsFile, pathKind))
+		argsStr := strings.Join(args, " ")
+		c := &pod.Spec.Containers[index]
+		c.Command = command
+		c.Args = []string{argsStr}
+	} else {
+		return fmt.Errorf("Unable to find primary container %v in mutated pod containers %v",
+			trial.Spec.PrimaryContainerName, pod.Spec.Containers)
+	}
+	return nil
+}
+
+func getMarkCompletedCommand(mountPath string, pathKind common.FileSystemKind) string {
+	dir := mountPath
+	if pathKind == common.FileKind {
+		dir = filepath.Dir(mountPath)
+	}
+	// $$ is process id in shell
+	pidFile := filepath.Join(dir, "$$$$.pid")
+	return fmt.Sprintf("echo %s > %s", mccommon.TrainingCompleted, pidFile)
+}
+
+func mutateVolume(pod *v1.Pod, jobKind, mountPath, sidecarContainerName string, pathKind common.FileSystemKind) error {
+	metricsVol := v1.Volume{
+		Name: common.MetricsVolume,
+		VolumeSource: v1.VolumeSource{
+			EmptyDir: &v1.EmptyDirVolumeSource{},
+		},
+	}
+	dir := mountPath
+	if pathKind == common.FileKind {
+		dir = filepath.Dir(mountPath)
+	}
+	vm := v1.VolumeMount{
+		Name:      metricsVol.Name,
+		MountPath: dir,
+	}
+	indexList := []int{}
+	for i, c := range pod.Spec.Containers {
+		shouldMount := false
+		if c.Name == sidecarContainerName {
+			shouldMount = true
+		} else {
+			jobProvider, err := jobv1beta1.New(jobKind)
+>>>>>>> Add primary container name
 			if err != nil {
 				return "", "", err
 			}

--- a/pkg/webhook/v1beta1/pod/inject_webhook_test.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook_test.go
@@ -2,22 +2,15 @@ package pod
 
 import (
 	"context"
+	"path/filepath"
 	"reflect"
 	"sync"
 	"testing"
 	"time"
 
-	"path/filepath"
-
-<<<<<<< HEAD
+	tfv1 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1"
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-=======
-	common "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
-	trialsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/trials/v1beta1"
-	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
-	mccommon "github.com/kubeflow/katib/pkg/metricscollector/v1beta1/common"
->>>>>>> Add primary container name
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,10 +20,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	common "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
+	trialsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/trials/v1beta1"
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/util"
 	mccommon "github.com/kubeflow/katib/pkg/metricscollector/v1beta1/common"
-	tfv1 "github.com/kubeflow/tf-operator/pkg/apis/tensorflow/v1"
 )
 
 func TestWrapWorkerContainer(t *testing.T) {

--- a/pkg/webhook/v1beta1/pod/inject_webhook_test.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook_test.go
@@ -9,8 +9,15 @@ import (
 
 	"path/filepath"
 
+<<<<<<< HEAD
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+=======
+	common "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
+	trialsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/trials/v1beta1"
+	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
+	mccommon "github.com/kubeflow/katib/pkg/metricscollector/v1beta1/common"
+>>>>>>> Add primary container name
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,15 +35,15 @@ import (
 
 func TestWrapWorkerContainer(t *testing.T) {
 	testCases := []struct {
-		Pod           *v1.Pod
-		Namespace     string
-		JobKind       string
-		MetricsFile   string
-		PathKind      common.FileSystemKind
-		MC            common.MetricsCollectorSpec
-		Expected      *v1.Pod
-		ExpectedError error
-		Name          string
+		Pod         *v1.Pod
+		Namespace   string
+		JobKind     string
+		MetricsFile string
+		PathKind    common.FileSystemKind
+		Trial       *trialsv1beta1.Trial
+		Expected    *v1.Pod
+		Err         bool
+		Name        string
 	}{
 		{
 			Pod: &v1.Pod{
@@ -55,9 +62,13 @@ func TestWrapWorkerContainer(t *testing.T) {
 			JobKind:     "TFJob",
 			MetricsFile: "testfile",
 			PathKind:    common.FileKind,
-			MC: common.MetricsCollectorSpec{
-				Collector: &common.CollectorSpec{
-					Kind: common.StdOutCollector,
+			Trial: &trialsv1beta1.Trial{
+				Spec: trialsv1beta1.TrialSpec{
+					MetricsCollector: common.MetricsCollectorSpec{
+						Collector: &common.CollectorSpec{
+							Kind: common.StdOutCollector,
+						},
+					},
 				},
 			},
 			Expected: &v1.Pod{
@@ -75,45 +86,8 @@ func TestWrapWorkerContainer(t *testing.T) {
 					},
 				},
 			},
-			ExpectedError: nil,
-			Name:          "tensorflow container without sh -c",
-		},
-		{
-			Pod: &v1.Pod{
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Name: "test",
-							Command: []string{
-								"python main.py",
-							},
-						},
-					},
-				},
-			},
-			Namespace:   "nohere",
-			JobKind:     "TFJob",
-			MetricsFile: "testfile",
-			PathKind:    common.FileKind,
-			MC: common.MetricsCollectorSpec{
-				Collector: &common.CollectorSpec{
-					Kind: common.StdOutCollector,
-				},
-			},
-			Expected: &v1.Pod{
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Name: "test",
-							Command: []string{
-								"python main.py",
-							},
-						},
-					},
-				},
-			},
-			ExpectedError: nil,
-			Name:          "test container without sh -c",
+			Err:  false,
+			Name: "tensorflow container without sh -c",
 		},
 		{
 			Pod: &v1.Pod{
@@ -133,9 +107,13 @@ func TestWrapWorkerContainer(t *testing.T) {
 			JobKind:     "TFJob",
 			MetricsFile: "testfile",
 			PathKind:    common.FileKind,
-			MC: common.MetricsCollectorSpec{
-				Collector: &common.CollectorSpec{
-					Kind: common.StdOutCollector,
+			Trial: &trialsv1beta1.Trial{
+				Spec: trialsv1beta1.TrialSpec{
+					MetricsCollector: common.MetricsCollectorSpec{
+						Collector: &common.CollectorSpec{
+							Kind: common.StdOutCollector,
+						},
+					},
 				},
 			},
 			Expected: &v1.Pod{
@@ -153,22 +131,101 @@ func TestWrapWorkerContainer(t *testing.T) {
 					},
 				},
 			},
-			ExpectedError: nil,
-			Name:          "Tensorflow container with sh -c",
+			Err:  false,
+			Name: "tensorflow container with sh -c",
+		},
+		{
+			Pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "primary-container",
+							Command: []string{
+								"sh", "-c",
+								"python main.py",
+							},
+						},
+						{
+							Name: "not-primary-container",
+							Command: []string{
+								"sh", "-c",
+								"python main.py",
+							},
+						},
+					},
+				},
+			},
+			MetricsFile: "testfile",
+			PathKind:    common.FileKind,
+			Trial: &trialsv1beta1.Trial{
+				Spec: trialsv1beta1.TrialSpec{
+					PrimaryContainerName: "primary-container",
+					MetricsCollector: common.MetricsCollectorSpec{
+						Collector: &common.CollectorSpec{
+							Kind: common.StdOutCollector,
+						},
+					},
+				},
+			},
+			Expected: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "primary-container",
+							Command: []string{
+								"sh", "-c",
+							},
+							Args: []string{
+								"python main.py 1>testfile 2>&1 && echo completed > $$$$.pid",
+							},
+						},
+						{
+							Name: "not-primary-container",
+							Command: []string{
+								"sh", "-c",
+								"python main.py",
+							},
+						},
+					},
+				},
+			},
+			Err:  false,
+			Name: "Primary container name is set for training pod",
+		},
+		{
+			Pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "not-primary-container",
+						},
+					},
+				},
+			},
+			PathKind: common.FileKind,
+			Trial: &trialsv1beta1.Trial{
+				Spec: trialsv1beta1.TrialSpec{
+					PrimaryContainerName: "primary-container",
+				},
+			},
+			Err:  true,
+			Name: "Training pod doesn't have primary container name",
 		},
 	}
 
 	for _, c := range testCases {
-		err := wrapWorkerContainer(c.Pod, c.Namespace, c.JobKind, c.MetricsFile, c.PathKind, c.MC)
-		if err != c.ExpectedError {
-			t.Errorf("Expected error %v, got %v", c.ExpectedError, err)
-		}
-		if err == nil {
-			if !equality.Semantic.DeepEqual(c.Pod.Spec.Containers, c.Expected.Spec.Containers) {
-				t.Errorf("Case %s: Expected pod %v, got %v",
+		err := wrapWorkerContainer(c.Pod, c.Namespace, c.JobKind, c.MetricsFile, c.PathKind, c.Trial)
+		if c.Err && err == nil {
+			t.Errorf("Case %s failed. Expected error, got nil", c.Name)
+		} else if !c.Err {
+			if err != nil {
+				t.Errorf("Case %s failed. Expected nil, got error: %v", c.Name, err)
+			} else if !equality.Semantic.DeepEqual(c.Pod.Spec.Containers, c.Expected.Spec.Containers) {
+				t.Errorf("Case %s failed. Expected pod: %v, got: %v",
 					c.Name, c.Expected.Spec.Containers, c.Pod.Spec.Containers)
 			}
 		}
+
 	}
 }
 

--- a/sdk/python/v1beta1/docs/V1beta1TrialSpec.md
+++ b/sdk/python/v1beta1/docs/V1beta1TrialSpec.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 **metrics_collector** | [**V1beta1MetricsCollectorSpec**](V1beta1MetricsCollectorSpec.md) | Describes how metrics will be collected | [optional] 
 **objective** | [**V1beta1ObjectiveSpec**](V1beta1ObjectiveSpec.md) | Describes the objective of the experiment. | [optional] 
 **parameter_assignments** | [**list[V1beta1ParameterAssignment]**](V1beta1ParameterAssignment.md) | Key-value pairs for hyperparameters and assignment values. | 
+**primary_container_name** | **str** | Name of training container where actual model training is running | [optional] 
 **primary_pod_labels** | **dict(str, str)** | Label that determines if pod needs to be injected by Katib sidecar container | [optional] 
 **retain_run** | **bool** | Whether to retain the trial run object after completed. | [optional] 
 **run_spec** | [**V1UnstructuredUnstructured**](V1UnstructuredUnstructured.md) | Raw text for the trial run spec. This can be any generic Kubernetes runtime object. The trial operator should create the resource as written, and let the corresponding resource controller (e.g. tf-operator) handle the rest. | [optional] 

--- a/sdk/python/v1beta1/docs/V1beta1TrialTemplate.md
+++ b/sdk/python/v1beta1/docs/V1beta1TrialTemplate.md
@@ -4,6 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **config_map** | [**V1beta1ConfigMapSource**](V1beta1ConfigMapSource.md) | ConfigMap spec represents a reference to ConfigMap | [optional] 
+**primary_container_name** | **str** | Name of training container where actual model training is running | [optional] 
 **primary_pod_labels** | **dict(str, str)** | Labels that determines if pod needs to be injected by Katib sidecar container | [optional] 
 **retain** | **bool** | Retain indicates that trial resources must be not cleanup | [optional] 
 **trial_parameters** | [**list[V1beta1TrialParameterSpec]**](V1beta1TrialParameterSpec.md) | List of parameters that are used in trial template | [optional] 

--- a/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_trial_spec.py
+++ b/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_trial_spec.py
@@ -39,6 +39,7 @@ class V1beta1TrialSpec(object):
         'metrics_collector': 'V1beta1MetricsCollectorSpec',
         'objective': 'V1beta1ObjectiveSpec',
         'parameter_assignments': 'list[V1beta1ParameterAssignment]',
+        'primary_container_name': 'str',
         'primary_pod_labels': 'dict(str, str)',
         'retain_run': 'bool',
         'run_spec': 'V1UnstructuredUnstructured'
@@ -48,17 +49,19 @@ class V1beta1TrialSpec(object):
         'metrics_collector': 'metricsCollector',
         'objective': 'objective',
         'parameter_assignments': 'parameterAssignments',
+        'primary_container_name': 'primaryContainerName',
         'primary_pod_labels': 'primaryPodLabels',
         'retain_run': 'retainRun',
         'run_spec': 'runSpec'
     }
 
-    def __init__(self, metrics_collector=None, objective=None, parameter_assignments=None, primary_pod_labels=None, retain_run=None, run_spec=None):  # noqa: E501
+    def __init__(self, metrics_collector=None, objective=None, parameter_assignments=None, primary_container_name=None, primary_pod_labels=None, retain_run=None, run_spec=None):  # noqa: E501
         """V1beta1TrialSpec - a model defined in Swagger"""  # noqa: E501
 
         self._metrics_collector = None
         self._objective = None
         self._parameter_assignments = None
+        self._primary_container_name = None
         self._primary_pod_labels = None
         self._retain_run = None
         self._run_spec = None
@@ -69,6 +72,8 @@ class V1beta1TrialSpec(object):
         if objective is not None:
             self.objective = objective
         self.parameter_assignments = parameter_assignments
+        if primary_container_name is not None:
+            self.primary_container_name = primary_container_name
         if primary_pod_labels is not None:
             self.primary_pod_labels = primary_pod_labels
         if retain_run is not None:
@@ -146,6 +151,29 @@ class V1beta1TrialSpec(object):
             raise ValueError("Invalid value for `parameter_assignments`, must not be `None`")  # noqa: E501
 
         self._parameter_assignments = parameter_assignments
+
+    @property
+    def primary_container_name(self):
+        """Gets the primary_container_name of this V1beta1TrialSpec.  # noqa: E501
+
+        Name of training container where actual model training is running  # noqa: E501
+
+        :return: The primary_container_name of this V1beta1TrialSpec.  # noqa: E501
+        :rtype: str
+        """
+        return self._primary_container_name
+
+    @primary_container_name.setter
+    def primary_container_name(self, primary_container_name):
+        """Sets the primary_container_name of this V1beta1TrialSpec.
+
+        Name of training container where actual model training is running  # noqa: E501
+
+        :param primary_container_name: The primary_container_name of this V1beta1TrialSpec.  # noqa: E501
+        :type: str
+        """
+
+        self._primary_container_name = primary_container_name
 
     @property
     def primary_pod_labels(self):

--- a/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_trial_template.py
+++ b/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_trial_template.py
@@ -36,6 +36,7 @@ class V1beta1TrialTemplate(object):
     """
     swagger_types = {
         'config_map': 'V1beta1ConfigMapSource',
+        'primary_container_name': 'str',
         'primary_pod_labels': 'dict(str, str)',
         'retain': 'bool',
         'trial_parameters': 'list[V1beta1TrialParameterSpec]',
@@ -44,16 +45,18 @@ class V1beta1TrialTemplate(object):
 
     attribute_map = {
         'config_map': 'configMap',
+        'primary_container_name': 'primaryContainerName',
         'primary_pod_labels': 'primaryPodLabels',
         'retain': 'retain',
         'trial_parameters': 'trialParameters',
         'trial_spec': 'trialSpec'
     }
 
-    def __init__(self, config_map=None, primary_pod_labels=None, retain=None, trial_parameters=None, trial_spec=None):  # noqa: E501
+    def __init__(self, config_map=None, primary_container_name=None, primary_pod_labels=None, retain=None, trial_parameters=None, trial_spec=None):  # noqa: E501
         """V1beta1TrialTemplate - a model defined in Swagger"""  # noqa: E501
 
         self._config_map = None
+        self._primary_container_name = None
         self._primary_pod_labels = None
         self._retain = None
         self._trial_parameters = None
@@ -62,6 +65,8 @@ class V1beta1TrialTemplate(object):
 
         if config_map is not None:
             self.config_map = config_map
+        if primary_container_name is not None:
+            self.primary_container_name = primary_container_name
         if primary_pod_labels is not None:
             self.primary_pod_labels = primary_pod_labels
         if retain is not None:
@@ -93,6 +98,29 @@ class V1beta1TrialTemplate(object):
         """
 
         self._config_map = config_map
+
+    @property
+    def primary_container_name(self):
+        """Gets the primary_container_name of this V1beta1TrialTemplate.  # noqa: E501
+
+        Name of training container where actual model training is running  # noqa: E501
+
+        :return: The primary_container_name of this V1beta1TrialTemplate.  # noqa: E501
+        :rtype: str
+        """
+        return self._primary_container_name
+
+    @primary_container_name.setter
+    def primary_container_name(self, primary_container_name):
+        """Sets the primary_container_name of this V1beta1TrialTemplate.
+
+        Name of training container where actual model training is running  # noqa: E501
+
+        :param primary_container_name: The primary_container_name of this V1beta1TrialTemplate.  # noqa: E501
+        :type: str
+        """
+
+        self._primary_container_name = primary_container_name
 
     @property
     def primary_pod_labels(self):


### PR DESCRIPTION
Related: https://github.com/kubeflow/katib/issues/1214.
WIP until we merge this: https://github.com/kubeflow/katib/pull/1305, after that I will generate API clients, etc, but it would be great if you can start to review it.

`PrimaryContainerName ` defines container name that metrics collector should mutate.

/assign @gaocegege @johnugeorge @sperlingxx 


