### PR TITLE
Bump Tensorflow from 1.15.2 to 1.15.4

### DIFF
--- a/cmd/suggestion/nas/enas/v1alpha3/requirements.txt
+++ b/cmd/suggestion/nas/enas/v1alpha3/requirements.txt
@@ -1,4 +1,4 @@
 grpcio==1.23.0
 protobuf==3.9.1
 googleapis-common-protos==1.6.0
-tensorflow==1.15.2
+tensorflow==1.15.4

--- a/cmd/suggestion/nas/enas/v1beta1/requirements.txt
+++ b/cmd/suggestion/nas/enas/v1beta1/requirements.txt
@@ -1,4 +1,4 @@
 grpcio==1.23.0
 protobuf==3.9.1
 googleapis-common-protos==1.6.0
-tensorflow==1.15.2
+tensorflow==1.15.4

--- a/examples/v1alpha3/nas/enas-cnn-cifar10/requirements-cpu.txt
+++ b/examples/v1alpha3/nas/enas-cnn-cifar10/requirements-cpu.txt
@@ -1,2 +1,2 @@
-tensorflow==1.15.2
+tensorflow==1.15.4
 keras==2.2.4

--- a/examples/v1alpha3/nas/enas-cnn-cifar10/requirements-gpu.txt
+++ b/examples/v1alpha3/nas/enas-cnn-cifar10/requirements-gpu.txt
@@ -1,2 +1,2 @@
-tensorflow-gpu==1.15.2
+tensorflow-gpu==1.15.4
 keras==2.2.4

--- a/examples/v1beta1/nas/enas-cnn-cifar10/requirements-cpu.txt
+++ b/examples/v1beta1/nas/enas-cnn-cifar10/requirements-cpu.txt
@@ -1,2 +1,2 @@
-tensorflow==1.15.2
+tensorflow==1.15.4
 keras==2.2.4

--- a/examples/v1beta1/nas/enas-cnn-cifar10/requirements-gpu.txt
+++ b/examples/v1beta1/nas/enas-cnn-cifar10/requirements-gpu.txt
@@ -1,2 +1,2 @@
-tensorflow-gpu==1.15.2
+tensorflow-gpu==1.15.4
 keras==2.2.4


### PR DESCRIPTION
I manually changed TF version to 1.15.4, I verified and it should work.

Related PRs: https://github.com/kubeflow/katib/pull/1353, https://github.com/kubeflow/katib/pull/1352, https://github.com/kubeflow/katib/pull/1351.
We should re-created PR, since our CI has been changed.

/assign @gaocegege @johnugeorge 