### PR TITLE
Re-enable Github Actions

### DIFF
--- a/.github/workflows/test-charmed-katib.yaml
+++ b/.github/workflows/test-charmed-katib.yaml
@@ -2,7 +2,7 @@ name: Charmed Katib
 
 on:
   - push
-  # - pull_request # TODO (andreyvelich): Actions should be fixed in: https://github.com/kubeflow/katib/issues/1453
+  - pull_request
 
 jobs:
   build:
@@ -15,7 +15,7 @@ jobs:
 
       - uses: balchua/microk8s-actions@v0.2.2
         with:
-          channel: "1.19/stable"
+          channel: "1.20/stable"
           addons: '["dns", "storage", "rbac"]'
 
       - name: Install dependencies


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes Github Actions CI testing by bumping up installed version of MicroK8s from 1.19 to 1.20. I haven't delved into why exactly it's failing, but did raise a MicroK8s issue:

https://github.com/ubuntu/microk8s/issues/2083