### PR TITLE
Add trial metadata substitution example

### DIFF
--- a/examples/v1beta1/trial-metadata-substitution.yaml
+++ b/examples/v1beta1/trial-metadata-substitution.yaml
@@ -55,6 +55,9 @@ spec:
           "custom-key": "custom-label"
       spec:
         template:
+          metadata:
+            annotations:
+              sidecar.istio.io/inject: "false"
           spec:
             containers:
               - name: training-container

--- a/examples/v1beta1/trial-metadata-substitution.yaml
+++ b/examples/v1beta1/trial-metadata-substitution.yaml
@@ -1,0 +1,80 @@
+# This example shows how you can use trial metadata in template substitution
+apiVersion: "kubeflow.org/v1beta1"
+kind: Experiment
+metadata:
+  namespace: kubeflow
+  name: trial-metadata-substitution
+spec:
+  objective:
+    type: maximize
+    goal: 0.99
+    objectiveMetricName: Validation-accuracy
+    additionalMetricNames:
+      - Train-accuracy
+  algorithm:
+    algorithmName: random
+  parallelTrialCount: 3
+  maxTrialCount: 12
+  maxFailedTrialCount: 3
+  parameters:
+    - name: lr
+      parameterType: double
+      feasibleSpace:
+        min: "0.01"
+        max: "0.03"
+  trialTemplate:
+    trialParameters:
+      - name: learningRate
+        description: Learning rate for the training model
+        reference: lr
+      - name: trialName
+        description: Name of the current trial
+        reference: ${trialSpec.Name}
+      - name: trialNamespace
+        description: Namespace of the current trial
+        reference: ${trialSpec.Namespace}
+      - name: trialKind
+        description: Kind of the current trial
+        reference: ${trialSpec.Kind}
+      - name: trialAPIVersion
+        description: API version of the current trial
+        reference: ${trialSpec.APIVersion}
+      - name: trialLabelCustom
+        description: Trial label with custom value
+        reference: ${trialSpec.Labels[custom-key]}
+      - name: trialAnnotationCustom
+        description: Trial annotation with custom value
+        reference: ${trialSpec.Annotations[custom-key]}
+    trialSpec:
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        annotations:
+          "custom-key": "custom-annotation"
+        labels:
+          "custom-key": "custom-label"
+      spec:
+        template:
+          spec:
+            containers:
+              - name: training-container
+                image: docker.io/kubeflowkatib/mxnet-mnist
+                command:
+                  - "python3"
+                  - "/opt/mxnet-mnist/mnist.py"
+                  - "--batch-size=64"
+                  - "--lr=${trialParameters.learningRate}"
+                env:
+                  - name: TRIAL_NAME
+                    value: ${trialParameters.trialName}
+                  - name: TRIAL_NAMESPACE
+                    value: ${trialParameters.trialNamespace}
+                  - name: TRIAL_KIND
+                    value: ${trialParameters.trialKind}
+                  - name: TRIAL_API_VERSION
+                    value: ${trialParameters.trialAPIVersion}
+                  - name: TRIAL_LABEL_CUSTOM
+                    value: ${trialParameters.trialLabelCustom}
+                  - name: TRIAL_ANNOTATION_CUSTOM
+                    value: ${trialParameters.trialAnnotationCustom}
+            restartPolicy: Never

--- a/examples/v1beta1/trial-metadata-substitution.yaml
+++ b/examples/v1beta1/trial-metadata-substitution.yaml
@@ -28,22 +28,22 @@ spec:
         description: Learning rate for the training model
         reference: lr
       - name: trialName
-        description: Name of the current trial
+        description: Name of the current trial's job
         reference: ${trialSpec.Name}
       - name: trialNamespace
-        description: Namespace of the current trial
+        description: Namespace of the current trial's job
         reference: ${trialSpec.Namespace}
       - name: trialKind
-        description: Kind of the current trial
+        description: Kind of the current trial's job
         reference: ${trialSpec.Kind}
       - name: trialAPIVersion
-        description: API version of the current trial
+        description: API version of the current trial's job
         reference: ${trialSpec.APIVersion}
       - name: trialLabelCustom
-        description: Trial label with custom value
+        description: Trial's job label with custom value
         reference: ${trialSpec.Labels[custom-key]}
       - name: trialAnnotationCustom
-        description: Trial annotation with custom value
+        description: Trial's job annotation with custom value
         reference: ${trialSpec.Annotations[custom-key]}
     trialSpec:
       apiVersion: batch/v1


### PR DESCRIPTION
Part of https://github.com/kubeflow/katib/issues/1280.
I added example for trial metadata injection from template.

/assign @sperlingxx 