### PR TITLE
Move Adopters file

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -2,12 +2,13 @@
 
 Below are the adopters of project Katib. If you are using Katib
 please add yourself into the following list by a pull request.
+Please keep the list in alphabetical order.
 
 | Organization | Contact | Description of Use |
 | ------------ | ------- | ------------------ |
-| [caicloud](https://caicloud.io/) |[@gaocegege](https://github.com/gaocegege) | Hyperparameter tuning in Caicloud Cloud-Native AI Platform |
 | [Ant Group](https://www.antgroup.com/) |[@ohmystack](https://github.com/ohmystack) | Automatic training in Ant Group internal AI Platform |
-| [cisco](https://cisco.com/) |[@ramdootp](https://github.com/ramdootp) | Hyperparameter tuning for conversational AI interface using Rasa |
 | [babylon health](https://www.babylonhealth.com/) |[@jeremievallee](https://github.com/jeremievallee) | Hyperparameter tuning for AIR internal AI Platform |
+| [caicloud](https://caicloud.io/) |[@gaocegege](https://github.com/gaocegege) | Hyperparameter tuning in Caicloud Cloud-Native AI Platform |
+| [cisco](https://cisco.com/) |[@ramdootp](https://github.com/ramdootp) | Hyperparameter tuning for conversational AI interface using Rasa |
 | [cubonacci](https://www.cubonacci.com) |[@janvdvegt](https://github.com/janvdvegt) | Hyperparameter tuning within the Cubonacci machine learning platform |
 | [karrot](https://uk.karrotmarket.com/) |[@muik](https://github.com/muik) | Hyperparameter tuning in Karrot ML Platform |

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ Please see [Quick Start Guide](./docs/quick-start.md).
 
 ## Who are using Katib?
 
-Please see [adopters.md](./docs/community/adopters.md).
+Please see [ADOPTERS.md](ADOPTERS.md).
 
 ## CONTRIBUTING
 


### PR DESCRIPTION
I moved Adopters file to the root and more users can see it.
Also, let's keep the list in alphabetical order.

/assign @gaocegege @johnugeorge 