### PR TITLE
Feature/waitallprocesses config

### DIFF
--- a/cmd/metricscollector/v1beta1/file-metricscollector/main.go
+++ b/cmd/metricscollector/v1beta1/file-metricscollector/main.go
@@ -353,11 +353,7 @@ func main() {
 		go printMetricsFile(*metricsFilePath)
 	}
 
-	waitAll, err := strconv.ParseBool(*waitAllProcesses)
-	if err != nil {
-		klog.Errorf("Cannot parse %s to bool, defaulting to waitAllProcesses=%s", *waitAllProcesses, common.DefaultWaitAllProcesses)
-		waitAll, _ = strconv.ParseBool(common.DefaultWaitAllProcesses)
-	}
+	waitAll, _ := strconv.ParseBool(*waitAllProcesses)
 
 	wopts := common.WaitPidsOpts{
 		PollInterval:           *pollInterval,

--- a/cmd/metricscollector/v1beta1/file-metricscollector/main.go
+++ b/cmd/metricscollector/v1beta1/file-metricscollector/main.go
@@ -107,7 +107,7 @@ var (
 	metricFilters        = flag.String("f", "", "Metric filters")
 	pollInterval         = flag.Duration("p", common.DefaultPollInterval, "Poll interval between running processes check")
 	timeout              = flag.Duration("timeout", common.DefaultTimeout, "Timeout before invoke error during running processes check")
-	waitAll              = flag.Bool("w", common.DefaultWaitAll, "Whether wait for all other main process of container exiting")
+	waitAllProcesses     = flag.String("w", common.DefaultWaitAllProcesses, "Whether wait for all other main process of container exiting")
 	stopRules            stopRulesFlag
 	isEarlyStopped       = false
 )
@@ -353,10 +353,16 @@ func main() {
 		go printMetricsFile(*metricsFilePath)
 	}
 
+	waitAll, err := strconv.ParseBool(*waitAllProcesses)
+	if err != nil {
+		klog.Errorf("Cannot parse %s to bool, defaulting to waitAllProcesses=%s", *waitAllProcesses, common.DefaultWaitAllProcesses)
+		waitAll, _ = strconv.ParseBool(common.DefaultWaitAllProcesses)
+	}
+
 	wopts := common.WaitPidsOpts{
 		PollInterval:           *pollInterval,
 		Timeout:                *timeout,
-		WaitAll:                *waitAll,
+		WaitAll:                waitAll,
 		CompletedMarkedDirPath: filepath.Dir(*metricsFilePath),
 	}
 	if err := common.WaitMainProcesses(wopts); err != nil {

--- a/cmd/metricscollector/v1beta1/tfevent-metricscollector/main.py
+++ b/cmd/metricscollector/v1beta1/tfevent-metricscollector/main.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
     logger.addHandler(handler)
     logger.propagate = False
     opt = parse_options()
-    wait_all_processes = opt.wait_all_processes.lower() != "false"
+    wait_all_processes = opt.wait_all_processes.lower() == "true"
     db_manager_server = opt.db_manager_server_addr.split(':')
     if len(db_manager_server) != 2:
         raise Exception("Invalid Katib DB manager service address: %s" %

--- a/cmd/metricscollector/v1beta1/tfevent-metricscollector/main.py
+++ b/cmd/metricscollector/v1beta1/tfevent-metricscollector/main.py
@@ -24,7 +24,7 @@ def parse_options():
     parser.add_argument("-f", "--metric_filters", type=str, default="")
     parser.add_argument("-p", "--poll_interval", type=int, default=const.DEFAULT_POLL_INTERVAL)
     parser.add_argument("-timeout", "--timeout", type=int, default=const.DEFAULT_TIMEOUT)
-    parser.add_argument("-w", "--wait_all_processes", type=str, default=const.DEFAULT_WAIT_ALL)
+    parser.add_argument("-w", "--wait_all_processes", type=str, default=const.DEFAULT_WAIT_ALL_PROCESSES)
 
     opt = parser.parse_args()
     return opt

--- a/cmd/metricscollector/v1beta1/tfevent-metricscollector/main.py
+++ b/cmd/metricscollector/v1beta1/tfevent-metricscollector/main.py
@@ -38,13 +38,7 @@ if __name__ == '__main__':
     logger.addHandler(handler)
     logger.propagate = False
     opt = parse_options()
-    try:
-        wait_all_processes = bool(opt.wait_all_processes)
-    except:
-        logger.error(
-            "Cannot parse {} to bool, defaulting to waitAllProcesses={}".format(opt.wait_all_processes,
-                                                                                const.DEFAULT_WAIT_ALL))
-        wait_all_processes = bool(const.DEFAULT_WAIT_ALL)
+    wait_all_processes = opt.wait_all_processes.lower() != "false"
     db_manager_server = opt.db_manager_server_addr.split(':')
     if len(db_manager_server) != 2:
         raise Exception("Invalid Katib DB manager service address: %s" %

--- a/cmd/metricscollector/v1beta1/tfevent-metricscollector/main.py
+++ b/cmd/metricscollector/v1beta1/tfevent-metricscollector/main.py
@@ -24,7 +24,7 @@ def parse_options():
     parser.add_argument("-f", "--metric_filters", type=str, default="")
     parser.add_argument("-p", "--poll_interval", type=int, default=const.DEFAULT_POLL_INTERVAL)
     parser.add_argument("-timeout", "--timeout", type=int, default=const.DEFAULT_TIMEOUT)
-    parser.add_argument("-w", "--wait_all", type=bool, default=const.DEFAULT_WAIT_ALL)
+    parser.add_argument("-w", "--wait_all_processes", type=str, default=const.DEFAULT_WAIT_ALL)
 
     opt = parser.parse_args()
     return opt
@@ -38,6 +38,13 @@ if __name__ == '__main__':
     logger.addHandler(handler)
     logger.propagate = False
     opt = parse_options()
+    try:
+        wait_all_processes = bool(opt.wait_all_processes)
+    except:
+        logger.error(
+            "Cannot parse {} to bool, defaulting to waitAllProcesses={}".format(opt.wait_all_processes,
+                                                                                const.DEFAULT_WAIT_ALL))
+        wait_all_processes = bool(const.DEFAULT_WAIT_ALL)
     db_manager_server = opt.db_manager_server_addr.split(':')
     if len(db_manager_server) != 2:
         raise Exception("Invalid Katib DB manager service address: %s" %
@@ -46,7 +53,7 @@ if __name__ == '__main__':
     WaitMainProcesses(
         pool_interval=opt.poll_interval,
         timout=opt.timeout,
-        wait_all=opt.wait_all,
+        wait_all=wait_all_processes,
         completed_marked_dir=opt.metrics_file_dir)
 
     mc = MetricsCollector(opt.metric_names.split(';'))

--- a/pkg/metricscollector/v1beta1/common/const.go
+++ b/pkg/metricscollector/v1beta1/common/const.go
@@ -27,7 +27,7 @@ const (
 	// To run without timeout set value to 0
 	DefaultTimeout = 0
 	// DefaultWaitAll is the default value whether wait for all other main process of container exiting
-	DefaultWaitAll = true
+	DefaultWaitAllProcesses = "true"
 	// TrainingCompleted is the job finished marker in $$$$.pid file when main training process is completed
 	TrainingCompleted = "completed"
 

--- a/pkg/metricscollector/v1beta1/common/const.py
+++ b/pkg/metricscollector/v1beta1/common/const.py
@@ -3,7 +3,7 @@ DEFAULT_POLL_INTERVAL = 1
 # Default value for timeout before invoke error during running processes check
 DEFAULT_TIMEOUT = 0
 # Default value whether wait for all other main process of container exiting
-DEFAULT_WAIT_ALL = "True"
+DEFAULT_WAIT_ALL_PROCESSES = "True"
 # Default value for directory where TF event metrics are reported
 DEFAULT_METRICS_FILE_DIR = "/log"
 # Job finished marker in $$$$.pid file when main process is completed

--- a/pkg/metricscollector/v1beta1/common/const.py
+++ b/pkg/metricscollector/v1beta1/common/const.py
@@ -3,7 +3,7 @@ DEFAULT_POLL_INTERVAL = 1
 # Default value for timeout before invoke error during running processes check
 DEFAULT_TIMEOUT = 0
 # Default value whether wait for all other main process of container exiting
-DEFAULT_WAIT_ALL = True
+DEFAULT_WAIT_ALL = "True"
 # Default value for directory where TF event metrics are reported
 DEFAULT_METRICS_FILE_DIR = "/log"
 # Job finished marker in $$$$.pid file when main process is completed

--- a/pkg/util/v1beta1/katibconfig/config.go
+++ b/pkg/util/v1beta1/katibconfig/config.go
@@ -18,12 +18,12 @@ import (
 // SuggestionConfig is the JSON suggestion structure in Katib config.
 type SuggestionConfig struct {
 	Image                     string                           `json:"image"`
-	ImagePullPolicy           corev1.PullPolicy                `json:"imagePullPolicy"`
-	Resource                  corev1.ResourceRequirements      `json:"resources"`
-	ServiceAccountName        string                           `json:"serviceAccountName"`
-	VolumeMountPath           string                           `json:"volumeMountPath"`
-	PersistentVolumeClaimSpec corev1.PersistentVolumeClaimSpec `json:"persistentVolumeClaimSpec"`
-	PersistentVolumeSpec      corev1.PersistentVolumeSpec      `json:"persistentVolumeSpec"`
+	ImagePullPolicy           corev1.PullPolicy                `json:"imagePullPolicy,omitempty"`
+	Resource                  corev1.ResourceRequirements      `json:"resources,omitempty"`
+	ServiceAccountName        string                           `json:"serviceAccountName,omitempty"`
+	VolumeMountPath           string                           `json:"volumeMountPath,omitempty"`
+	PersistentVolumeClaimSpec corev1.PersistentVolumeClaimSpec `json:"persistentVolumeClaimSpec,omitempty"`
+	PersistentVolumeSpec      corev1.PersistentVolumeSpec      `json:"persistentVolumeSpec,omitempty"`
 }
 
 // MetricsCollectorConfig is the JSON metrics collector structure in Katib config.
@@ -37,7 +37,7 @@ type MetricsCollectorConfig struct {
 // EarlyStoppingConfig is the JSON early stopping structure in Katib config.
 type EarlyStoppingConfig struct {
 	Image           string            `json:"image"`
-	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy"`
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 }
 
 // GetSuggestionConfigData gets the config data for the given suggestion algorithm name.

--- a/pkg/util/v1beta1/katibconfig/config.go
+++ b/pkg/util/v1beta1/katibconfig/config.go
@@ -29,9 +29,9 @@ type SuggestionConfig struct {
 // MetricsCollectorConfig is the JSON metrics collector structure in Katib config.
 type MetricsCollectorConfig struct {
 	Image            string                      `json:"image"`
-	ImagePullPolicy  corev1.PullPolicy           `json:"imagePullPolicy"`
-	Resource         corev1.ResourceRequirements `json:"resources"`
-	WaitAllProcesses string                      `json:"waitAllProcesses"`
+	ImagePullPolicy  corev1.PullPolicy           `json:"imagePullPolicy,omitempty"`
+	Resource         corev1.ResourceRequirements `json:"resources,omitempty"`
+	WaitAllProcesses *bool                       `json:"waitAllProcesses,omitempty"`
 }
 
 // EarlyStoppingConfig is the JSON early stopping structure in Katib config.

--- a/pkg/util/v1beta1/katibconfig/config.go
+++ b/pkg/util/v1beta1/katibconfig/config.go
@@ -28,9 +28,10 @@ type SuggestionConfig struct {
 
 // MetricsCollectorConfig is the JSON metrics collector structure in Katib config.
 type MetricsCollectorConfig struct {
-	Image           string                      `json:"image"`
-	ImagePullPolicy corev1.PullPolicy           `json:"imagePullPolicy"`
-	Resource        corev1.ResourceRequirements `json:"resources"`
+	Image            string                      `json:"image"`
+	ImagePullPolicy  corev1.PullPolicy           `json:"imagePullPolicy"`
+	Resource         corev1.ResourceRequirements `json:"resources"`
+	WaitAllProcesses string                      `json:"waitAllProcesses"`
 }
 
 // EarlyStoppingConfig is the JSON early stopping structure in Katib config.

--- a/pkg/webhook/v1beta1/pod/inject_webhook.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook.go
@@ -295,8 +295,8 @@ func (s *sidecarInjector) getMetricsCollectorArgs(trial *trialsv1beta1.Trial, me
 	if mc.Source != nil && mc.Source.Filter != nil && len(mc.Source.Filter.MetricsFormat) > 0 {
 		args = append(args, "-f", strings.Join(mc.Source.Filter.MetricsFormat, ";"))
 	}
-	if metricsCollectorConfigData.WaitAllProcesses != "" {
-		args = append(args, "-w", metricsCollectorConfigData.WaitAllProcesses)
+	if metricsCollectorConfigData.WaitAllProcesses != nil {
+		args = append(args, "-w", strconv.FormatBool(*metricsCollectorConfigData.WaitAllProcesses))
 	}
 	// Add stop rules and service endpoint for Early Stopping
 	if len(esRules) > 0 {

--- a/pkg/webhook/v1beta1/pod/inject_webhook_test.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook_test.go
@@ -254,7 +254,7 @@ func TestGetMetricsCollectorArgs(t *testing.T) {
 	testMetricName := "accuracy"
 	katibDBAddress := fmt.Sprintf("katib-db-manager.%v:%v", testNamespace, consts.DefaultSuggestionPort)
 	katibEarlyStopAddress := fmt.Sprintf("%v-%v.%v:%v", testSuggestionName, testAlgorithm, testNamespace, consts.DefaultEarlyStoppingPort)
-
+	waitAllProcessesValue := false
 	testPath := "/test/path"
 
 	earlyStoppingRules := []string{
@@ -308,7 +308,7 @@ func TestGetMetricsCollectorArgs(t *testing.T) {
 				},
 			},
 			KatibConfig: katibconfig.MetricsCollectorConfig{
-				WaitAllProcesses: "false",
+				WaitAllProcesses: &waitAllProcessesValue,
 			},
 			ExpectedArgs: []string{
 				"-t", testTrialName,

--- a/pkg/webhook/v1beta1/pod/inject_webhook_test.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook_test.go
@@ -3,6 +3,7 @@ package pod
 import (
 	"context"
 	"fmt"
+	"github.com/kubeflow/katib/pkg/util/v1beta1/katibconfig"
 	"path/filepath"
 	"reflect"
 	"sync"
@@ -293,6 +294,7 @@ func TestGetMetricsCollectorArgs(t *testing.T) {
 		MetricNames        string
 		MCSpec             common.MetricsCollectorSpec
 		EarlyStoppingRules []string
+		KatibConfig        katibconfig.MetricsCollectorConfig
 		ExpectedArgs       []string
 		Name               string
 		Err                bool
@@ -305,12 +307,16 @@ func TestGetMetricsCollectorArgs(t *testing.T) {
 					Kind: common.StdOutCollector,
 				},
 			},
+			KatibConfig: katibconfig.MetricsCollectorConfig{
+				WaitAllProcesses: "false",
+			},
 			ExpectedArgs: []string{
 				"-t", testTrialName,
 				"-m", testMetricName,
 				"-o-type", string(testObjective),
 				"-s-db", katibDBAddress,
 				"-path", common.DefaultFilePath,
+				"-w", "false",
 			},
 			Name: "StdOut MC",
 		},
@@ -333,6 +339,7 @@ func TestGetMetricsCollectorArgs(t *testing.T) {
 					},
 				},
 			},
+			KatibConfig: katibconfig.MetricsCollectorConfig{},
 			ExpectedArgs: []string{
 				"-t", testTrialName,
 				"-m", testMetricName,
@@ -356,6 +363,7 @@ func TestGetMetricsCollectorArgs(t *testing.T) {
 					},
 				},
 			},
+			KatibConfig: katibconfig.MetricsCollectorConfig{},
 			ExpectedArgs: []string{
 				"-t", testTrialName,
 				"-m", testMetricName,
@@ -373,6 +381,7 @@ func TestGetMetricsCollectorArgs(t *testing.T) {
 					Kind: common.CustomCollector,
 				},
 			},
+			KatibConfig: katibconfig.MetricsCollectorConfig{},
 			ExpectedArgs: []string{
 				"-t", testTrialName,
 				"-m", testMetricName,
@@ -394,6 +403,7 @@ func TestGetMetricsCollectorArgs(t *testing.T) {
 					},
 				},
 			},
+			KatibConfig: katibconfig.MetricsCollectorConfig{},
 			ExpectedArgs: []string{
 				"-t", testTrialName,
 				"-m", testMetricName,
@@ -411,6 +421,7 @@ func TestGetMetricsCollectorArgs(t *testing.T) {
 					Kind: common.PrometheusMetricCollector,
 				},
 			},
+			KatibConfig: katibconfig.MetricsCollectorConfig{},
 			ExpectedArgs: []string{
 				"-t", testTrialName,
 				"-m", testMetricName,
@@ -428,6 +439,7 @@ func TestGetMetricsCollectorArgs(t *testing.T) {
 				},
 			},
 			EarlyStoppingRules: earlyStoppingRules,
+			KatibConfig:        katibconfig.MetricsCollectorConfig{},
 			ExpectedArgs: []string{
 				"-t", testTrialName,
 				"-m", testMetricName,
@@ -452,6 +464,7 @@ func TestGetMetricsCollectorArgs(t *testing.T) {
 				},
 			},
 			EarlyStoppingRules: earlyStoppingRules,
+			KatibConfig:        katibconfig.MetricsCollectorConfig{},
 			Name:               "Trial with invalid Experiment label name. Suggestion is not created",
 			Err:                true,
 		},
@@ -465,7 +478,7 @@ func TestGetMetricsCollectorArgs(t *testing.T) {
 	}, timeout).ShouldNot(gomega.HaveOccurred())
 
 	for _, tc := range testCases {
-		args, err := si.getMetricsCollectorArgs(tc.Trial, tc.MetricNames, tc.MCSpec, tc.EarlyStoppingRules)
+		args, err := si.getMetricsCollectorArgs(tc.Trial, tc.MetricNames, tc.MCSpec, tc.KatibConfig, tc.EarlyStoppingRules)
 
 		if !tc.Err && err != nil {
 			t.Errorf("Case: %v failed. Expected nil, got %v", tc.Name, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Adds the waitAllProcesses option to the katib-config metricsCollector spec. It is made optional, defaulting to true.

**Which issue(s) this PR fixes** 
See #1383 for discussion

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Available waitAllProcesses option to katib-config's metrics-collector-sidecar spec.
```
