### PR TITLE
feat: Ignore pb files in update gofmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
         - goveralls -coverprofile=coverage.out
     - name: "Prettier frontend check"
       language: node_js
-      node_js: "10.13.0"
+      node_js: "12.18.1"
       install:
         - npm install --global prettier@1.19.1
       script:

--- a/hack/update-gofmt.sh
+++ b/hack/update-gofmt.sh
@@ -18,4 +18,4 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-find . -name "*.go" | grep -v "\/vendor\/" | xargs gofmt -s -w
+find . -name "*.go" | grep -v "\/vendor\/" | grep -v "\.pb\.go$" | xargs gofmt -s -w

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -17,7 +17,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if ! which gofmt > /dev/null; then
+if ! which gofmt >/dev/null; then
   echo "Can not find gofmt"
   exit 1
 fi


### PR DESCRIPTION
See comment: https://github.com/kubeflow/katib/pull/1312#issuecomment-693612090.
We should not update .pb files in `update-gofmt` script.

Also, I update nvm version for travis.

/assign @gaocegege @johnugeorge 

/cc @khersey 