### PR TITLE
Fix: Add taskruns to Katib controller role to run Tekton Pipelines

### DIFF
--- a/manifests/v1beta1/katib-controller/rbac.yaml
+++ b/manifests/v1beta1/katib-controller/rbac.yaml
@@ -77,6 +77,7 @@ rules:
       - tekton.dev
     resources:
       - pipelineruns
+      - taskruns
     verbs:
       - "*"
   - apiGroups:

--- a/pkg/webhook/v1beta1/pod/inject_webhook.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook.go
@@ -72,10 +72,8 @@ func (s *sidecarInjector) Handle(ctx context.Context, req types.Request) types.R
 	if err != nil {
 		log.Info("Unable to run MutationRequired", "Error", err)
 		return admission.ErrorResponse(http.StatusInternalServerError, err)
-	} else {
-		if !needMutate {
-			return admission.ValidationResponse(true, "")
-		}
+	} else if !needMutate {
+		return admission.ValidationResponse(true, "")
 	}
 
 	// Do mutation

--- a/pkg/webhook/v1beta1/pod/inject_webhook.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook.go
@@ -70,6 +70,7 @@ func (s *sidecarInjector) Handle(ctx context.Context, req types.Request) types.R
 	// Check whether the pod need to be mutated
 	needMutate, err := s.MutationRequired(pod, namespace)
 	if err != nil {
+		log.Info("Unable to run MutationRequired", "Error", err)
 		return admission.ErrorResponse(http.StatusInternalServerError, err)
 	} else {
 		if !needMutate {


### PR DESCRIPTION
We should add this role to run Tekton Pipeline.

The workflow is that:
Katib `Trial` -> Tekton `PipelineRun` -> Tekton `TaskRun` -> Kubernetes `Pod`.
Katib controller should have access to all of these resources.

/assign @johnugeorge @gaocegege 
