### PR TITLE
Remove duecredit pkg from the Suggestions

### DIFF
--- a/cmd/suggestion/chocolate/v1beta1/requirements.txt
+++ b/cmd/suggestion/chocolate/v1beta1/requirements.txt
@@ -1,5 +1,4 @@
 grpcio==1.23.0
-duecredit===0.7.0
 cloudpickle==0.5.6
 numpy>=1.13.3
 scikit-learn>=0.19.0

--- a/cmd/suggestion/hyperband/v1beta1/requirements.txt
+++ b/cmd/suggestion/hyperband/v1beta1/requirements.txt
@@ -1,5 +1,4 @@
 grpcio==1.23.0
-duecredit===0.7.0
 cloudpickle==0.5.6
 numpy>=1.13.3
 scikit-learn>=0.19.0

--- a/cmd/suggestion/hyperopt/v1beta1/requirements.txt
+++ b/cmd/suggestion/hyperopt/v1beta1/requirements.txt
@@ -1,5 +1,4 @@
 grpcio==1.23.0
-duecredit===0.7.0
 cloudpickle==0.5.6
 numpy>=1.13.3
 scikit-learn>=0.19.0

--- a/cmd/suggestion/skopt/v1beta1/requirements.txt
+++ b/cmd/suggestion/skopt/v1beta1/requirements.txt
@@ -1,5 +1,4 @@
 grpcio==1.23.0
-duecredit===0.7.0
 cloudpickle==0.5.6
 numpy>=1.13.3
 scikit-learn==0.22.0


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1399.

I think we don't need `duecredit` package in our Suggestions.

/assign @gaocegege @johnugeorge 