### PR TITLE
test: Pin manifests to stable v1.2-branch

### DIFF
--- a/test/workflows/components/workflows-v1beta1.libsonnet
+++ b/test/workflows/components/workflows-v1beta1.libsonnet
@@ -363,7 +363,7 @@
                 ],
                 env: prow_env + [{
                   name: "EXTRA_REPOS",
-                  value: "kubeflow/testing@HEAD;kubeflow/manifests@HEAD",
+                  value: "kubeflow/testing@HEAD;kubeflow/manifests@v1.2-branch",
                 }],
                 image: testWorkerImage,
                 volumeMounts: [


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the e2e tests by pinning the kubeflow/manifests dependency to a stable branch.

**Which issue(s) this PR fixes**:
Fixes #1433
