### PR TITLE
Add katib controller flags to developers guide

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -5,6 +5,7 @@
   - [Requirements](#requirements)
   - [Build from source code](#build-from-source-code)
   - [Modify controller APIs](#modify-controller-apis)
+  - [Controller Flags](#controller-flags)
   - [Workflow design](#workflow-design)
   - [Implement a new algorithm and use it in Katib](#implement-a-new-algorithm-and-use-it-in-katib)
   - [Algorithm settings documentation](#algorithm-settings-documentation)
@@ -59,6 +60,21 @@ You can update necessary files as follows:
 ```bash
 make generate
 ```
+
+## Controller Flags
+
+Below is a list of command-line flags accepted by Katib controller:
+
+| Name                            | Type                        | Default             | Description                                                                                                             |
+| ------------------------------- | --------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| cert-localfs                    | bool                        | false               | Store the webhook cert in local file system                                                                             |
+| enable-grpc-probe-in-suggestion | bool                        | true                | Enable grpc probe in suggestions                                                                                        |
+| experiment-suggestion-name      | string                      | "default"           | The implementation of suggestion interface in experiment controller                                                     |
+| metrics-addr                    | string                      | ":8080"             | The address the metric endpoint binds to                                                                                |
+| trial-resources                 | []schema.GroupVersionKind   | null                | The list of resources that can be used as trial template, in the form: Kind.version.group (e.g. TFJob.v1.kubeflow.org)  |
+| webhook-inject-securitycontext  | bool                        | false               | Inject the securityContext of container[0] in the sidecar                                                               |
+| webhook-port                    | int                         | 8443                | The port number to be used for admission webhook server                                                                 |
+| webhook-service-name            | string                      | "katib-controller"  | The service name which will be used in webhook                                                                          |
 
 ## Workflow design
 


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
- Document Katib controller flags in the developer guide
- Flags were based on https://github.com/kubeflow/katib/blob/fe64c18172ba370fb3934552c50442f1da21ec1a/cmd/katib-controller/v1beta1/main.go#L50

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubeflow/katib/issues/1239

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/hold for feedback