### PR TITLE
select non-root process by user id instead of parent

### DIFF
--- a/pkg/metricscollector/v1beta1/common/pns.go
+++ b/pkg/metricscollector/v1beta1/common/pns.go
@@ -69,14 +69,14 @@ func GetMainProcesses(completedMarkedDirPath string) (map[int]bool, int, error) 
 			return nil, 0, fmt.Errorf("Failed to create new Process from pid %v, error: %v", pid, err)
 		}
 
-		// Get parent process
-		ppid, err := proc.Ppid()
+		// Get process uids
+		pidUids, err := proc.Uids()
 		if err != nil {
-			return nil, 0, fmt.Errorf("Unable to get parent pid for pid: %v, error: %v", ppid, err)
+			return nil, 0, fmt.Errorf("Unable to get uids for pid: %v, error: %v", pidUids, err)
 		}
 
-		// Ignore the pause container, our own pid, and non-root processes (parent pid != 0)
-		if pid == 1 || pid == int32(thisPID) || ppid != 0 {
+		// Ignore the pause container, our own pid, and non-root processes (first pid user id != 0)
+		if pid == 1 || pid == int32(thisPID) || pidUids[0] != 0 {
 			continue
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Enables running trials with Istio enabled, and any other process that run as non root.

**Which issue(s) this PR fixes**:
Fixes #1383 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
