### PR TITLE
Remove default values for Trial template

### DIFF
--- a/pkg/apis/controller/experiments/v1beta1/constants.go
+++ b/pkg/apis/controller/experiments/v1beta1/constants.go
@@ -19,12 +19,6 @@ const (
 	// DefaultTrialParallelCount is the default value of spec.parallelTrialCount.
 	DefaultTrialParallelCount = 3
 
-	// DefaultTrialConfigMapName is the default value of spec.trialTemplate.configMapName for Trial template.
-	DefaultTrialConfigMapName = "trial-template"
-
-	// DefaultTrialTemplatePath is the default value of spec.trialTemplate.TemplatePath.
-	DefaultTrialTemplatePath = "defaultTrialTemplate.yaml"
-
 	// DefaultResumePolicy is the default value of spec.resumePolicy.
 	DefaultResumePolicy = LongRunning
 

--- a/pkg/apis/controller/experiments/v1beta1/experiment_defaults.go
+++ b/pkg/apis/controller/experiments/v1beta1/experiment_defaults.go
@@ -96,40 +96,9 @@ func (e *Experiment) setDefaultObjective() {
 
 func (e *Experiment) setDefaultTrialTemplate() {
 	t := e.Spec.TrialTemplate
-	if t == nil {
-		t = &TrialTemplate{
-			Retain: true,
-		}
-	}
-	if t.TrialSource.TrialSpec == nil && t.TrialSource.ConfigMap == nil && t.TrialParameters == nil {
-		t.TrialSource = TrialSource{
-			ConfigMap: &ConfigMapSource{
-				ConfigMapNamespace: consts.DefaultKatibNamespace,
-				ConfigMapName:      DefaultTrialConfigMapName,
-				TemplatePath:       DefaultTrialTemplatePath,
-			},
-		}
-		t.TrialParameters = []TrialParameterSpec{
-			{
-				Name:        "learningRate",
-				Description: "Learning rate for the training model",
-				Reference:   "lr",
-			},
-			{
-				Name:        "numberLayers",
-				Description: "Number of training model layers",
-				Reference:   "num-layers",
-			},
-			{
-				Name:        "optimizer",
-				Description: "Training model optimizer (sdg, adam or ftrl)",
-				Reference:   "optimizer",
-			},
-		}
-	}
 
 	// Set default values for Job, TFJob and PyTorchJob if TrialSpec is not nil
-	if t.TrialSource.TrialSpec != nil {
+	if t != nil && t.TrialSource.TrialSpec != nil {
 		jobKind := t.TrialSource.TrialSpec.GetKind()
 		if jobKind == consts.JobKindJob {
 			if t.SuccessCondition == "" {

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -200,6 +200,10 @@ func (g *DefaultValidator) validateTrialTemplate(instance *experimentsv1beta1.Ex
 
 	trialTemplate := instance.Spec.TrialTemplate
 
+	if trialTemplate == nil {
+		return fmt.Errorf("spec.trialTemplate must be specified")
+	}
+
 	// Check if PrimaryContainerName is set
 	if trialTemplate.PrimaryContainerName == "" {
 		return fmt.Errorf("spec.trialTemplate.primaryContainerName must be specified")

--- a/pkg/webhook/v1beta1/experiment/validator/validator_test.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator_test.go
@@ -211,11 +211,11 @@ func TestValidateExperiment(t *testing.T) {
 		{
 			Instance: func() *experimentsv1beta1.Experiment {
 				i := newFakeInstance()
-				i.Spec.TrialTemplate.TrialParameters[0].Name = "Invalid"
+				i.Spec.TrialTemplate = nil
 				return i
 			}(),
 			Err:             true,
-			testDescription: "Invalid Trial parameter name",
+			testDescription: "Trial template is nil",
 		},
 		{
 			Instance: func() *experimentsv1beta1.Experiment {


### PR DESCRIPTION
I think it's better to remove default values for the `spec.trialTemplate.TrialSpec`.
It's make very unclear for the user that Experiment can be created without `trialTemplate` and which `spec.parameters` should be set.

WDYT @gaocegege @johnugeorge  ?