### PR TITLE
Add Stale config to close inactivity issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,20 @@
+# Configuration for stale probot https://probot.github.io/apps/stale/
+
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 20
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - lifecycle/frozen
+# Label to use when marking an issue as stale
+staleLabel: lifecycle/stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because it has not had recent
+  activity. Please comment "/reopen" to reopen it.


### PR DESCRIPTION
I've added Stale config so we can better track inactive issues in Katib.

/assign @gaocegege @johnugeorge 
/cc @jlewi 