### PR TITLE
add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,405 @@
+updates:
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: examples/v1beta1/file-metrics-collector
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: examples/v1beta1/mxnet-mnist
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: examples/v1beta1/nas/enas-cnn-cifar10
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: examples/v1beta1/nas/darts-cnn-cifar10
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/katib-controller/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/ui/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/suggestion/hyperband/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/suggestion/skopt/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/suggestion/chocolate/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/suggestion/hyperopt/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/suggestion/nas/darts/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/suggestion/nas/enas/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/suggestion/goptuna/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/earlystopping/medianstop/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/db-manager/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/metricscollector/v1beta1/file-metricscollector
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/metricscollector/v1beta1/tfevent-metricscollector
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: pkg/apis/manager/v1beta1/gen-doc
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: pkg/ui/v1beta1/frontend
+  open-pull-requests-limit: 10
+  package-ecosystem: npm
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: sdk/python/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/suggestion/hyperband/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/suggestion/skopt/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/suggestion/chocolate/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/suggestion/hyperopt/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/suggestion/nas/darts/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/suggestion/nas/enas/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/earlystopping/medianstop/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: cmd/metricscollector/v1beta1/tfevent-metricscollector
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: test/suggestion/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: test/e2e/v1beta1
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - gaocegege
+  - hougangliu
+  - johnugeorge
+  directory: vendor
+  open-pull-requests-limit: 10
+  package-ecosystem: gomod
+  reviewers:
+  - c-bata
+  - sperlingxx
+  schedule:
+    interval: daily
+version: 2

--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,6 @@ endif
 # Prettier UI format check for Katib v1beta1
 prettier-check:
 	npm run format:check --prefix pkg/ui/v1beta1/frontend
+
+build-dependabot:
+	python3 hack/create_dependabot.py

--- a/hack/create_dependabot.py
+++ b/hack/create_dependabot.py
@@ -1,0 +1,100 @@
+import yaml
+import collections
+from pathlib import Path
+
+dependabot = {}
+dependabot['version'] = 2
+dependabot['updates'] = []
+ignored_folders = ['node_modules', 'dist', '.git', 'deprecated']
+
+def get_owners(path):
+    while not Path(path/'OWNERS').is_file():
+        path = path.parent.absolute()
+    with open(path/'OWNERS') as owner_file:
+        owners = yaml.load(owner_file)
+        return owners
+
+def get_docker_paths():
+    dockerfile_list = list(repo_path.glob('**/*ockerfile*'))
+    docker_clean_list = []
+    for dockerfile in dockerfile_list:
+        if all(x not in str(dockerfile) for x in ignored_folders):
+            if dockerfile.parents[0] not in docker_clean_list:
+                docker_clean_list.append(dockerfile.parents[0])
+    return docker_clean_list
+
+def get_npm_paths():
+    npm_list = list(repo_path.glob('**/package*.json'))
+    npm_clean_list = []
+    for npm_file in npm_list:
+        if all(x not in str(npm_file) for x in ignored_folders):
+            if npm_file.parents[0] not in npm_clean_list:
+                npm_clean_list.append(npm_file.parents[0])
+    return npm_clean_list
+
+def get_pip_paths():
+    pip_list = list(repo_path.glob('**/*requirements.txt'))
+    pip_clean_list = []
+    for pip_file in pip_list:
+        if all(x not in str(pip_file) for x in ignored_folders):
+            if pip_file.parents[0] not in pip_clean_list:
+                pip_clean_list.append(pip_file.parents[0])
+    return pip_clean_list
+
+def get_go_paths():
+    go_list = list(repo_path.glob('**/go.*'))
+    go_clean_list = []
+    for go_file in go_list:
+        if all(x not in str(go_file) for x in ignored_folders):
+            if go_file.parents[0] not in go_clean_list:
+                go_clean_list.append(go_file.parents[0])
+    return go_clean_list
+
+def append_updates(ecosystem, directory, assignees, reviewers=None):
+    config = {}
+    config['package-ecosystem'] = ecosystem
+    config['directory'] = directory
+    config['schedule']= {}
+    config['schedule']['interval'] = 'daily'
+    config['open-pull-requests-limit'] = 10
+    config['assignees'] = assignees
+    if reviewers:
+        config['reviewers'] = reviewers
+    dependabot['updates'].append(config)
+
+def main():
+    for docker_path in get_docker_paths():
+        string_path = str(docker_path)
+        assignees = get_owners(docker_path).get('approvers')
+        reviewers = get_owners(docker_path).get('reviewers')
+        append_updates('docker', string_path, assignees, reviewers)
+
+    for npm_path in get_npm_paths():
+        string_path = str(npm_path)
+        assignees = get_owners(npm_path).get('approvers')
+        reviewers = get_owners(npm_path).get('reviewers')
+        append_updates('npm', string_path, assignees, reviewers)
+
+    for pip_path in get_pip_paths():
+        string_path = str(pip_path)
+        assignees = get_owners(pip_path).get('approvers')
+        reviewers = get_owners(pip_path).get('reviewers')
+        append_updates('pip', string_path, assignees, reviewers)
+
+    for go_path in get_go_paths():
+        string_path = str(go_path)
+        assignees = get_owners(go_path).get('approvers')
+        reviewers = get_owners(go_path).get('reviewers')
+        append_updates('gomod', string_path, assignees, reviewers)
+
+    with open('.github/dependabot.yml', 'w') as outfile:
+        yaml.dump(dependabot, outfile, default_flow_style=False)
+
+    print(get_docker_paths())
+    print(get_npm_paths())
+    print(get_pip_paths())
+    print(get_go_paths())
+
+if __name__ == "__main__":
+    repo_path = Path(__file__).parents[1]
+    main()


### PR DESCRIPTION
Inspired by https://github.com/kubeflow/pipelines/issues/4682  I created a script that will create a config file for depandabot so that it knows what directories to scan. It will scan the repository for files named `*ockerfile*`, `package*.json`, `*requirements.txt` and `go.*`.  It is setup for dockerfiles, npm packages, pip dependencies and gomod at the moment. It is trivial to further customize what folders are selected if further customization is needed. It also parses the closest `OWNERS` file for a given dependency listing file, and assigns the relevant approvers and adds the relevant reviewers to the PRs it creates. 

This is a sibling PR to https://github.com/kubeflow/pipelines/pull/5015, https://github.com/kubeflow/kubeflow/pull/5542, https://github.com/kubeflow/kfserving/pull/1309, https://github.com/kubeflow/arena/pull/403, https://github.com/kubeflow/testing/pull/855, https://github.com/kubeflow/fairing/pull/550 and https://github.com/kubeflow/kfp-tekton/pull/432.

As it stands now, about 60 PRs will be created with this configuration. 

For reference, the PRs that will be created can be found here: https://github.com/DavidSpek/katib/pulls
