### PR TITLE
UI: Add resume policy to submit Experiment by parameters

### DIFF
--- a/pkg/ui/v1beta1/frontend/src/components/HP/Create/Params/CommonSpec.jsx
+++ b/pkg/ui/v1beta1/frontend/src/components/HP/Create/Params/CommonSpec.jsx
@@ -7,6 +7,10 @@ import Tooltip from '@material-ui/core/Tooltip';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
 
 import { changeSpec } from '../../../../actions/hpCreateActions';
 
@@ -27,6 +31,9 @@ const useStyles = makeStyles({
     padding: 2,
     marginBottom: 10,
   },
+  selectBox: {
+    width: 150,
+  },
 });
 
 const CommonParametersSpec = props => {
@@ -39,7 +46,39 @@ const CommonParametersSpec = props => {
   return (
     <div>
       {props.commonParametersSpec.map((param, i) => {
-        return (
+        return param.name === 'ResumePolicy' ? (
+          <div key={i} className={classes.parameter}>
+            <Grid container alignItems={'center'}>
+              <Grid item xs={12} sm={3}>
+                <Typography>
+                  <Tooltip title={param.description}>
+                    <HelpOutlineIcon className={classes.help} color={'primary'} />
+                  </Tooltip>
+                  {param.name}
+                </Typography>
+              </Grid>
+              <Grid item xs={12} sm={8}>
+                <FormControl variant="outlined" className={classes.formControl}>
+                  <InputLabel>Resume Policy</InputLabel>
+                  <Select
+                    value={param.value}
+                    onChange={onSpecChange(param.name)}
+                    className={classes.selectBox}
+                    label="Resume Policy"
+                  >
+                    {props.allResumePolicyTypes.map((type, i) => {
+                      return (
+                        <MenuItem value={type} key={i}>
+                          {type}
+                        </MenuItem>
+                      );
+                    })}
+                  </Select>
+                </FormControl>
+              </Grid>
+            </Grid>
+          </div>
+        ) : (
           <div key={i} className={classes.parameter}>
             <Grid container alignItems={'center'}>
               <Grid item xs={12} sm={3}>
@@ -68,6 +107,7 @@ const CommonParametersSpec = props => {
 const mapStateToProps = state => {
   return {
     commonParametersSpec: state[HP_CREATE_MODULE].commonParametersSpec,
+    allResumePolicyTypes: state[HP_CREATE_MODULE].allResumePolicyTypes,
   };
 };
 

--- a/pkg/ui/v1beta1/frontend/src/components/NAS/Create/Params/CommonSpec.jsx
+++ b/pkg/ui/v1beta1/frontend/src/components/NAS/Create/Params/CommonSpec.jsx
@@ -7,6 +7,10 @@ import Tooltip from '@material-ui/core/Tooltip';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
 
 import { changeSpec } from '../../../../actions/nasCreateActions';
 
@@ -27,6 +31,9 @@ const useStyles = makeStyles({
     padding: 2,
     marginBottom: 10,
   },
+  selectBox: {
+    width: 150,
+  },
 });
 
 const CommonParametersSpec = props => {
@@ -39,7 +46,39 @@ const CommonParametersSpec = props => {
   return (
     <div>
       {props.commonParametersSpec.map((param, i) => {
-        return (
+        return param.name === 'ResumePolicy' ? (
+          <div key={i} className={classes.parameter}>
+            <Grid container alignItems={'center'}>
+              <Grid item xs={12} sm={3}>
+                <Typography>
+                  <Tooltip title={param.description}>
+                    <HelpOutlineIcon className={classes.help} color={'primary'} />
+                  </Tooltip>
+                  {param.name}
+                </Typography>
+              </Grid>
+              <Grid item xs={12} sm={8}>
+                <FormControl variant="outlined" className={classes.formControl}>
+                  <InputLabel>Resume Policy</InputLabel>
+                  <Select
+                    value={param.value}
+                    onChange={onSpecChange(param.name)}
+                    className={classes.selectBox}
+                    label="Resume Policy"
+                  >
+                    {props.allResumePolicyTypes.map((type, i) => {
+                      return (
+                        <MenuItem value={type} key={i}>
+                          {type}
+                        </MenuItem>
+                      );
+                    })}
+                  </Select>
+                </FormControl>
+              </Grid>
+            </Grid>
+          </div>
+        ) : (
           <div key={i} className={classes.parameter}>
             <Grid container alignItems={'center'}>
               <Grid item xs={12} sm={3}>
@@ -68,6 +107,7 @@ const CommonParametersSpec = props => {
 const mapStateToProps = state => {
   return {
     commonParametersSpec: state[NAS_CREATE_MODULE].commonParametersSpec,
+    allResumePolicyTypes: state[NAS_CREATE_MODULE].allResumePolicyTypes,
   };
 };
 

--- a/pkg/ui/v1beta1/frontend/src/reducers/hpCreate.js
+++ b/pkg/ui/v1beta1/frontend/src/reducers/hpCreate.js
@@ -7,31 +7,37 @@ const initialState = {
     {
       name: 'Name',
       value: 'random-experiment',
-      description: 'A name of an experiment',
+      description: 'A name of an Experiment',
     },
     {
       name: 'Namespace',
       value: 'kubeflow',
-      description: 'Namespace to deploy an experiment',
+      description: 'Namespace to deploy an Experiment',
     },
   ],
   commonParametersSpec: [
     {
       name: 'ParallelTrialCount',
       value: '3',
-      description: 'How many trials can be processed in parallel',
+      description: 'How many Trials can be processed in parallel',
     },
     {
       name: 'MaxTrialCount',
       value: '12',
-      description: 'Max completed trials to mark experiment as succeeded',
+      description: 'Max completed Trials to mark Experiment as succeeded',
     },
     {
       name: 'MaxFailedTrialCount',
       value: '3',
-      description: 'Max failed trials to mark experiment as failed',
+      description: 'Max failed trials to mark Experiment as failed',
+    },
+    {
+      name: 'ResumePolicy',
+      value: 'LongRunning',
+      description: 'Resume policy describes how the Experiment should be restarted',
     },
   ],
+  allResumePolicyTypes: ['Never', 'LongRunning', 'FromVolume'],
   allObjectiveTypes: ['minimize', 'maximize'],
   objective: [
     {
@@ -56,7 +62,7 @@ const initialState = {
     },
   ],
   algorithmName: 'random',
-  allAlgorithms: ['grid', 'random', 'hyperband', 'bayesianoptimization', 'tpe'],
+  allAlgorithms: ['grid', 'random', 'hyperband', 'bayesianoptimization', 'tpe', 'cmaes'],
   algorithmSettings: [],
   parameters: [
     {

--- a/pkg/ui/v1beta1/frontend/src/reducers/nasCreate.js
+++ b/pkg/ui/v1beta1/frontend/src/reducers/nasCreate.js
@@ -6,31 +6,37 @@ const initialState = {
     {
       name: 'Name',
       value: 'enas-example',
-      description: 'A name of an experiment',
+      description: 'A name of an Experiment',
     },
     {
       name: 'Namespace',
       value: 'kubeflow',
-      description: 'Namespace to deploy an experiment',
+      description: 'Namespace to deploy an Experiment',
     },
   ],
   commonParametersSpec: [
     {
       name: 'ParallelTrialCount',
       value: '3',
-      description: 'How many trials can be processed in parallel',
+      description: 'How many Trials can be processed in parallel',
     },
     {
       name: 'MaxTrialCount',
       value: '12',
-      description: 'Max completed trials to mark experiment as succeeded',
+      description: 'Max completed Trials to mark Experiment as succeeded',
     },
     {
       name: 'MaxFailedTrialCount',
       value: '3',
-      description: 'Max failed trials to mark experiment as failed',
+      description: 'Max failed Trials to mark Experiment as failed',
+    },
+    {
+      name: 'ResumePolicy',
+      value: 'LongRunning',
+      description: 'Resume policy describes how the Experiment should be restarted',
     },
   ],
+  allResumePolicyTypes: ['Never', 'LongRunning', 'FromVolume'],
   allObjectiveTypes: ['minimize', 'maximize'],
   objective: [
     {
@@ -51,7 +57,7 @@ const initialState = {
   ],
   additionalMetricNames: [],
   algorithmName: 'enas',
-  allAlgorithms: ['enas'],
+  allAlgorithms: ['enas', 'darts'],
   algorithmSettings: [
     {
       name: 'controller_hidden_size',


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1221.

I added `ResumePolicy` select box in submit Experiment by parameters.
Also, I added missing HP and NAS supported algorithms.

![ResumePolicy](https://user-images.githubusercontent.com/31112157/96499315-294eb700-1245-11eb-8654-9f11a981177f.gif)

/cc @gaocegege @johnugeorge 