### PR TITLE
Update CI test cluster version to 1.16

### DIFF
--- a/test/scripts/v1alpha3/create-cluster.sh
+++ b/test/scripts/v1alpha3/create-cluster.sh
@@ -34,7 +34,7 @@ gcloud --project ${PROJECT} beta container clusters create ${CLUSTER_NAME} \
     --zone ${ZONE} \
     --machine-type=n1-standard-8 \
     --num-nodes=6 \
-    --cluster-version 1.14
+    --cluster-version 1.16
 echo "Configuring kubectl"
 gcloud --project ${PROJECT} container clusters get-credentials ${CLUSTER_NAME} \
     --zone ${ZONE}

--- a/test/scripts/v1beta1/create-cluster.sh
+++ b/test/scripts/v1beta1/create-cluster.sh
@@ -33,7 +33,7 @@ gcloud --project ${PROJECT} beta container clusters create ${CLUSTER_NAME} \
     --zone ${ZONE} \
     --machine-type=n1-standard-8 \
     --num-nodes=6 \
-    --cluster-version 1.14
+    --cluster-version 1.16
 echo "Configuring kubectl"
 gcloud --project ${PROJECT} container clusters get-credentials ${CLUSTER_NAME} \
     --zone ${ZONE}

--- a/test/workflows/components/workflows-v1alpha3.libsonnet
+++ b/test/workflows/components/workflows-v1alpha3.libsonnet
@@ -100,11 +100,6 @@
           retryStrategy: {
             limit: 3,
             retryPolicy: "Always",
-            backoff: {
-              duration: 1,
-              factor: 2,
-              maxDuration: "1m",
-            },
           },
           container: {
             command: command,

--- a/test/workflows/components/workflows-v1alpha3.libsonnet
+++ b/test/workflows/components/workflows-v1alpha3.libsonnet
@@ -97,6 +97,15 @@
         // command: List to pass as the container command.
         buildTemplate(step_name, image, command):: {
           name: step_name,
+          retryStrategy: {
+            limit: 3,
+            retryPolicy: "Always",
+            backoff: {
+              duration: 1,
+              factor: 2,
+              maxDuration: "1m",
+            },
+          },
           container: {
             command: command,
             image: image,

--- a/test/workflows/components/workflows-v1beta1.libsonnet
+++ b/test/workflows/components/workflows-v1beta1.libsonnet
@@ -100,11 +100,6 @@
           retryStrategy: {
             limit: 3,
             retryPolicy: "Always",
-            backoff: {
-              duration: 1,
-              factor: 2,
-              maxDuration: "1m",
-            },
           },
           container: {
             command: command,

--- a/test/workflows/components/workflows-v1beta1.libsonnet
+++ b/test/workflows/components/workflows-v1beta1.libsonnet
@@ -97,6 +97,15 @@
         // command: List to pass as the container command.
         buildTemplate(step_name, image, command):: {
           name: step_name,
+          retryStrategy: {
+            limit: 3,
+            retryPolicy: "Always",
+            backoff: {
+              duration: 1,
+              factor: 2,
+              maxDuration: "1m",
+            },
+          },
           container: {
             command: command,
             image: image,


### PR DESCRIPTION
It seems that we can't create new GKE cluster with 1.14 version.

Ref: https://cloud.google.com/kubernetes-engine/docs/release-notes#august_27_2020_r28.
I update version to 1.16, KF serving [uses it](https://github.com/kubeflow/kfserving/blob/master/test/scripts/create-cluster.sh#L35) also.

/assign @johnugeorge @gaocegege 
/cc @yuzisun 