### PR TITLE
Remove completed TODOs for Katib config

### DIFF
--- a/hack/update-openapigen.sh
+++ b/hack/update-openapigen.sh
@@ -24,10 +24,6 @@ if [[ -z "${GOPATH:-}" ]]; then
   export GOPATH=$(go env GOPATH)
 fi
 
-# TODO (andreyvelich): Temporarily solution to fix "go install: no install location for directory" error
-# We should update the Kubernetes dependencies with controller-runtime to remove this
-export GOBIN=$GOPATH/bin
-
 # Grab code-generator version from go.sum
 CODEGEN_VERSION=$(cd ../../.. && grep 'k8s.io/code-generator' go.sum | awk '{print $2}' | sed 's/\/go.mod//g' | head -1)
 CODEGEN_PKG=$(echo $(go env GOPATH)"/pkg/mod/k8s.io/code-generator@${CODEGEN_VERSION}")

--- a/pkg/controller.v1beta1/suggestion/composer/composer.go
+++ b/pkg/controller.v1beta1/suggestion/composer/composer.go
@@ -114,9 +114,7 @@ func (g *General) DesiredDeployment(s *suggestionsv1beta1.Suggestion) (*appsv1.D
 		}
 	}
 
-	// Attach service account if early stopping is used
-	// TODO (andreyvelich): Document that custom service account
-	// should not be equal "<suggestion-name>-<suggestion-algorithm>".
+	// Attach ServiceAccount if early stopping is used.
 	// For custom service account user should manually add appropriate Role to change Trial status.
 	if s.Spec.EarlyStopping != nil && s.Spec.EarlyStopping.AlgorithmName != "" && suggestionConfigData.ServiceAccountName == "" {
 		d.Spec.Template.Spec.ServiceAccountName = util.GetSuggestionRBACName(s)

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller.go
@@ -221,7 +221,8 @@ func (r *ReconcileSuggestion) ReconcileSuggestion(instance *suggestionsv1beta1.S
 	}
 
 	// If early stopping is used, create RBAC.
-	// ServiceAccount name should be equal <suggestion-name>-<suggestion-algorithm>
+	// If controller should reconcile RBAC,
+	// ServiceAccount name must be equal to <suggestion-name>-<suggestion-algorithm>
 	if instance.Spec.EarlyStopping != nil && instance.Spec.EarlyStopping.AlgorithmName != "" &&
 		deploy.Spec.Template.Spec.ServiceAccountName == util.GetSuggestionRBACName(instance) {
 

--- a/pkg/util/v1beta1/katibconfig/config.go
+++ b/pkg/util/v1beta1/katibconfig/config.go
@@ -127,7 +127,6 @@ func GetSuggestionConfigData(algorithmName string, client client.Client) (Sugges
 		// Set PersistentVolumeReclaimPolicy to "Delete" to automatically delete PV once PVC is deleted.
 		// Kubernetes doesn't allow to specify ownerReferences for the cluster-scoped
 		// resources (which PV is) with namespace-scoped owner (which Suggestion is).
-		// TODO (andreyvelich): We should document this.
 		pvSpec.PersistentVolumeReclaimPolicy = corev1.PersistentVolumeReclaimDelete
 
 		// Set default access modes


### PR DESCRIPTION
Blocked by: https://github.com/kubeflow/website/pull/2533.
I removed few TODOs that we completed.