### PR TITLE
Enhance katib client by adding get_success_trial_details()

### DIFF
--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -352,17 +352,17 @@ class KatibClient(object):
             result = []
             for i in katibtrial.get("items"):
                 output = {}
-                if i.get("metadata", {}).get("ownerReferences")[0].get("name") == name:                    
-                    output["status"] = i.get("status", {}).get(
-                    "conditions", [])[-1].get("type")
-                    output["name"] = i.get("metadata", {}).get("name")
-                    output["hyperparameters"] = i.get("spec", {}).get("parameterAssignments", [])
-                    output["metrics"] = (                            
-                        i.get("status", {})
-                        .get("observation", {})
-                        .get("metrics", [])
-                    )
-                    result.append(output)
+                if i.get("metadata", {}).get("ownerReferences")[0].get("name") == name:
+                    status = i.get("status", {}).get("conditions", [])[-1].get("type")
+                    if status == "Succeeded":
+                        output["name"] = i.get("metadata", {}).get("name")
+                        output["hyperparameters"] = i.get("spec", {}).get("parameterAssignments", [])
+                        output["metrics"] = (
+                            i.get("status", {})
+                            .get("observation", {})
+                            .get("metrics", [])
+                        )
+                        result.append(output)
         except multiprocessing.TimeoutError:
             raise RuntimeError("Timeout trying to getkatib experiment.")
         except client.rest.ApiException as e:

--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -357,8 +357,7 @@ class KatibClient(object):
                     if status == "Succeeded":
                         output["name"] = i.get("metadata", {}).get("name")
                         output["hyperparams"] = i.get("spec", {}).get("parameterAssignments", [])
-                        output["metrics"] = (
-                            # FIXME: Support additional parameters
+                        output["metrics"] = (                            
                             i.get("status", {})
                             .get("observation", {})
                             .get("metrics", [])

--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -334,7 +334,7 @@ class KatibClient(object):
         Get trial details that succeeded for an experiment
         :param name: existing experiment name
         :param namespace: defaults to current or default namespace
-        :return: trials name with hyperparams and metrics
+        :return: trials name with hyperparameters and metrics
         """
         if namespace is None:
             namespace = utils.get_default_target_namespace()
@@ -352,17 +352,17 @@ class KatibClient(object):
             result = []
             for i in katibtrial.get("items"):
                 output = {}
-                if i.get("metadata", {}).get("ownerReferences")[0].get("name") == name:
-                    status = i.get("status", {}).get("conditions", [])[-1].get("type")
-                    if status == "Succeeded":
-                        output["name"] = i.get("metadata", {}).get("name")
-                        output["hyperparams"] = i.get("spec", {}).get("parameterAssignments", [])
-                        output["metrics"] = (                            
-                            i.get("status", {})
-                            .get("observation", {})
-                            .get("metrics", [])
-                        )
-                        result.append(output)
+                if i.get("metadata", {}).get("ownerReferences")[0].get("name") == name:                    
+                    output["status"] = i.get("status", {}).get(
+                    "conditions", [])[-1].get("type")
+                    output["name"] = i.get("metadata", {}).get("name")
+                    output["hyperparameters"] = i.get("spec", {}).get("parameterAssignments", [])
+                    output["metrics"] = (                            
+                        i.get("status", {})
+                        .get("observation", {})
+                        .get("metrics", [])
+                    )
+                    result.append(output)
         except multiprocessing.TimeoutError:
             raise RuntimeError("Timeout trying to getkatib experiment.")
         except client.rest.ApiException as e:

--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -329,6 +329,53 @@ class KatibClient(object):
           {2} ".format(name, namespace, e))
         return result
 
+    def get_success_trial_details(self, name=None, namespace=None):
+        """
+        Get trial details that succeeded for an experiment
+        :param name: existing experiment name
+        :param namespace: defaults to current or default namespace
+        :return: trials name with hyperparams and metrics
+        """
+        if namespace is None:
+            namespace = utils.get_default_target_namespace()
+
+        thread = self.api_instance.list_namespaced_custom_object(
+            constants.KUBEFLOW_GROUP,
+            constants.KATIB_VERSION,
+            namespace=namespace,
+            plural=constants.TRIAL_PLURAL,
+            async_req=True)
+
+        katibtrial = None
+        try:
+            katibtrial = thread.get(constants.APISERVER_TIMEOUT)
+            result = []
+            for i in katibtrial.get("items"):
+                output = {}
+                if i.get("metadata", {}).get("ownerReferences")[0].get("name") == name:
+                    status = i.get("status", {}).get("conditions", [])[-1].get("type")
+                    if status == "Succeeded":
+                        output["name"] = i.get("metadata", {}).get("name")
+                        output["hyperparams"] = i.get("spec", {}).get("parameterAssignments", [])
+                        output["metrics"] = (
+                            # FIXME: Support additional parameters
+                            i.get("status", {})
+                            .get("observation", {})
+                            .get("metrics", [])
+                        )
+                        result.append(output)
+        except multiprocessing.TimeoutError:
+            raise RuntimeError("Timeout trying to getkatib experiment.")
+        except client.rest.ApiException as e:
+            raise RuntimeError(
+                "Exception when calling CustomObjectsApi->get_namespaced_custom_object:\
+          %s\n" % e)
+        except Exception as e:
+            raise RuntimeError(
+                "There was a problem to get experiment {0} in namespace {1}. Exception: \
+          {2} ".format(name, namespace, e))
+        return result
+
     def get_optimal_hyperparameters(self, name=None, namespace=None):
         """
         Get status, currentOptimalTrial with parameterAssignments


### PR DESCRIPTION
Added API to get list of trials that succeded with hyperparam and metrics to KatibClient

```
get_success_trial_details(self, name, namespace) -> List of trial name with hyperparams and metrics
```
