### PR TITLE
Update Trial images to v1beta1-45c5727

### DIFF
--- a/examples/v1beta1/bayesianoptimization-example.yaml
+++ b/examples/v1beta1/bayesianoptimization-example.yaml
@@ -56,7 +56,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-45c5727
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/cmaes-example.yaml
+++ b/examples/v1beta1/cmaes-example.yaml
@@ -53,7 +53,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-45c5727
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/custom-metricscollector-example.yaml
+++ b/examples/v1beta1/custom-metricscollector-example.yaml
@@ -66,7 +66,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
                 command:
                   - "python3"
                   - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/early-stopping/median-stop.yaml
+++ b/examples/v1beta1/early-stopping/median-stop.yaml
@@ -53,7 +53,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-45c5727
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/file-metricscollector-example.yaml
+++ b/examples/v1beta1/file-metricscollector-example.yaml
@@ -53,7 +53,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
                 command:
                   - "python3"
                   - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/grid-example.yaml
+++ b/examples/v1beta1/grid-example.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-45c5727
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hyperband-example.yaml
+++ b/examples/v1beta1/hyperband-example.yaml
@@ -68,7 +68,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-45c5727
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/metric-strategy-example.yaml
+++ b/examples/v1beta1/metric-strategy-example.yaml
@@ -58,7 +58,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-45c5727
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/nas/darts-example-cpu.yaml
+++ b/examples/v1beta1/nas/darts-example-cpu.yaml
@@ -59,7 +59,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/darts-cnn-cifar10:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/darts-cnn-cifar10:v1beta1-45c5727
                 command:
                   - python3
                   - run_trial.py

--- a/examples/v1beta1/nas/darts-example-gpu.yaml
+++ b/examples/v1beta1/nas/darts-example-gpu.yaml
@@ -76,7 +76,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/darts-cnn-cifar10:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/darts-cnn-cifar10:v1beta1-45c5727
                 command:
                   - python3
                   - run_trial.py

--- a/examples/v1beta1/nas/enas-example-cpu.yaml
+++ b/examples/v1beta1/nas/enas-example-cpu.yaml
@@ -139,7 +139,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-45c5727
                 command:
                   - python3
                   - -u

--- a/examples/v1beta1/nas/enas-example-gpu.yaml
+++ b/examples/v1beta1/nas/enas-example-gpu.yaml
@@ -136,7 +136,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/enas-cnn-cifar10-gpu:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/enas-cnn-cifar10-gpu:v1beta1-45c5727
                 command:
                   - python3
                   - -u

--- a/examples/v1beta1/pytorchjob-example.yaml
+++ b/examples/v1beta1/pytorchjob-example.yaml
@@ -45,7 +45,7 @@ spec:
               spec:
                 containers:
                   - name: pytorch
-                    image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-c6c9172
+                    image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
                     command:
                       - "python3"
                       - "/opt/pytorch-mnist/mnist.py"
@@ -59,7 +59,7 @@ spec:
               spec:
                 containers:
                   - name: pytorch
-                    image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-c6c9172
+                    image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
                     command:
                       - "python3"
                       - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/random-example.yaml
+++ b/examples/v1beta1/random-example.yaml
@@ -53,7 +53,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-45c5727
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/resume-experiment/from-volume-resume.yaml
+++ b/examples/v1beta1/resume-experiment/from-volume-resume.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-45c5727
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/resume-experiment/never-resume.yaml
+++ b/examples/v1beta1/resume-experiment/never-resume.yaml
@@ -56,7 +56,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-45c5727
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/tekton/pipeline-run.yaml
+++ b/examples/v1beta1/tekton/pipeline-run.yaml
@@ -88,7 +88,7 @@ spec:
                     description: Number of training examples
                 steps:
                   - name: model-training
-                    image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-c6c9172
+                    image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-45c5727
                     command:
                       - "python3"
                       - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/tpe-example.yaml
+++ b/examples/v1beta1/tpe-example.yaml
@@ -53,7 +53,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-45c5727
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/trial-metadata-substitution.yaml
+++ b/examples/v1beta1/trial-metadata-substitution.yaml
@@ -59,7 +59,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-45c5727
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/manifests/v1beta1/components/controller/trial-templates.yaml
+++ b/manifests/v1beta1/components/controller/trial-templates.yaml
@@ -14,7 +14,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-c6c9172
+              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-45c5727
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -32,7 +32,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-c6c9172
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-45c5727
               command:
                 - python3
                 - -u
@@ -53,7 +53,7 @@ data:
             spec:
               containers:
                 - name: pytorch
-                  image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-c6c9172
+                  image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
                   imagePullPolicy: Always
                   command:
                     - "python3"
@@ -68,7 +68,7 @@ data:
             spec:
               containers:
                 - name: pytorch
-                  image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-c6c9172
+                  image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
                   imagePullPolicy: Always
                   command:
                     - "python3"

--- a/operators/katib-controller/src/defaultTrialTemplate.yaml
+++ b/operators/katib-controller/src/defaultTrialTemplate.yaml
@@ -5,7 +5,7 @@ spec:
     spec:
       containers:
         - name: training-container
-          image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-c6c9172
+          image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-45c5727
           command:
             - "python3"
             - "/opt/mxnet-mnist/mnist.py"

--- a/operators/katib-controller/src/enasCPUTemplate.yaml
+++ b/operators/katib-controller/src/enasCPUTemplate.yaml
@@ -5,7 +5,7 @@ spec:
     spec:
       containers:
         - name: training-container
-          image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-c6c9172
+          image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-45c5727
           command:
             - python3
             - -u

--- a/operators/katib-controller/src/pytorchJobTemplate.yaml
+++ b/operators/katib-controller/src/pytorchJobTemplate.yaml
@@ -9,7 +9,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-c6c9172
+              image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
               imagePullPolicy: Always
               command:
                 - "python3"
@@ -24,7 +24,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-c6c9172
+              image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
               imagePullPolicy: Always
               command:
                 - "python3"

--- a/test/e2e/v1beta1/invalid-experiment.yaml
+++ b/test/e2e/v1beta1/invalid-experiment.yaml
@@ -52,7 +52,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-45c5727
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/test/e2e/v1beta1/run-e2e-experiment.go
+++ b/test/e2e/v1beta1/run-e2e-experiment.go
@@ -285,14 +285,15 @@ func verifySuggestion(kclient katibclient.Client, exp *experimentsv1beta1.Experi
 
 	// Verify Suggestion with resume policy Never and FromVolume.
 	if exp.Spec.ResumePolicy == experimentsv1beta1.NeverResume || exp.Spec.ResumePolicy == experimentsv1beta1.FromVolume {
+
+		// Give controller time to delete Suggestion resources and change Suggestion status.
+		// TODO (andreyvelich): Think about better way to handle this.
+		time.Sleep(10 * time.Second)
+
 		// When Suggestion has resume policy Never or FromVolume, it should be not running.
 		if sug.IsRunning() {
 			return fmt.Errorf("Suggestion is still running while ResumePolicy = %v", exp.Spec.ResumePolicy)
 		}
-
-		// Give some controller some time to delete Suggestion resources
-		// TODO (andreyvelich): Think about better way to handle this.
-		time.Sleep(10 * time.Second)
 
 		// Suggestion service should be deleted.
 		serviceName := controllerUtil.GetSuggestionServiceName(sug)

--- a/test/e2e/v1beta1/valid-experiment.yaml
+++ b/test/e2e/v1beta1/valid-experiment.yaml
@@ -52,7 +52,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-c6c9172
+                image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-45c5727
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"


### PR DESCRIPTION
This PR: https://github.com/kubeflow/katib/pull/1464 fixes problems in the PyTorch and MXNet mnist examples.
We should update the examples images to the `v1beta1-45c5727` tag.

/assign @gaocegege @johnugeorge 