### PR TITLE
Fix indentation in the OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,8 @@
 approvers:
-    - gaocegege
-    - hougangliu
-    - johnugeorge
-    - andreyvelich
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
 reviewers:
-    - sperlingxx
-    - c-bata
+  - c-bata
+  - sperlingxx


### PR DESCRIPTION
See comment: https://github.com/kubeflow/katib/pull/1403#issuecomment-737420797.
I remove redundant indentation in the OWNERS file and alphabetise names.

/assign @gaocegege @johnugeorge 