### PR TITLE
UI: Support new parameters in Trial template 

### DIFF
--- a/pkg/ui/v1beta1/frontend/src/actions/generalActions.js
+++ b/pkg/ui/v1beta1/frontend/src/actions/generalActions.js
@@ -91,36 +91,6 @@ export const closeDialogSuggestion = () => ({
   type: CLOSE_DIALOG_SUGGESTION,
 });
 
-export const FILTER_TEMPLATES_EXPERIMENT = 'FILTER_TEMPLATES_EXPERIMENT';
-
-export const filterTemplatesExperiment = (
-  configMapNamespaceIndex,
-  configMapNameIndex,
-  configMapPathIndex,
-) => ({
-  type: FILTER_TEMPLATES_EXPERIMENT,
-  configMapNamespaceIndex,
-  configMapNameIndex,
-  configMapPathIndex,
-});
-
-export const VALIDATION_ERROR = 'VALIDATION_ERROR';
-
-export const validationError = message => ({
-  type: VALIDATION_ERROR,
-  message,
-});
-
-export const EDIT_TRIAL_PARAMETERS = 'EDIT_TRIAL_PARAMETERS';
-
-export const editTrialParameters = (index, name, reference, description) => ({
-  type: EDIT_TRIAL_PARAMETERS,
-  index,
-  name,
-  reference,
-  description,
-});
-
 export const FETCH_EXPERIMENTS_REQUEST = 'FETCH_EXPERIMENTS_REQUEST';
 export const FETCH_EXPERIMENTS_SUCCESS = 'FETCH_EXPERIMENTS_SUCCESS';
 export const FETCH_EXPERIMENTS_FAILURE = 'FETCH_EXPERIMENTS_FAILURE';
@@ -143,4 +113,78 @@ export const changeStatus = (filter, checked) => ({
   type: CHANGE_STATUS,
   filter,
   checked,
+});
+
+export const CHANGE_TRIAL_TEMPLATE_SOURCE = 'CHANGE_TRIAL_TEMPLATE_SOURCE';
+
+export const changeTrialTemplateSource = source => ({
+  type: CHANGE_TRIAL_TEMPLATE_SOURCE,
+  source,
+});
+
+export const ADD_PRIMARY_POD_LABEL = 'ADD_PRIMARY_POD_LABEL';
+
+export const addPrimaryPodLabel = () => ({
+  type: ADD_PRIMARY_POD_LABEL,
+});
+
+export const CHANGE_PRIMARY_POD_LABEL = 'CHANGE_PRIMARY_POD_LABEL';
+
+export const changePrimaryPodLabel = (fieldName, index, value) => ({
+  type: CHANGE_PRIMARY_POD_LABEL,
+  fieldName,
+  index,
+  value,
+});
+
+export const DELETE_PRIMARY_POD_LABEL = 'DELETE_PRIMARY_POD_LABEL';
+
+export const deletePrimaryPodLabel = index => ({
+  type: DELETE_PRIMARY_POD_LABEL,
+  index,
+});
+
+export const CHANGE_TRIAL_TEMPLATE_SPEC = 'CHANGE_TRIAL_TEMPLATE_SPEC';
+
+export const changeTrialTemplateSpec = (name, value) => ({
+  type: CHANGE_TRIAL_TEMPLATE_SPEC,
+  name,
+  value,
+});
+
+export const FILTER_TEMPLATES_EXPERIMENT = 'FILTER_TEMPLATES_EXPERIMENT';
+
+export const filterTemplatesExperiment = (
+  configMapNamespaceIndex,
+  configMapNameIndex,
+  configMapPathIndex,
+) => ({
+  type: FILTER_TEMPLATES_EXPERIMENT,
+  configMapNamespaceIndex,
+  configMapNameIndex,
+  configMapPathIndex,
+});
+
+export const CHANGE_TRIAL_TEMPLATE_YAML = 'CHANGE_TRIAL_TEMPLATE_YAML';
+
+export const changeTrialTemplateYAML = templateYAML => ({
+  type: CHANGE_TRIAL_TEMPLATE_YAML,
+  templateYAML,
+});
+
+export const CHANGE_TRIAL_PARAMETERS = 'CHANGE_TRIAL_PARAMETERS';
+
+export const changeTrialParameters = (index, name, reference, description) => ({
+  type: CHANGE_TRIAL_PARAMETERS,
+  index,
+  name,
+  reference,
+  description,
+});
+
+export const VALIDATION_ERROR = 'VALIDATION_ERROR';
+
+export const validationError = message => ({
+  type: VALIDATION_ERROR,
+  message,
 });

--- a/pkg/ui/v1beta1/frontend/src/components/Common/Create/Params/MetricsCollector.jsx
+++ b/pkg/ui/v1beta1/frontend/src/components/Common/Create/Params/MetricsCollector.jsx
@@ -525,7 +525,7 @@ class MetricsCollectorSpec extends React.Component {
                 <Tooltip title={'Yaml structure for the custom metrics collector container'}>
                   <HelpOutlineIcon className={classes.help} color={'primary'} />
                 </Tooltip>
-                {'Yaml for the Custom Container'}
+                {'YAML for the Custom Container'}
               </Typography>
             </Grid>
             <Grid item xs={6}>

--- a/pkg/ui/v1beta1/frontend/src/components/Common/Create/Params/Trial/TrialParameters.jsx
+++ b/pkg/ui/v1beta1/frontend/src/components/Common/Create/Params/Trial/TrialParameters.jsx
@@ -8,7 +8,7 @@ import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 
-import { editTrialParameters } from '../../../../../actions/generalActions';
+import { changeTrialParameters } from '../../../../../actions/generalActions';
 import { GENERAL_MODULE } from '../../../../../constants/constants';
 
 const useStyles = makeStyles({
@@ -36,21 +36,21 @@ const TrialParameters = props => {
     let param = props.trialParameters[index];
     let reference = param.reference;
     let description = param.description;
-    props.editTrialParameters(index, event.target.value, reference, description);
+    props.changeTrialParameters(index, event.target.value, reference, description);
   };
 
   const onReferenceChange = index => event => {
     let param = props.trialParameters[index];
     let name = param.name;
     let description = param.description;
-    props.editTrialParameters(index, name, event.target.value, description);
+    props.changeTrialParameters(index, name, event.target.value, description);
   };
 
   const onDescriptionChange = index => event => {
     let param = props.trialParameters[index];
     let name = param.name;
     let reference = param.reference;
-    props.editTrialParameters(index, name, reference, event.target.value);
+    props.changeTrialParameters(index, name, reference, event.target.value);
   };
 
   return (
@@ -121,4 +121,4 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(mapStateToProps, { editTrialParameters })(TrialParameters);
+export default connect(mapStateToProps, { changeTrialParameters })(TrialParameters);

--- a/pkg/ui/v1beta1/frontend/src/components/Common/Create/Params/Trial/TrialTemplate.jsx
+++ b/pkg/ui/v1beta1/frontend/src/components/Common/Create/Params/Trial/TrialTemplate.jsx
@@ -1,15 +1,235 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
+import AceEditor from 'react-ace';
+import 'ace-builds/src-noconflict/theme-sqlserver';
+import 'ace-builds/src-noconflict/mode-yaml';
+
+import { withStyles } from '@material-ui/core/styles';
 import Divider from '@material-ui/core/Divider';
-
+import FormControl from '@material-ui/core/FormControl';
+import InputLabel from '@material-ui/core/InputLabel';
+import Select from '@material-ui/core/Select';
+import Grid from '@material-ui/core/Grid';
+import Tooltip from '@material-ui/core/Tooltip';
+import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
+import Typography from '@material-ui/core/Typography';
+import TextField from '@material-ui/core/TextField';
+import Button from '@material-ui/core/Button';
+import IconButton from '@material-ui/core/IconButton';
+import DeleteIcon from '@material-ui/icons/Delete';
+import MenuItem from '@material-ui/core/MenuItem';
 import TrialConfigMap from './TrialConfigMap';
 import TrialParameters from './TrialParameters';
 
+import { GENERAL_MODULE, TEMPLATE_SOURCE_CONFIG_MAP } from '../../../../../constants/constants';
+import {
+  changeTrialTemplateSource,
+  addPrimaryPodLabel,
+  changePrimaryPodLabel,
+  deletePrimaryPodLabel,
+  changeTrialTemplateSpec,
+  changeTrialTemplateYAML,
+} from '../../../../../actions/generalActions';
+import { fetchTrialTemplates } from '../../../../../actions/templateActions';
+
+const styles = () => ({
+  parameter: {
+    padding: 2,
+    marginBottom: 10,
+  },
+  help: {
+    padding: 4 / 2,
+    verticalAlign: 'middle',
+    marginRight: 5,
+  },
+  textField: {
+    marginLeft: 4,
+    marginRight: 4,
+    width: '90%',
+  },
+  button: {
+    marginTop: 10,
+    marginBottom: 10,
+  },
+  formSelect: {
+    width: '70%',
+  },
+});
+
 class TrialTemplate extends React.Component {
+  onTrialTemplateSourceChange = event => {
+    // Change source only if value is changed.
+    if (event.target.value !== this.props.trialTemplateSource) {
+      this.props.changeTrialTemplateSource(event.target.value);
+      // Fetch templates if source is ConfigMap.
+      if (event.target.value === TEMPLATE_SOURCE_CONFIG_MAP) {
+        this.props.fetchTrialTemplates();
+      }
+    }
+  };
+
+  onPrimaryPodLabelAdd = () => {
+    this.props.addPrimaryPodLabel();
+  };
+
+  onPrimaryPodLabelChange = (fieldName, index) => event => {
+    this.props.changePrimaryPodLabel(fieldName, index, event.target.value);
+  };
+
+  onPrimaryPodLabelDelete = index => () => {
+    this.props.deletePrimaryPodLabel(index);
+  };
+
+  onTrialTemplateSpecChange = name => event => {
+    this.props.changeTrialTemplateSpec(name, event.target.value);
+  };
+
+  onTrialTemplateYAMLChange = templateYAML => {
+    this.props.changeTrialTemplateYAML(templateYAML);
+  };
+
   render() {
+    const { classes } = this.props;
     return (
       <div>
-        <TrialConfigMap></TrialConfigMap>
+        <Grid container alignItems={'center'}>
+          <Grid item xs={3}>
+            <Typography variant={'subtitle1'}>
+              <Tooltip title={'Source type for Trial template'}>
+                <HelpOutlineIcon className={classes.help} color={'primary'} />
+              </Tooltip>
+              {'Source type'}
+            </Typography>
+          </Grid>
+          <Grid item xs={3}>
+            <FormControl variant="outlined" className={classes.formSelect}>
+              <InputLabel>Source type</InputLabel>
+              <Select
+                value={this.props.trialTemplateSource}
+                onChange={this.onTrialTemplateSourceChange}
+                label="Source type"
+              >
+                {this.props.trialTemplateSourceList.map((source, i) => {
+                  return (
+                    <MenuItem value={source} key={i}>
+                      {source}
+                    </MenuItem>
+                  );
+                })}
+              </Select>
+            </FormControl>
+          </Grid>
+        </Grid>
+        <Grid container alignItems={'center'}>
+          <Grid item xs={3}>
+            <Typography variant={'subtitle1'}>
+              <Tooltip
+                title={
+                  'Labels to indicate if pod needs to be injected by Katib sidecar container.\
+              If labels are omitted, all created pods are injected'
+                }
+              >
+                <HelpOutlineIcon className={classes.help} color={'primary'} />
+              </Tooltip>
+              {'PrimaryPodLabels (optional)'}
+            </Typography>
+            <Button
+              variant={'contained'}
+              color={'primary'}
+              className={classes.button}
+              onClick={this.onPrimaryPodLabelAdd}
+            >
+              Add Label
+            </Button>
+          </Grid>
+        </Grid>
+        {this.props.primaryPodLabels.map((label, index) => {
+          return (
+            <div key={index} className={classes.parameter}>
+              <Grid container alignItems={'center'}>
+                <Grid item xs={3} />
+                <Grid item xs={3}>
+                  <TextField
+                    label={'Label Key'}
+                    className={classes.textField}
+                    value={label.key}
+                    onChange={this.onPrimaryPodLabelChange('key', index)}
+                  />
+                </Grid>
+                <Grid item xs={3}>
+                  <TextField
+                    label={'Label Value'}
+                    className={classes.textField}
+                    value={label.value}
+                    onChange={this.onPrimaryPodLabelChange('value', index)}
+                  />
+                </Grid>
+                <Grid item xs={1}>
+                  <IconButton
+                    aria-label="Close"
+                    color={'primary'}
+                    onClick={this.onPrimaryPodLabelDelete(index)}
+                  >
+                    <DeleteIcon />
+                  </IconButton>
+                </Grid>
+              </Grid>
+            </div>
+          );
+        })}
+        {this.props.trialTemplateSpec.map((param, i) => {
+          return (
+            <div key={i} className={classes.parameter}>
+              <Grid container alignItems={'center'}>
+                <Grid item xs={12} sm={3}>
+                  <Typography variant={'subtitle1'}>
+                    <Tooltip title={param.description}>
+                      <HelpOutlineIcon className={classes.help} color={'primary'} />
+                    </Tooltip>
+                    {param.name}
+                  </Typography>
+                </Grid>
+                <Grid item xs={12} sm={8}>
+                  <TextField
+                    className={classes.textField}
+                    value={param.value}
+                    onChange={this.onTrialTemplateSpecChange(param.name)}
+                  />
+                </Grid>
+              </Grid>
+            </div>
+          );
+        })}
+        {this.props.trialTemplateSource === TEMPLATE_SOURCE_CONFIG_MAP ? (
+          <TrialConfigMap></TrialConfigMap>
+        ) : (
+          <Grid container alignItems={'center'}>
+            <Grid item xs={3}>
+              <Typography variant={'subtitle1'}>
+                <Tooltip title={'YAML structure for Trial template'}>
+                  <HelpOutlineIcon className={classes.help} color={'primary'} />
+                </Tooltip>
+                {'Trial template YAML'}
+              </Typography>
+            </Grid>
+            <Grid item xs={6}>
+              <AceEditor
+                mode="yaml"
+                theme="sqlserver"
+                value={this.props.trialTemplateYAML}
+                tabSize={2}
+                fontSize={13}
+                width={'100%'}
+                showPrintMargin={false}
+                autoScrollEditorIntoView={true}
+                maxLines={40}
+                minLines={20}
+                onChange={this.onTrialTemplateYAMLChange}
+              />
+            </Grid>
+          </Grid>
+        )}
         <Divider />
         <TrialParameters></TrialParameters>
       </div>
@@ -17,4 +237,22 @@ class TrialTemplate extends React.Component {
   }
 }
 
-export default TrialTemplate;
+const mapStateToProps = state => {
+  return {
+    trialTemplateSourceList: state[GENERAL_MODULE].trialTemplateSourceList,
+    trialTemplateSource: state[GENERAL_MODULE].trialTemplateSource,
+    primaryPodLabels: state[GENERAL_MODULE].primaryPodLabels,
+    trialTemplateSpec: state[GENERAL_MODULE].trialTemplateSpec,
+    trialTemplateYAML: state[GENERAL_MODULE].trialTemplateYAML,
+  };
+};
+
+export default connect(mapStateToProps, {
+  changeTrialTemplateSource,
+  addPrimaryPodLabel,
+  changePrimaryPodLabel,
+  deletePrimaryPodLabel,
+  changeTrialTemplateSpec,
+  changeTrialTemplateYAML,
+  fetchTrialTemplates,
+})(withStyles(styles)(TrialTemplate));

--- a/pkg/ui/v1beta1/frontend/src/components/HP/Create/HPParameters.jsx
+++ b/pkg/ui/v1beta1/frontend/src/components/HP/Create/HPParameters.jsx
@@ -196,7 +196,6 @@ const HPParameters = props => {
     // Add Trial specification.
     data.spec.trialTemplate = {};
     deCapitalizeFirstLetterAndAppend(props.trialTemplateSpec, data.spec.trialTemplate);
-    console.log(data.spec.trialTemplate.retain);
     if (data.spec.trialTemplate.retain === 'true') {
       data.spec.trialTemplate.retain = true;
     } else if (data.spec.trialTemplate.retain === 'false') {
@@ -227,22 +226,24 @@ const HPParameters = props => {
       // Try to parse template YAML to JSON.
       try {
         let trialTemplateJSON = jsyaml.load(props.trialTemplateYAML);
-        data.spec.trialTemplate.trialSource = trialTemplateJSON;
+        data.spec.trialTemplate.trialSpec = trialTemplateJSON;
       } catch {
         props.validationError('Trial Template is not valid YAML!');
         return;
       }
       // Otherwise assign ConfigMap.
     } else {
-      data.spec.trialTemplate = {
-        configMap: {
-          configMapNamespace: props.templateConfigMapNamespace,
-          configMapName: props.templateConfigMapName,
-          templatePath: props.templateConfigMapPath,
-        },
+      data.spec.trialTemplate.configMap = {
+        configMapNamespace: props.templateConfigMapNamespace,
+        configMapName: props.templateConfigMapName,
+        templatePath: props.templateConfigMapPath,
       };
     }
-    data.spec.trialTemplate.trialParameters = props.trialParameters;
+
+    // Add Trial parameters if it is not empty.
+    if (props.trialParameters.length > 0) {
+      data.spec.trialTemplate.trialParameters = props.trialParameters;
+    }
 
     props.submitHPJob(data);
   };

--- a/pkg/ui/v1beta1/frontend/src/components/NAS/Create/NASParameters.jsx
+++ b/pkg/ui/v1beta1/frontend/src/components/NAS/Create/NASParameters.jsx
@@ -322,6 +322,7 @@ const mapStateToProps = state => {
     inputSize: state[constants.NAS_CREATE_MODULE].inputSize,
     outputSize: state[constants.NAS_CREATE_MODULE].outputSize,
     operations: state[constants.NAS_CREATE_MODULE].operations,
+    primaryPodLabels: state[constants.GENERAL_MODULE].primaryPodLabels,
     trialTemplateSpec: state[constants.GENERAL_MODULE].trialTemplateSpec,
     trialTemplateSource: state[constants.GENERAL_MODULE].trialTemplateSource,
     templateConfigMapNamespace: templateCMNamespace,

--- a/pkg/ui/v1beta1/frontend/src/constants/constants.js
+++ b/pkg/ui/v1beta1/frontend/src/constants/constants.js
@@ -31,3 +31,6 @@ export const HP_MONITOR_MODULE = 'hpMonitor';
 export const NAS_CREATE_MODULE = 'nasCreate';
 export const NAS_MONITOR_MODULE = 'nasMonitor';
 export const TEMPLATE_MODULE = 'template';
+
+export const TEMPLATE_SOURCE_CONFIG_MAP = 'ConfigMap';
+export const TEMPLATE_SOURCE_YAML = 'YAML';

--- a/pkg/ui/v1beta1/frontend/src/reducers/hpCreate.js
+++ b/pkg/ui/v1beta1/frontend/src/reducers/hpCreate.js
@@ -109,6 +109,7 @@ const initialState = {
   mcCustomContainerYaml: '',
 };
 
+// filterValue finds index from array where name == key.
 const filterValue = (obj, key) => {
   return obj.findIndex(p => p.name === key);
 };

--- a/pkg/ui/v1beta1/frontend/src/reducers/nasCreate.js
+++ b/pkg/ui/v1beta1/frontend/src/reducers/nasCreate.js
@@ -349,6 +349,7 @@ const initialState = {
   mcCustomContainerYaml: '',
 };
 
+// filterValue finds index from array where name == key.
 const filterValue = (obj, key) => {
   return obj.findIndex(p => p.name === key);
 };


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1217.

I added all parameters from `TrialTemplate` to submit Experiment page.
As well, user can add template YAML directly from submit Experiment by parameters page.

![new Trial Template Params](https://user-images.githubusercontent.com/31112157/96757366-3eeee880-13cd-11eb-8e5f-eb520f989ae6.gif)


/assign @gaocegege @johnugeorge 