### PR TITLE
Update Python SDK version to 0.10.0

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -36,6 +36,7 @@ workflows:
       - cmd/suggestion/goptuna/v1beta1/*
       - cmd/ui/v1beta1/*
       - examples/v1beta1/*
+      - sdk/python/v1beta1/*
       - test/e2e/v1beta1/*
       - test/scripts/v1beta1/*
       - test/suggestion/v1beta1/*

--- a/sdk/python/v1beta1/README.md
+++ b/sdk/python/v1beta1/README.md
@@ -36,7 +36,7 @@ Our SDK is located in [`kubeflow-katib` PyPi package](https://pypi.org/project/k
 If you want to release new SDK version with updated API you have to ask anyone from
 [OWNERS](https://github.com/kubeflow/katib/blob/master/OWNERS) file to follow these steps:
 
-- Go to SDK directory: `cd sdk/python/v1beta1`
+- Go to the SDK directory: `cd sdk/python/v1beta1`
 
 - Update version in [`setup.py`](https://github.com/kubeflow/katib/blob/master/sdk/python/v1beta1/setup.py#L22)
 
@@ -46,7 +46,7 @@ If you want to release new SDK version with updated API you have to ask anyone f
 
 - Remove created directories: `rm -r dist/ build/`
 
-- Submit PR to with updated version
+- Submit PR with updated version
 
 ## Getting Started
 

--- a/sdk/python/v1beta1/README.md
+++ b/sdk/python/v1beta1/README.md
@@ -36,11 +36,17 @@ Our SDK is located in [`kubeflow-katib` PyPi package](https://pypi.org/project/k
 If you want to release new SDK version with updated API you have to ask anyone from
 [OWNERS](https://github.com/kubeflow/katib/blob/master/OWNERS) file to follow these steps:
 
+- Go to SDK directory: `cd sdk/python/v1beta1`
+
 - Update version in [`setup.py`](https://github.com/kubeflow/katib/blob/master/sdk/python/v1beta1/setup.py#L22)
 
 - Generate distributive packages: `python3 setup.py sdist bdist_wheel`
 
 - Upload package to PyPi: `twine upload dist/*`
+
+- Remove created directories: `rm -r dist/ build/`
+
+- Submit PR to with updated version
 
 ## Getting Started
 

--- a/sdk/python/v1beta1/setup.py
+++ b/sdk/python/v1beta1/setup.py
@@ -19,7 +19,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name='kubeflow-katib',
-    version='0.0.6',
+    version='0.10.0',
     author="Kubeflow Authors",
     author_email='premnath.vel@gmail.com',
     license="Apache License Version 2.0",

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-from setuptools import setup
-
-setup(name="pkg",
-      packages=["pkg"])


### PR DESCRIPTION
I updated SDK for the Katib 0.10 release.
Let's stick SDK version with Katib version to be consistent between the releases.
Fixes: https://github.com/kubeflow/katib/issues/1331.

If we change any API before the Katib 0.11 release, we can release new Patch SDK version. For example: 
`kubeflow-katib: 0.10.1`.

As well, I delete `setup.py`. It was added in this PR: https://github.com/kubeflow/katib/pull/406, we are not using it in [`python-test.sh`](https://github.com/kubeflow/katib/blob/master/test/scripts/v1beta1/python-tests.sh).

What do you think @gaocegege @johnugeorge ?
