### PR TITLE
feat(metrics-collector): enable nuking of ephemeral-storage request

### DIFF
--- a/pkg/util/v1beta1/katibconfig/config.go
+++ b/pkg/util/v1beta1/katibconfig/config.go
@@ -250,5 +250,16 @@ func setResourceRequirements(configResource corev1.ResourceRequirements) corev1.
 		defaultDiskLimit, _ := resource.ParseQuantity(consts.DefaultDiskLimit)
 		configResource.Limits[corev1.ResourceEphemeralStorage] = defaultDiskLimit
 	}
+
+	// If user explicitly sets ephemeral-storage value to something negative, nuke it.
+	// This enables compability with the GKE nodepool autoscalers, which cannot scale
+	// pods which define ephemeral-storage resource constraints.
+	if !diskLimit.IsZero() && !diskRequest.IsZero() {
+		if diskLimit.Sign() == -1 && diskRequest.Sign() == -1 {
+			delete(configResource.Limits, corev1.ResourceEphemeralStorage)
+			delete(configResource.Requests, corev1.ResourceEphemeralStorage)
+		}
+	}
+
 	return configResource
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
- Allows users to nuke ephemeral-storage request and limit by setting these values to something negative in the katib-config configmap.  
- This fixes an issue where GKE node pools will not scale up because they are not compatible with any pod requesting ephemeral-storage (see linked issue for more details)

**Which issue(s) this PR fixes**:
Fixes #1289

**Special notes for your reviewer**:

1. First time contributing here and also first time dabbling in GoLang, let me know if changes are needed.