### PR TITLE
Fix compare step for the early stopping

### DIFF
--- a/cmd/metricscollector/v1beta1/file-metricscollector/main.go
+++ b/cmd/metricscollector/v1beta1/file-metricscollector/main.go
@@ -228,9 +228,9 @@ func watchMetricsFile(mFile string, stopRules stopRulesFlag, filters []string) {
 
 					// Reduce steps if appropriate metric is reported.
 					// Once rest steps are empty we apply early stopping rule.
-					if restSteps, ok := metricStartStep[metricName]; ok {
+					if _, ok := metricStartStep[metricName]; ok {
 						metricStartStep[metricName]--
-						if restSteps != 0 {
+						if metricStartStep[metricName] != 0 {
 							continue
 						}
 					}

--- a/examples/v1beta1/early-stopping/median-stop.yaml
+++ b/examples/v1beta1/early-stopping/median-stop.yaml
@@ -21,13 +21,6 @@ spec:
         value: "3"
       - name: start_step
         value: "5"
-  metricsCollectorSpec:
-    collector:
-      kind: StdOut
-    source:
-      filter:
-        metricsFormat:
-          - ([\w|-]+)\s*=\s*((-?\d+)(\.\d+)?)
   parallelTrialCount: 2
   maxTrialCount: 15
   maxFailedTrialCount: 3


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1385.
We should not wait one more step to compare values.
As well, I removed unnecessary params from the early stopping yaml.

/assign @gaocegege @johnugeorge 