### PR TITLE
Add release process script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,15 +49,22 @@ endif
 	bash scripts/v1beta1/build.sh $(REGISTRY) $(COMMIT_TAG) $(RELEASE_TAG)
 
 # Build and push Katib images from the latest master commit.
-release-latest:
+push-latest:
 	bash scripts/v1beta1/push.sh docker.io/andreyvelichkevich v1beta1-$(COMMIT) latest
 
-# Build and push Katib images from the given tag and commit.
-release-tag:
+# Build and push Katib images for the given tag.
+push-tag:
 ifeq ($(TAG),)
-	$(error TAG must be set. Usage: make release-tag TAG=<release-tag>)
+	$(error TAG must be set. Usage: make push-tag TAG=<release-tag>)
 endif
 	bash scripts/v1beta1/push.sh docker.io/andreyvelichkevich v1beta1-$(COMMIT) $(TAG)
+
+# Release new version of Katib.
+release:
+ifeq ($(and $(BRANCH),$(TAG)),)
+	$(error BRANCH and TAG must be set. Usage: make release BRANCH=<branch> TAG=<tag>)
+endif
+	bash scripts/v1beta1/release.sh $(BRANCH) $(TAG)
 
 # Prettier UI format check for Katib v1beta1.
 prettier-check:

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,10 @@ endif
 
 # Build images for Katib v1beta1 components
 build: generate
-ifeq ($(and $(REGISTRY),$(TAG)),)
-	$(error REGISTRY and TAG must be set. Usage make build REGISTRY=<registry> TAG=<TAG>)
+ifeq ($(and $(REGISTRY),$(COMMIT_TAG),$(RELEASE_TAG)),)
+	$(error REGISTRY, COMMIT_TAG and RELEASE_TAG must be set. Usage make build REGISTRY=<registry> COMMIT_TAG=<commit-tag> RELEASE_TAG=<release-tag>)
 endif
-	bash scripts/v1beta1/build.sh -r $(REGISTRY) -t $(TAG)
+	bash scripts/v1beta1/build.sh $(REGISTRY) $(COMMIT_TAG) $(RELEASE_TAG)
 
 # Prettier UI format check for Katib v1beta1
 prettier-check:

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ endif
 # Build images for the Katib v1beta1 components.
 build: generate
 ifeq ($(and $(REGISTRY),$(TAG)),)
-	$(error REGISTRY, TAG must be set. $(REGISTRY) $(TAG) Usage: make build REGISTRY=<registry> TAG=<tag>)
+	$(error REGISTRY and TAG must be set. Usage: make build REGISTRY=<registry> TAG=<tag>)
 endif
 	bash scripts/v1beta1/build.sh $(REGISTRY) $(TAG)
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 	hack/gen-python-sdk/gen-sdk.sh
 
 # Build images for the Katib v1beta1 components.
-build:
+build: generate
 ifeq ($(and $(REGISTRY),$(COMMIT_TAG),$(RELEASE_TAG)),)
 	$(error REGISTRY, COMMIT_TAG and RELEASE_TAG must be set. Usage: make build REGISTRY=<registry> COMMIT_TAG=<commit-tag> RELEASE_TAG=<release-tag>)
 endif
@@ -50,16 +50,16 @@ endif
 
 # Build and push Katib images from the latest master commit.
 push-latest:
-	bash scripts/v1beta1/push.sh docker.io/andreyvelichkevich v1beta1-$(COMMIT) latest
+	bash scripts/v1beta1/push.sh docker.io/kubeflowkatib v1beta1-$(COMMIT) latest
 
 # Build and push Katib images for the given tag.
 push-tag:
 ifeq ($(TAG),)
 	$(error TAG must be set. Usage: make push-tag TAG=<release-tag>)
 endif
-	bash scripts/v1beta1/push.sh docker.io/andreyvelichkevich v1beta1-$(COMMIT) $(TAG)
+	bash scripts/v1beta1/push.sh docker.io/kubeflowkatib v1beta1-$(COMMIT) $(TAG)
 
-# Release new version of Katib.
+# Release a new version of Katib.
 release:
 ifeq ($(and $(BRANCH),$(TAG)),)
 	$(error BRANCH and TAG must be set. Usage: make release BRANCH=<branch> TAG=<tag>)

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -37,13 +37,7 @@ see the following user guides:
 Check source code as follows:
 
 ```bash
-make build REGISTRY=<image-registry> COMMIT_TAG=<commit-tag> RELEASE_TAG=<release-tag>
-```
-
-If you want to add only `latest` tag to your images, run:
-
-```bash
-make build REGISTRY=<image-registry> COMMIT_TAG=latest RELEASE_TAG=latest
+make build REGISTRY=<image-registry> TAG=<image-tag>
 ```
 
 You can deploy Katib v1beta1 manifests into a k8s cluster as follows:

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -37,7 +37,13 @@ see the following user guides:
 Check source code as follows:
 
 ```bash
-make build REGISTRY=<image-registry> TAG=<image-tag>
+make build REGISTRY=<image-registry> COMMIT_TAG=<commit-tag> RELEASE_TAG=<release-tag>
+```
+
+If you want to add only `latest` tag to your images, run:
+
+```bash
+make build REGISTRY=<image-registry> COMMIT_TAG=latest RELEASE_TAG=latest
 ```
 
 You can deploy Katib v1beta1 manifests into a k8s cluster as follows:

--- a/scripts/v1beta1/build.sh
+++ b/scripts/v1beta1/build.sh
@@ -15,19 +15,16 @@
 # limitations under the License.
 
 # This script is used to build all Katib images.
-# It adds commit tag and release tag to the images.
-# Commit tag format must be: v1beta1-<COMMIT-SHA>.
-# Run ./scripts/v1beta1/build.sh <IMAGE_REGISTRY> <COMMIT_TAG> <RELEASE_TAG> to execute it.
+# Run ./scripts/v1beta1/build.sh <IMAGE_REGISTRY> <TAG> to execute it.
 
 set -e
 
 REGISTRY=$1
-COMMIT_TAG=$2
-RELEASE_TAG=$3
+TAG=$2
 
-if [[ -z "$REGISTRY" || -z "$COMMIT_TAG" || -z "$RELEASE_TAG" ]]; then
-    echo "Image registry, commit tag and release tag must be set"
-    echo "Usage: $0 <image-registry> <commit-tag> <release-tag>" 1>&2
+if [[ -z "$REGISTRY" || -z "$TAG" ]]; then
+    echo "Image registry and tag must be set"
+    echo "Usage: $0 <image-registry> <image-tag>" 1>&2
     exit 1
 fi
 
@@ -37,87 +34,86 @@ MACHINE_ARCH=$(uname -m)
 
 echo "Building images for Katib ${VERSION}..."
 echo "Image registry: ${REGISTRY}"
-echo "Image commit tag: ${COMMIT_TAG}"
-echo "Image release tag: ${RELEASE_TAG}"
+echo "Image tag: ${TAG}"
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/../..
 cd ${SCRIPT_ROOT}
 
 # Katib core images
 echo -e "\nBuilding Katib controller image...\n"
-docker build -t ${REGISTRY}/katib-controller:${COMMIT_TAG} -t ${REGISTRY}/katib-controller:${RELEASE_TAG} -f ${CMD_PREFIX}/katib-controller/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/katib-controller:${TAG} -f ${CMD_PREFIX}/katib-controller/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding Katib DB manager image...\n"
-docker build -t ${REGISTRY}/katib-db-manager:${COMMIT_TAG} -t ${REGISTRY}/katib-db-manager:${RELEASE_TAG} -f ${CMD_PREFIX}/db-manager/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/katib-db-manager:${TAG} -f ${CMD_PREFIX}/db-manager/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding Katib UI image...\n"
-docker build -t ${REGISTRY}/katib-ui:${COMMIT_TAG} -t ${REGISTRY}/katib-ui:${RELEASE_TAG} -f ${CMD_PREFIX}/ui/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/katib-ui:${TAG} -f ${CMD_PREFIX}/ui/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding Katib cert generator image...\n"
-docker build -t ${REGISTRY}/cert-generator:${COMMIT_TAG} -t ${REGISTRY}/cert-generator:${RELEASE_TAG} -f ${CMD_PREFIX}/cert-generator/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/cert-generator:${TAG} -f ${CMD_PREFIX}/cert-generator/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding file metrics collector image...\n"
-docker build -t ${REGISTRY}/file-metrics-collector:${COMMIT_TAG} -t ${REGISTRY}/file-metrics-collector:${RELEASE_TAG} -f ${CMD_PREFIX}/metricscollector/${VERSION}/file-metricscollector/Dockerfile .
+docker build -t ${REGISTRY}/file-metrics-collector:${TAG} -f ${CMD_PREFIX}/metricscollector/${VERSION}/file-metricscollector/Dockerfile .
 
 echo -e "\nBuilding TF Event metrics collector image...\n"
 if [ $MACHINE_ARCH == "aarch64" ]; then
-    docker build -t ${REGISTRY}/tfevent-metrics-collector:${COMMIT_TAG} -t ${REGISTRY}/tfevent-metrics-collector:${RELEASE_TAG} -f ${CMD_PREFIX}/metricscollector/${VERSION}/tfevent-metricscollector/Dockerfile.aarch64 .
+    docker build -t ${REGISTRY}/tfevent-metrics-collector:${TAG} -f ${CMD_PREFIX}/metricscollector/${VERSION}/tfevent-metricscollector/Dockerfile.aarch64 .
 elif [ $MACHINE_ARCH == "ppc64le" ]; then
-    docker build -t ${REGISTRY}/tfevent-metrics-collector:${COMMIT_TAG} -t ${REGISTRY}/tfevent-metrics-collector:${RELEASE_TAG} -f ${CMD_PREFIX}/metricscollector/${VERSION}/tfevent-metricscollector/Dockerfile.ppc64le .
+    docker build -t ${REGISTRY}/tfevent-metrics-collector:${TAG} -f ${CMD_PREFIX}/metricscollector/${VERSION}/tfevent-metricscollector/Dockerfile.ppc64le .
 else
-    docker build -t ${REGISTRY}/tfevent-metrics-collector:${COMMIT_TAG} -t ${REGISTRY}/tfevent-metrics-collector:${RELEASE_TAG} -f ${CMD_PREFIX}/metricscollector/${VERSION}/tfevent-metricscollector/Dockerfile .
+    docker build -t ${REGISTRY}/tfevent-metrics-collector:${TAG} -f ${CMD_PREFIX}/metricscollector/${VERSION}/tfevent-metricscollector/Dockerfile .
 fi
 
 # Suggestion images
 echo -e "\nBuilding suggestion images..."
 
 echo -e "\nBuilding hyperopt suggestion...\n"
-docker build -t ${REGISTRY}/suggestion-hyperopt:${COMMIT_TAG} -t ${REGISTRY}/suggestion-hyperopt:${RELEASE_TAG} -f ${CMD_PREFIX}/suggestion/hyperopt/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/suggestion-hyperopt:${TAG} -f ${CMD_PREFIX}/suggestion/hyperopt/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding chocolate suggestion...\n"
-docker build -t ${REGISTRY}/suggestion-chocolate:${COMMIT_TAG} -t ${REGISTRY}/suggestion-chocolate:${RELEASE_TAG} -f ${CMD_PREFIX}/suggestion/chocolate/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/suggestion-chocolate:${TAG} -f ${CMD_PREFIX}/suggestion/chocolate/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding hyperband suggestion...\n"
-docker build -t ${REGISTRY}/suggestion-hyperband:${COMMIT_TAG} -t ${REGISTRY}/suggestion-hyperband:${RELEASE_TAG} -f ${CMD_PREFIX}/suggestion/hyperband/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/suggestion-hyperband:${TAG} -f ${CMD_PREFIX}/suggestion/hyperband/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding skopt suggestion...\n"
-docker build -t ${REGISTRY}/suggestion-skopt:${COMMIT_TAG} -t ${REGISTRY}/suggestion-skopt:${RELEASE_TAG} -f ${CMD_PREFIX}/suggestion/skopt/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/suggestion-skopt:${TAG} -f ${CMD_PREFIX}/suggestion/skopt/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding goptuna suggestion...\n"
-docker build -t ${REGISTRY}/suggestion-goptuna:${COMMIT_TAG} -t ${REGISTRY}/suggestion-goptuna:${RELEASE_TAG} -f ${CMD_PREFIX}/suggestion/goptuna/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/suggestion-goptuna:${TAG} -f ${CMD_PREFIX}/suggestion/goptuna/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding ENAS suggestion...\n"
 if [ $MACHINE_ARCH == "aarch64" ]; then
-    docker build -t ${REGISTRY}/suggestion-enas:${COMMIT_TAG} -t ${REGISTRY}/suggestion-enas:${RELEASE_TAG} -f ${CMD_PREFIX}/suggestion/nas/enas/${VERSION}/Dockerfile.aarch64 .
+    docker build -t ${REGISTRY}/suggestion-enas:${TAG} -f ${CMD_PREFIX}/suggestion/nas/enas/${VERSION}/Dockerfile.aarch64 .
 else
-    docker build -t ${REGISTRY}/suggestion-enas:${COMMIT_TAG} -t ${REGISTRY}/suggestion-enas:${RELEASE_TAG} -f ${CMD_PREFIX}/suggestion/nas/enas/${VERSION}/Dockerfile .
+    docker build -t ${REGISTRY}/suggestion-enas:${TAG} -f ${CMD_PREFIX}/suggestion/nas/enas/${VERSION}/Dockerfile .
 fi
 
 echo -e "\nBuilding DARTS suggestion...\n"
-docker build -t ${REGISTRY}/suggestion-darts:${COMMIT_TAG} -t ${REGISTRY}/suggestion-darts:${RELEASE_TAG} -f ${CMD_PREFIX}/suggestion/nas/darts/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/suggestion-darts:${TAG} -f ${CMD_PREFIX}/suggestion/nas/darts/${VERSION}/Dockerfile .
 
 # Early stopping images
 echo -e "\nBuilding early stopping images...\n"
 
 echo -e "\nBuilding median stopping rule...\n"
-docker build -t ${REGISTRY}/earlystopping-medianstop:${COMMIT_TAG} -t ${REGISTRY}/earlystopping-medianstop:${RELEASE_TAG} -f ${CMD_PREFIX}/earlystopping/medianstop/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/earlystopping-medianstop:${TAG} -f ${CMD_PREFIX}/earlystopping/medianstop/${VERSION}/Dockerfile .
 
 # Training container images
 echo -e "\nBuilding training container images..."
 
 echo -e "\nBuilding mxnet mnist training container example...\n"
-docker build -t ${REGISTRY}/mxnet-mnist:${COMMIT_TAG} -t ${REGISTRY}/mxnet-mnist:${RELEASE_TAG} -f examples/${VERSION}/mxnet-mnist/Dockerfile .
+docker build -t ${REGISTRY}/mxnet-mnist:${TAG} -f examples/${VERSION}/mxnet-mnist/Dockerfile .
 
 echo -e "\nBuilding PyTorch mnist training container example...\n"
-docker build -t ${REGISTRY}/pytorch-mnist:${COMMIT_TAG} -t ${REGISTRY}/pytorch-mnist:${RELEASE_TAG} -f examples/${VERSION}/pytorch-mnist/Dockerfile .
+docker build -t ${REGISTRY}/pytorch-mnist:${TAG} -f examples/${VERSION}/pytorch-mnist/Dockerfile .
 
 echo -e "\nBuilding Keras CIFAR-10 CNN training container example for ENAS with GPU support...\n"
-docker build -t ${REGISTRY}/enas-cnn-cifar10-gpu:${COMMIT_TAG} -t ${REGISTRY}/enas-cnn-cifar10-gpu:${RELEASE_TAG} -f examples/${VERSION}/nas/enas-cnn-cifar10/Dockerfile.gpu .
+docker build -t ${REGISTRY}/enas-cnn-cifar10-gpu:${TAG} -f examples/${VERSION}/nas/enas-cnn-cifar10/Dockerfile.gpu .
 
 echo -e "\nBuilding Keras CIFAR-10 CNN training container example for ENAS with CPU support...\n"
-docker build -t ${REGISTRY}/enas-cnn-cifar10-cpu:${COMMIT_TAG} -t ${REGISTRY}/enas-cnn-cifar10-cpu:${RELEASE_TAG} -f examples/${VERSION}/nas/enas-cnn-cifar10/Dockerfile.cpu .
+docker build -t ${REGISTRY}/enas-cnn-cifar10-cpu:${TAG} -f examples/${VERSION}/nas/enas-cnn-cifar10/Dockerfile.cpu .
 
 echo -e "\nBuilding PyTorch CIFAR-10 CNN training container example for DARTS...\n"
-docker build -t ${REGISTRY}/darts-cnn-cifar10:${COMMIT_TAG} -t ${REGISTRY}/darts-cnn-cifar10:${RELEASE_TAG} -f examples/${VERSION}/nas/darts-cnn-cifar10/Dockerfile .
+docker build -t ${REGISTRY}/darts-cnn-cifar10:${TAG} -f examples/${VERSION}/nas/darts-cnn-cifar10/Dockerfile .
 
-echo -e "\nAll Katib images have been built successfully!\n"
+echo -e "\nAll Katib images with ${TAG} tag have been built successfully!\n"

--- a/scripts/v1beta1/build.sh
+++ b/scripts/v1beta1/build.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 # This script is used to build all Katib images.
-# It adds release tag and commit tag to the images.
-# Commit tag format: v1beta1-<COMMIT-SHA>.
+# It adds commit tag and release tag to the images.
+# Commit tag format must be: v1beta1-<COMMIT-SHA>.
 # Run ./scripts/v1beta1/build.sh <IMAGE_REGISTRY> <COMMIT_TAG> <RELEASE_TAG> to execute it.
 
 set -e
@@ -119,3 +119,5 @@ docker build -t ${REGISTRY}/enas-cnn-cifar10-cpu:${COMMIT_TAG} -t ${REGISTRY}/en
 
 echo -e "\nBuilding PyTorch CIFAR-10 CNN training container example for DARTS...\n"
 docker build -t ${REGISTRY}/darts-cnn-cifar10:${COMMIT_TAG} -t ${REGISTRY}/darts-cnn-cifar10:${RELEASE_TAG} -f examples/${VERSION}/nas/darts-cnn-cifar10/Dockerfile .
+
+echo -e "\nAll Katib images have been built successfully!\n"

--- a/scripts/v1beta1/build.sh
+++ b/scripts/v1beta1/build.sh
@@ -15,33 +15,19 @@
 # limitations under the License.
 
 # This script is used to build all Katib images.
-# It adds "<TAG>" and "latest" tag to them.
-# Run ./scripts/v1beta1/build.sh -r <image-registry> -t <image-tag> to execute it.
+# It adds release tag and commit tag to the images.
+# Commit tag format: v1beta1-<COMMIT-SHA>.
+# Run ./scripts/v1beta1/build.sh <IMAGE_REGISTRY> <COMMIT_TAG> <RELEASE_TAG> to execute it.
 
 set -e
 
-usage() {
-    echo "Usage: $0 [-r <REGISTRY>] [-t <TAG>]" 1>&2
-    exit 1
-}
+REGISTRY=$1
+COMMIT_TAG=$2
+RELEASE_TAG=$3
 
-while getopts ":t::r::p:" opt; do
-    case $opt in
-    r)
-        REGISTRY=${OPTARG}
-        ;;
-    t)
-        TAG=${OPTARG}
-        ;;
-    *)
-        usage
-        ;;
-    esac
-done
-
-if [[ -z "$REGISTRY" || -z "$TAG" ]]; then
-    echo "Image registry and tag must be set"
-    echo "Usage: $0 [-r <REGISTRY>] [-t <TAG>]" 1>&2
+if [[ -z "$REGISTRY" || -z "$COMMIT_TAG" || -z "$RELEASE_TAG" ]]; then
+    echo "Image registry, commit tag and release tag must be set"
+    echo "Usage: $0 <image-registry> <commit-tag> <release-tag>" 1>&2
     exit 1
 fi
 
@@ -51,84 +37,85 @@ MACHINE_ARCH=$(uname -m)
 
 echo "Building images for Katib ${VERSION}..."
 echo "Image registry: ${REGISTRY}"
-echo "Image tag: ${TAG}"
+echo "Image commit tag: ${COMMIT_TAG}"
+echo "Image release tag: ${RELEASE_TAG}"
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/../..
 cd ${SCRIPT_ROOT}
 
 # Katib core images
 echo -e "\nBuilding Katib controller image...\n"
-docker build -t ${REGISTRY}/katib-controller:${TAG} -t ${REGISTRY}/katib-controller:latest -f ${CMD_PREFIX}/katib-controller/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/katib-controller:${COMMIT_TAG} -t ${REGISTRY}/katib-controller:${RELEASE_TAG} -f ${CMD_PREFIX}/katib-controller/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding Katib DB manager image...\n"
-docker build -t ${REGISTRY}/katib-db-manager:${TAG} -t ${REGISTRY}/katib-db-manager:latest -f ${CMD_PREFIX}/db-manager/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/katib-db-manager:${COMMIT_TAG} -t ${REGISTRY}/katib-db-manager:${RELEASE_TAG} -f ${CMD_PREFIX}/db-manager/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding Katib UI image...\n"
-docker build -t ${REGISTRY}/katib-ui:${TAG} -t ${REGISTRY}/katib-ui:latest -f ${CMD_PREFIX}/ui/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/katib-ui:${COMMIT_TAG} -t ${REGISTRY}/katib-ui:${RELEASE_TAG} -f ${CMD_PREFIX}/ui/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding Katib cert generator image...\n"
-docker build -t ${REGISTRY}/cert-generator:${TAG} -t ${REGISTRY}/cert-generator:latest -f ${CMD_PREFIX}/cert-generator/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/cert-generator:${COMMIT_TAG} -t ${REGISTRY}/cert-generator:${RELEASE_TAG} -f ${CMD_PREFIX}/cert-generator/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding file metrics collector image...\n"
-docker build -t ${REGISTRY}/file-metrics-collector:${TAG} -t ${REGISTRY}/file-metrics-collector:latest -f ${CMD_PREFIX}/metricscollector/${VERSION}/file-metricscollector/Dockerfile .
+docker build -t ${REGISTRY}/file-metrics-collector:${COMMIT_TAG} -t ${REGISTRY}/file-metrics-collector:${RELEASE_TAG} -f ${CMD_PREFIX}/metricscollector/${VERSION}/file-metricscollector/Dockerfile .
 
 echo -e "\nBuilding TF Event metrics collector image...\n"
 if [ $MACHINE_ARCH == "aarch64" ]; then
-    docker build -t ${REGISTRY}/tfevent-metrics-collector:${TAG} -t ${REGISTRY}/tfevent-metrics-collector:latest -f ${CMD_PREFIX}/metricscollector/${VERSION}/tfevent-metricscollector/Dockerfile.aarch64 .
+    docker build -t ${REGISTRY}/tfevent-metrics-collector:${COMMIT_TAG} -t ${REGISTRY}/tfevent-metrics-collector:${RELEASE_TAG} -f ${CMD_PREFIX}/metricscollector/${VERSION}/tfevent-metricscollector/Dockerfile.aarch64 .
 elif [ $MACHINE_ARCH == "ppc64le" ]; then
-    docker build -t ${REGISTRY}/tfevent-metrics-collector:${TAG} -t ${REGISTRY}/tfevent-metrics-collector:latest -f ${CMD_PREFIX}/metricscollector/${VERSION}/tfevent-metricscollector/Dockerfile.ppc64le .
+    docker build -t ${REGISTRY}/tfevent-metrics-collector:${COMMIT_TAG} -t ${REGISTRY}/tfevent-metrics-collector:${RELEASE_TAG} -f ${CMD_PREFIX}/metricscollector/${VERSION}/tfevent-metricscollector/Dockerfile.ppc64le .
 else
-    docker build -t ${REGISTRY}/tfevent-metrics-collector:${TAG} -t ${REGISTRY}/tfevent-metrics-collector:latest -f ${CMD_PREFIX}/metricscollector/${VERSION}/tfevent-metricscollector/Dockerfile .
+    docker build -t ${REGISTRY}/tfevent-metrics-collector:${COMMIT_TAG} -t ${REGISTRY}/tfevent-metrics-collector:${RELEASE_TAG} -f ${CMD_PREFIX}/metricscollector/${VERSION}/tfevent-metricscollector/Dockerfile .
 fi
 
 # Suggestion images
 echo -e "\nBuilding suggestion images..."
 
 echo -e "\nBuilding hyperopt suggestion...\n"
-docker build -t ${REGISTRY}/suggestion-hyperopt:${TAG} -t ${REGISTRY}/suggestion-hyperopt:latest -f ${CMD_PREFIX}/suggestion/hyperopt/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/suggestion-hyperopt:${COMMIT_TAG} -t ${REGISTRY}/suggestion-hyperopt:${RELEASE_TAG} -f ${CMD_PREFIX}/suggestion/hyperopt/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding chocolate suggestion...\n"
-docker build -t ${REGISTRY}/suggestion-chocolate:${TAG} -t ${REGISTRY}/suggestion-chocolate:latest -f ${CMD_PREFIX}/suggestion/chocolate/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/suggestion-chocolate:${COMMIT_TAG} -t ${REGISTRY}/suggestion-chocolate:${RELEASE_TAG} -f ${CMD_PREFIX}/suggestion/chocolate/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding hyperband suggestion...\n"
-docker build -t ${REGISTRY}/suggestion-hyperband:${TAG} -t ${REGISTRY}/suggestion-hyperband:latest -f ${CMD_PREFIX}/suggestion/hyperband/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/suggestion-hyperband:${COMMIT_TAG} -t ${REGISTRY}/suggestion-hyperband:${RELEASE_TAG} -f ${CMD_PREFIX}/suggestion/hyperband/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding skopt suggestion...\n"
-docker build -t ${REGISTRY}/suggestion-skopt:${TAG} -t ${REGISTRY}/suggestion-skopt:latest -f ${CMD_PREFIX}/suggestion/skopt/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/suggestion-skopt:${COMMIT_TAG} -t ${REGISTRY}/suggestion-skopt:${RELEASE_TAG} -f ${CMD_PREFIX}/suggestion/skopt/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding goptuna suggestion...\n"
-docker build -t ${REGISTRY}/suggestion-goptuna:${TAG} -t ${REGISTRY}/suggestion-goptuna:latest -f ${CMD_PREFIX}/suggestion/goptuna/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/suggestion-goptuna:${COMMIT_TAG} -t ${REGISTRY}/suggestion-goptuna:${RELEASE_TAG} -f ${CMD_PREFIX}/suggestion/goptuna/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding ENAS suggestion...\n"
 if [ $MACHINE_ARCH == "aarch64" ]; then
-    docker build -t ${REGISTRY}/suggestion-enas:${TAG} -t ${REGISTRY}/suggestion-enas:latest -f ${CMD_PREFIX}/suggestion/nas/enas/${VERSION}/Dockerfile.aarch64 .
+    docker build -t ${REGISTRY}/suggestion-enas:${COMMIT_TAG} -t ${REGISTRY}/suggestion-enas:${RELEASE_TAG} -f ${CMD_PREFIX}/suggestion/nas/enas/${VERSION}/Dockerfile.aarch64 .
 else
-    docker build -t ${REGISTRY}/suggestion-enas:${TAG} -t ${REGISTRY}/suggestion-enas:latest -f ${CMD_PREFIX}/suggestion/nas/enas/${VERSION}/Dockerfile .
+    docker build -t ${REGISTRY}/suggestion-enas:${COMMIT_TAG} -t ${REGISTRY}/suggestion-enas:${RELEASE_TAG} -f ${CMD_PREFIX}/suggestion/nas/enas/${VERSION}/Dockerfile .
 fi
 
 echo -e "\nBuilding DARTS suggestion...\n"
-docker build -t ${REGISTRY}/suggestion-darts:${TAG} -t ${REGISTRY}/suggestion-darts:latest -f ${CMD_PREFIX}/suggestion/nas/darts/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/suggestion-darts:${COMMIT_TAG} -t ${REGISTRY}/suggestion-darts:${RELEASE_TAG} -f ${CMD_PREFIX}/suggestion/nas/darts/${VERSION}/Dockerfile .
 
 # Early stopping images
 echo -e "\nBuilding early stopping images...\n"
 
 echo -e "\nBuilding median stopping rule...\n"
-docker build -t ${REGISTRY}/earlystopping-medianstop:${TAG} -t ${REGISTRY}/earlystopping-medianstop:latest -f ${CMD_PREFIX}/earlystopping/medianstop/${VERSION}/Dockerfile .
+docker build -t ${REGISTRY}/earlystopping-medianstop:${COMMIT_TAG} -t ${REGISTRY}/earlystopping-medianstop:${RELEASE_TAG} -f ${CMD_PREFIX}/earlystopping/medianstop/${VERSION}/Dockerfile .
 
 # Training container images
 echo -e "\nBuilding training container images..."
 
 echo -e "\nBuilding mxnet mnist training container example...\n"
-docker build -t ${REGISTRY}/mxnet-mnist:${TAG} -t ${REGISTRY}/mxnet-mnist:latest -f examples/${VERSION}/mxnet-mnist/Dockerfile .
+docker build -t ${REGISTRY}/mxnet-mnist:${COMMIT_TAG} -t ${REGISTRY}/mxnet-mnist:${RELEASE_TAG} -f examples/${VERSION}/mxnet-mnist/Dockerfile .
 
 echo -e "\nBuilding PyTorch mnist training container example...\n"
-docker build -t ${REGISTRY}/pytorch-mnist:${TAG} -t ${REGISTRY}/pytorch-mnist:latest -f examples/${VERSION}/pytorch-mnist/Dockerfile .
+docker build -t ${REGISTRY}/pytorch-mnist:${COMMIT_TAG} -t ${REGISTRY}/pytorch-mnist:${RELEASE_TAG} -f examples/${VERSION}/pytorch-mnist/Dockerfile .
 
 echo -e "\nBuilding Keras CIFAR-10 CNN training container example for ENAS with GPU support...\n"
-docker build -t ${REGISTRY}/enas-cnn-cifar10-gpu:${TAG} -t ${REGISTRY}/enas-cnn-cifar10-gpu:latest -f examples/${VERSION}/nas/enas-cnn-cifar10/Dockerfile.gpu .
+docker build -t ${REGISTRY}/enas-cnn-cifar10-gpu:${COMMIT_TAG} -t ${REGISTRY}/enas-cnn-cifar10-gpu:${RELEASE_TAG} -f examples/${VERSION}/nas/enas-cnn-cifar10/Dockerfile.gpu .
 
 echo -e "\nBuilding Keras CIFAR-10 CNN training container example for ENAS with CPU support...\n"
-docker build -t ${REGISTRY}/enas-cnn-cifar10-cpu:${TAG} -t ${REGISTRY}/enas-cnn-cifar10-cpu:latest -f examples/${VERSION}/nas/enas-cnn-cifar10/Dockerfile.cpu .
+docker build -t ${REGISTRY}/enas-cnn-cifar10-cpu:${COMMIT_TAG} -t ${REGISTRY}/enas-cnn-cifar10-cpu:${RELEASE_TAG} -f examples/${VERSION}/nas/enas-cnn-cifar10/Dockerfile.cpu .
 
 echo -e "\nBuilding PyTorch CIFAR-10 CNN training container example for DARTS...\n"
-docker build -t ${REGISTRY}/darts-cnn-cifar10:${TAG} -t ${REGISTRY}/darts-cnn-cifar10:latest -f examples/${VERSION}/nas/darts-cnn-cifar10/Dockerfile .
+docker build -t ${REGISTRY}/darts-cnn-cifar10:${COMMIT_TAG} -t ${REGISTRY}/darts-cnn-cifar10:${RELEASE_TAG} -f examples/${VERSION}/nas/darts-cnn-cifar10/Dockerfile .

--- a/scripts/v1beta1/push.sh
+++ b/scripts/v1beta1/push.sh
@@ -14,117 +14,91 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script is used to build and push all Katib images to the registry.
-# It adds commit tag and release tag to the images.
-# Commit tag format must be: v1beta1-<COMMIT-SHA>.
-# Run ./scripts/v1beta1/push.sh <IMAGE_REGISTRY> <COMMIT_TAG> <RELEASE_TAG> to execute it.
+# This script is used to push all Katib images.
+# Run ./scripts/v1beta1/push.sh <IMAGE_REGISTRY> <TAG>
 
 set -e
 
 REGISTRY=$1
-COMMIT_TAG=$2
-RELEASE_TAG=$3
+TAG=$2
 
-if [[ -z "$REGISTRY" || -z "$COMMIT_TAG" || -z "$RELEASE_TAG" ]]; then
-  echo "Image registry, commit tag and release tag must be set"
-  echo "Usage: $0 <image-registry> <commit-tag> <release-tag>" 1>&2
+if [[ -z "$REGISTRY" || -z "$TAG" ]]; then
+  echo "Image registry and tag must be set"
+  echo "Usage: $0 <image-registry> <image-tag>" 1>&2
   exit 1
 fi
 
 VERSION="v1beta1"
 
-# Building the images
-make build REGISTRY=${REGISTRY} COMMIT_TAG=${COMMIT_TAG} RELEASE_TAG=${RELEASE_TAG}
-
 echo "Pushing images for Katib ${VERSION}..."
 echo "Image registry: ${REGISTRY}"
-echo "Image commit tag: ${COMMIT_TAG}"
-echo "Image release tag: ${RELEASE_TAG}"
+echo "Image tag: ${TAG}"
 
 # Katib core images
 echo -e "\nPushing Katib controller image...\n"
-docker push ${REGISTRY}/katib-controller:${COMMIT_TAG}
-docker push ${REGISTRY}/katib-controller:${RELEASE_TAG}
+docker push ${REGISTRY}/katib-controller:${TAG}
 
 echo -e "\nPushing Katib DB manager image...\n"
-docker push ${REGISTRY}/katib-db-manager:${COMMIT_TAG}
-docker push ${REGISTRY}/katib-db-manager:${RELEASE_TAG}
+docker push ${REGISTRY}/katib-db-manager:${TAG}
 
 echo -e "\nPushing Katib UI image...\n"
-docker push ${REGISTRY}/katib-ui:${COMMIT_TAG}
-docker push ${REGISTRY}/katib-ui:${RELEASE_TAG}
+docker push ${REGISTRY}/katib-ui:${TAG}
 
 echo -e "\nPushing Katib cert generator image...\n"
-docker push ${REGISTRY}/cert-generator:${COMMIT_TAG}
-docker push ${REGISTRY}/cert-generator:${RELEASE_TAG}
+docker push ${REGISTRY}/cert-generator:${TAG}
 
 echo -e "\nPushing file metrics collector image...\n"
-docker push ${REGISTRY}/file-metrics-collector:${COMMIT_TAG}
-docker push ${REGISTRY}/file-metrics-collector:${RELEASE_TAG}
+docker push ${REGISTRY}/file-metrics-collector:${TAG}
 
 echo -e "\nPushing TF Event metrics collector image...\n"
-docker push ${REGISTRY}/tfevent-metrics-collector:${COMMIT_TAG}
-docker push ${REGISTRY}/tfevent-metrics-collector:${RELEASE_TAG}
+docker push ${REGISTRY}/tfevent-metrics-collector:${TAG}
 
 # Suggestion images
 echo -e "\nPushing suggestion images..."
 
 echo -e "\nPushing hyperopt suggestion...\n"
-docker push ${REGISTRY}/suggestion-hyperopt:${COMMIT_TAG}
-docker push ${REGISTRY}/suggestion-hyperopt:${RELEASE_TAG}
+docker push ${REGISTRY}/suggestion-hyperopt:${TAG}
 
 echo -e "\nPushing chocolate suggestion...\n"
-docker push ${REGISTRY}/suggestion-chocolate:${COMMIT_TAG}
-docker push ${REGISTRY}/suggestion-chocolate:${RELEASE_TAG}
+docker push ${REGISTRY}/suggestion-chocolate:${TAG}
 
 echo -e "\nPushing hyperband suggestion...\n"
-docker push ${REGISTRY}/suggestion-hyperband:${COMMIT_TAG}
-docker push ${REGISTRY}/suggestion-hyperband:${RELEASE_TAG}
+docker push ${REGISTRY}/suggestion-hyperband:${TAG}
 
 echo -e "\nPushing skopt suggestion...\n"
-docker push ${REGISTRY}/suggestion-skopt:${COMMIT_TAG}
-docker push ${REGISTRY}/suggestion-skopt:${RELEASE_TAG}
+docker push ${REGISTRY}/suggestion-skopt:${TAG}
 
 echo -e "\nPushing goptuna suggestion...\n"
-docker push ${REGISTRY}/suggestion-goptuna:${COMMIT_TAG}
-docker push ${REGISTRY}/suggestion-goptuna:${RELEASE_TAG}
+docker push ${REGISTRY}/suggestion-goptuna:${TAG}
 
 echo -e "\nPushing ENAS suggestion...\n"
-docker push ${REGISTRY}/suggestion-enas:${COMMIT_TAG}
-docker push ${REGISTRY}/suggestion-enas:${RELEASE_TAG}
+docker push ${REGISTRY}/suggestion-enas:${TAG}
 
 echo -e "\nPushing DARTS suggestion...\n"
-docker push ${REGISTRY}/suggestion-darts:${COMMIT_TAG}
-docker push ${REGISTRY}/suggestion-darts:${RELEASE_TAG}
+docker push ${REGISTRY}/suggestion-darts:${TAG}
 
 # Early stopping images
 echo -e "\nPushing early stopping images...\n"
 
 echo -e "\nPushing median stopping rule...\n"
-docker push ${REGISTRY}/earlystopping-medianstop:${COMMIT_TAG}
-docker push ${REGISTRY}/earlystopping-medianstop:${RELEASE_TAG}
+docker push ${REGISTRY}/earlystopping-medianstop:${TAG}
 
 # Training container images
 echo -e "\nPushing training container images..."
 
 echo -e "\nPushing mxnet mnist training container example...\n"
-docker push ${REGISTRY}/mxnet-mnist:${COMMIT_TAG}
-docker push ${REGISTRY}/mxnet-mnist:${RELEASE_TAG}
+docker push ${REGISTRY}/mxnet-mnist:${TAG}
 
 echo -e "\nPushing PyTorch mnist training container example...\n"
-docker push ${REGISTRY}/pytorch-mnist:${COMMIT_TAG}
-docker push ${REGISTRY}/pytorch-mnist:${RELEASE_TAG}
+docker push ${REGISTRY}/pytorch-mnist:${TAG}
 
 echo -e "\nPushing Keras CIFAR-10 CNN training container example for ENAS with GPU support...\n"
-docker push ${REGISTRY}/enas-cnn-cifar10-gpu:${COMMIT_TAG}
-docker push ${REGISTRY}/enas-cnn-cifar10-gpu:${RELEASE_TAG}
+docker push ${REGISTRY}/enas-cnn-cifar10-gpu:${TAG}
 
 echo -e "\nPushing Keras CIFAR-10 CNN training container example for ENAS with CPU support...\n"
-docker push ${REGISTRY}/enas-cnn-cifar10-cpu:${COMMIT_TAG}
-docker push ${REGISTRY}/enas-cnn-cifar10-cpu:${RELEASE_TAG}
+docker push ${REGISTRY}/enas-cnn-cifar10-cpu:${TAG}
 
 echo -e "\nPushing PyTorch CIFAR-10 CNN training container example for DARTS...\n"
-docker push ${REGISTRY}/darts-cnn-cifar10:${COMMIT_TAG}
-docker push ${REGISTRY}/darts-cnn-cifar10:${RELEASE_TAG}
+docker push ${REGISTRY}/darts-cnn-cifar10:${TAG}
 
-echo -e "\nAll Katib images have been pushed successfully!\n"
+echo -e "\nAll Katib images with ${TAG} tag have been pushed successfully!\n"

--- a/scripts/v1beta1/push.sh
+++ b/scripts/v1beta1/push.sh
@@ -14,114 +14,117 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script is used to build and push all Katib images in docker.io/kubeflowkatib registry
-# It adds release tag and commit tag to the images.
+# This script is used to build and push all Katib images to the registry.
+# It adds commit tag and release tag to the images.
+# Commit tag format must be: v1beta1-<COMMIT-SHA>.
+# Run ./scripts/v1beta1/push.sh <IMAGE_REGISTRY> <COMMIT_TAG> <RELEASE_TAG> to execute it.
 
 set -e
 
-COMMIT=$(git rev-parse --short=7 HEAD)
-REGISTRY="docker.io/kubeflowkatib"
+REGISTRY=$1
+COMMIT_TAG=$2
+RELEASE_TAG=$3
+
+if [[ -z "$REGISTRY" || -z "$COMMIT_TAG" || -z "$RELEASE_TAG" ]]; then
+  echo "Image registry, commit tag and release tag must be set"
+  echo "Usage: $0 <image-registry> <commit-tag> <release-tag>" 1>&2
+  exit 1
+fi
+
 VERSION="v1beta1"
-TAG=${VERSION}-${COMMIT}
-
-echo "Releasing images for Katib ${VERSION}..."
-echo "Commit SHA: ${COMMIT}"
-echo "Image registry: ${REGISTRY}"
-echo -e "Image tag: ${TAG}\n"
-
-SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/../..
-cd ${SCRIPT_ROOT}
 
 # Building the images
-make build REGISTRY=${REGISTRY} TAG=${TAG}
+make build REGISTRY=${REGISTRY} COMMIT_TAG=${COMMIT_TAG} RELEASE_TAG=${RELEASE_TAG}
 
-# Releasing the images
-echo -e "\nAll Katib images have been successfully built\n"
+echo "Pushing images for Katib ${VERSION}..."
+echo "Image registry: ${REGISTRY}"
+echo "Image commit tag: ${COMMIT_TAG}"
+echo "Image release tag: ${RELEASE_TAG}"
 
 # Katib core images
 echo -e "\nPushing Katib controller image...\n"
-docker push ${REGISTRY}/katib-controller:${TAG}
-docker push ${REGISTRY}/katib-controller:latest
+docker push ${REGISTRY}/katib-controller:${COMMIT_TAG}
+docker push ${REGISTRY}/katib-controller:${RELEASE_TAG}
 
 echo -e "\nPushing Katib DB manager image...\n"
-docker push ${REGISTRY}/katib-db-manager:${TAG}
-docker push ${REGISTRY}/katib-db-manager:latest
+docker push ${REGISTRY}/katib-db-manager:${COMMIT_TAG}
+docker push ${REGISTRY}/katib-db-manager:${RELEASE_TAG}
 
 echo -e "\nPushing Katib UI image...\n"
-docker push ${REGISTRY}/katib-ui:${TAG}
-docker push ${REGISTRY}/katib-ui:latest
+docker push ${REGISTRY}/katib-ui:${COMMIT_TAG}
+docker push ${REGISTRY}/katib-ui:${RELEASE_TAG}
 
 echo -e "\nPushing Katib cert generator image...\n"
-docker push ${REGISTRY}/cert-generator:${TAG}
-docker push ${REGISTRY}/cert-generator:latest
+docker push ${REGISTRY}/cert-generator:${COMMIT_TAG}
+docker push ${REGISTRY}/cert-generator:${RELEASE_TAG}
 
 echo -e "\nPushing file metrics collector image...\n"
-docker push ${REGISTRY}/file-metrics-collector:${TAG}
-docker push ${REGISTRY}/file-metrics-collector:latest
+docker push ${REGISTRY}/file-metrics-collector:${COMMIT_TAG}
+docker push ${REGISTRY}/file-metrics-collector:${RELEASE_TAG}
 
 echo -e "\nPushing TF Event metrics collector image...\n"
-docker push ${REGISTRY}/tfevent-metrics-collector:${TAG}
-docker push ${REGISTRY}/tfevent-metrics-collector:latest
+docker push ${REGISTRY}/tfevent-metrics-collector:${COMMIT_TAG}
+docker push ${REGISTRY}/tfevent-metrics-collector:${RELEASE_TAG}
 
 # Suggestion images
 echo -e "\nPushing suggestion images..."
 
 echo -e "\nPushing hyperopt suggestion...\n"
-docker push ${REGISTRY}/suggestion-hyperopt:${TAG}
-docker push ${REGISTRY}/suggestion-hyperopt:latest
+docker push ${REGISTRY}/suggestion-hyperopt:${COMMIT_TAG}
+docker push ${REGISTRY}/suggestion-hyperopt:${RELEASE_TAG}
 
 echo -e "\nPushing chocolate suggestion...\n"
-docker push ${REGISTRY}/suggestion-chocolate:${TAG}
-docker push ${REGISTRY}/suggestion-chocolate:latest
+docker push ${REGISTRY}/suggestion-chocolate:${COMMIT_TAG}
+docker push ${REGISTRY}/suggestion-chocolate:${RELEASE_TAG}
 
 echo -e "\nPushing hyperband suggestion...\n"
-docker push ${REGISTRY}/suggestion-hyperband:${TAG}
-docker push ${REGISTRY}/suggestion-hyperband:latest
+docker push ${REGISTRY}/suggestion-hyperband:${COMMIT_TAG}
+docker push ${REGISTRY}/suggestion-hyperband:${RELEASE_TAG}
 
 echo -e "\nPushing skopt suggestion...\n"
-docker push ${REGISTRY}/suggestion-skopt:${TAG}
-docker push ${REGISTRY}/suggestion-skopt:latest
+docker push ${REGISTRY}/suggestion-skopt:${COMMIT_TAG}
+docker push ${REGISTRY}/suggestion-skopt:${RELEASE_TAG}
 
 echo -e "\nPushing goptuna suggestion...\n"
-docker push ${REGISTRY}/suggestion-goptuna:${TAG}
-docker push ${REGISTRY}/suggestion-goptuna:latest
+docker push ${REGISTRY}/suggestion-goptuna:${COMMIT_TAG}
+docker push ${REGISTRY}/suggestion-goptuna:${RELEASE_TAG}
 
 echo -e "\nPushing ENAS suggestion...\n"
-docker push ${REGISTRY}/suggestion-enas:${TAG}
-docker push ${REGISTRY}/suggestion-enas:latest
+docker push ${REGISTRY}/suggestion-enas:${COMMIT_TAG}
+docker push ${REGISTRY}/suggestion-enas:${RELEASE_TAG}
 
 echo -e "\nPushing DARTS suggestion...\n"
-docker push ${REGISTRY}/suggestion-darts:${TAG}
-docker push ${REGISTRY}/suggestion-darts:latest
+docker push ${REGISTRY}/suggestion-darts:${COMMIT_TAG}
+docker push ${REGISTRY}/suggestion-darts:${RELEASE_TAG}
 
 # Early stopping images
 echo -e "\nPushing early stopping images...\n"
 
 echo -e "\nPushing median stopping rule...\n"
-docker push ${REGISTRY}/earlystopping-medianstop:${TAG}
-docker push ${REGISTRY}/earlystopping-medianstop:latest
+docker push ${REGISTRY}/earlystopping-medianstop:${COMMIT_TAG}
+docker push ${REGISTRY}/earlystopping-medianstop:${RELEASE_TAG}
 
 # Training container images
 echo -e "\nPushing training container images..."
 
 echo -e "\nPushing mxnet mnist training container example...\n"
-docker push ${REGISTRY}/mxnet-mnist:${TAG}
-docker push ${REGISTRY}/mxnet-mnist:latest
+docker push ${REGISTRY}/mxnet-mnist:${COMMIT_TAG}
+docker push ${REGISTRY}/mxnet-mnist:${RELEASE_TAG}
 
 echo -e "\nPushing PyTorch mnist training container example...\n"
-docker push ${REGISTRY}/pytorch-mnist:${TAG}
-docker push ${REGISTRY}/pytorch-mnist:latest
+docker push ${REGISTRY}/pytorch-mnist:${COMMIT_TAG}
+docker push ${REGISTRY}/pytorch-mnist:${RELEASE_TAG}
 
 echo -e "\nPushing Keras CIFAR-10 CNN training container example for ENAS with GPU support...\n"
-docker push ${REGISTRY}/enas-cnn-cifar10-gpu:${TAG}
-docker push ${REGISTRY}/enas-cnn-cifar10-gpu:latest
+docker push ${REGISTRY}/enas-cnn-cifar10-gpu:${COMMIT_TAG}
+docker push ${REGISTRY}/enas-cnn-cifar10-gpu:${RELEASE_TAG}
 
 echo -e "\nPushing Keras CIFAR-10 CNN training container example for ENAS with CPU support...\n"
-docker push ${REGISTRY}/enas-cnn-cifar10-cpu:${TAG}
-docker push ${REGISTRY}/enas-cnn-cifar10-cpu:latest
+docker push ${REGISTRY}/enas-cnn-cifar10-cpu:${COMMIT_TAG}
+docker push ${REGISTRY}/enas-cnn-cifar10-cpu:${RELEASE_TAG}
 
 echo -e "\nPushing PyTorch CIFAR-10 CNN training container example for DARTS...\n"
-docker push ${REGISTRY}/darts-cnn-cifar10:${TAG}
-docker push ${REGISTRY}/darts-cnn-cifar10:latest
+docker push ${REGISTRY}/darts-cnn-cifar10:${COMMIT_TAG}
+docker push ${REGISTRY}/darts-cnn-cifar10:${RELEASE_TAG}
 
-echo -e "\nKatib ${VERSION} for commit SHA: ${COMMIT} has been released successfully!"
+echo -e "\nAll Katib images have been pushed successfully!\n"

--- a/scripts/v1beta1/push.sh
+++ b/scripts/v1beta1/push.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used to build and push all Katib images in docker.io/kubeflowkatib registry
+# It adds release tag and commit tag to the images.
+
+set -e
+
+COMMIT=$(git rev-parse --short=7 HEAD)
+REGISTRY="docker.io/kubeflowkatib"
+VERSION="v1beta1"
+TAG=${VERSION}-${COMMIT}
+
+echo "Releasing images for Katib ${VERSION}..."
+echo "Commit SHA: ${COMMIT}"
+echo "Image registry: ${REGISTRY}"
+echo -e "Image tag: ${TAG}\n"
+
+SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/../..
+cd ${SCRIPT_ROOT}
+
+# Building the images
+make build REGISTRY=${REGISTRY} TAG=${TAG}
+
+# Releasing the images
+echo -e "\nAll Katib images have been successfully built\n"
+
+# Katib core images
+echo -e "\nPushing Katib controller image...\n"
+docker push ${REGISTRY}/katib-controller:${TAG}
+docker push ${REGISTRY}/katib-controller:latest
+
+echo -e "\nPushing Katib DB manager image...\n"
+docker push ${REGISTRY}/katib-db-manager:${TAG}
+docker push ${REGISTRY}/katib-db-manager:latest
+
+echo -e "\nPushing Katib UI image...\n"
+docker push ${REGISTRY}/katib-ui:${TAG}
+docker push ${REGISTRY}/katib-ui:latest
+
+echo -e "\nPushing Katib cert generator image...\n"
+docker push ${REGISTRY}/cert-generator:${TAG}
+docker push ${REGISTRY}/cert-generator:latest
+
+echo -e "\nPushing file metrics collector image...\n"
+docker push ${REGISTRY}/file-metrics-collector:${TAG}
+docker push ${REGISTRY}/file-metrics-collector:latest
+
+echo -e "\nPushing TF Event metrics collector image...\n"
+docker push ${REGISTRY}/tfevent-metrics-collector:${TAG}
+docker push ${REGISTRY}/tfevent-metrics-collector:latest
+
+# Suggestion images
+echo -e "\nPushing suggestion images..."
+
+echo -e "\nPushing hyperopt suggestion...\n"
+docker push ${REGISTRY}/suggestion-hyperopt:${TAG}
+docker push ${REGISTRY}/suggestion-hyperopt:latest
+
+echo -e "\nPushing chocolate suggestion...\n"
+docker push ${REGISTRY}/suggestion-chocolate:${TAG}
+docker push ${REGISTRY}/suggestion-chocolate:latest
+
+echo -e "\nPushing hyperband suggestion...\n"
+docker push ${REGISTRY}/suggestion-hyperband:${TAG}
+docker push ${REGISTRY}/suggestion-hyperband:latest
+
+echo -e "\nPushing skopt suggestion...\n"
+docker push ${REGISTRY}/suggestion-skopt:${TAG}
+docker push ${REGISTRY}/suggestion-skopt:latest
+
+echo -e "\nPushing goptuna suggestion...\n"
+docker push ${REGISTRY}/suggestion-goptuna:${TAG}
+docker push ${REGISTRY}/suggestion-goptuna:latest
+
+echo -e "\nPushing ENAS suggestion...\n"
+docker push ${REGISTRY}/suggestion-enas:${TAG}
+docker push ${REGISTRY}/suggestion-enas:latest
+
+echo -e "\nPushing DARTS suggestion...\n"
+docker push ${REGISTRY}/suggestion-darts:${TAG}
+docker push ${REGISTRY}/suggestion-darts:latest
+
+# Early stopping images
+echo -e "\nPushing early stopping images...\n"
+
+echo -e "\nPushing median stopping rule...\n"
+docker push ${REGISTRY}/earlystopping-medianstop:${TAG}
+docker push ${REGISTRY}/earlystopping-medianstop:latest
+
+# Training container images
+echo -e "\nPushing training container images..."
+
+echo -e "\nPushing mxnet mnist training container example...\n"
+docker push ${REGISTRY}/mxnet-mnist:${TAG}
+docker push ${REGISTRY}/mxnet-mnist:latest
+
+echo -e "\nPushing PyTorch mnist training container example...\n"
+docker push ${REGISTRY}/pytorch-mnist:${TAG}
+docker push ${REGISTRY}/pytorch-mnist:latest
+
+echo -e "\nPushing Keras CIFAR-10 CNN training container example for ENAS with GPU support...\n"
+docker push ${REGISTRY}/enas-cnn-cifar10-gpu:${TAG}
+docker push ${REGISTRY}/enas-cnn-cifar10-gpu:latest
+
+echo -e "\nPushing Keras CIFAR-10 CNN training container example for ENAS with CPU support...\n"
+docker push ${REGISTRY}/enas-cnn-cifar10-cpu:${TAG}
+docker push ${REGISTRY}/enas-cnn-cifar10-cpu:latest
+
+echo -e "\nPushing PyTorch CIFAR-10 CNN training container example for DARTS...\n"
+docker push ${REGISTRY}/darts-cnn-cifar10:${TAG}
+docker push ${REGISTRY}/darts-cnn-cifar10:latest
+
+echo -e "\nKatib ${VERSION} for commit SHA: ${COMMIT} has been released successfully!"

--- a/scripts/v1beta1/release.sh
+++ b/scripts/v1beta1/release.sh
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script is used to release Katib project.
+# Run ./scripts/v1beta1/release.sh -b <BRANCH> -t <TAG> to execute it.
+# For example: ./scripts/v1beta1/release.sh -b release-0.3 -t v0.3.0
+# You must follow this format, Branch: release-X.Y, Tag: vX.Y.Z.
+
 set -e
 
 usage() {
@@ -43,9 +48,9 @@ if [[ -z "$BRANCH" || -z "$TAG" ]]; then
   exit 1
 fi
 
-# Clone Katib repo to temp dir.
+# Clone Katib repo to the temp dir.
 temp_dir=$(mktemp -d)
-git clone "git@github.com:andreyvelich/test-argocd.git" ${temp_dir}""
+git clone "git@github.com:kubeflow/katib.git" ${temp_dir}
 cd $temp_dir
 
 # Check if tag exists.
@@ -87,8 +92,8 @@ git commit -a -m "Katib official release ${TAG}"
 # Create new tag.
 git tag ${TAG}
 
-# Publish images to the registry with 2 tags: ${TAG} and v1beta1-<commit-sha>.
-# ---------------------------------
+# Publish images to the registry with 2 tags: ${TAG} and v1beta1-<commit-sha>
+make release-tag TAG=${TAG}
 
 read -p "Do you want to push Katib ${TAG} version to upstream? [y|n] "
 if [ "$REPLY" != "y" ]; then

--- a/scripts/v1beta1/release.sh
+++ b/scripts/v1beta1/release.sh
@@ -16,7 +16,7 @@
 
 # This script is used to release Katib project.
 # Run ./scripts/v1beta1/release.sh <BRANCH> <TAG> to execute it.
-# For example: ./scripts/v1beta1/release.sh release-0.3 v0.3.0
+# For example: ./scripts/v1beta1/release.sh release-0.11 v0.11.1
 # You must follow this format, Branch: release-X.Y, Tag: vX.Y.Z.
 
 set -e
@@ -50,7 +50,7 @@ if [[ ! -z $(git tag --list ${TAG}) ]]; then
   exit 1
 fi
 
-echo -e "\nCreating a new release. Branch: ${BRANCH}, TAG: ${TAG}\n"
+echo -e "\nCreating a new release. Branch: ${BRANCH}, Tag: ${TAG}\n"
 
 # Create or use the branch.
 if [[ -z $(git branch -r -l origin/${BRANCH}) ]]; then
@@ -66,8 +66,7 @@ else
 fi
 
 # ------------------ Change image tag ------------------
-# Change Katib image tags to the release ${TAG}.
-# Get current image tag.
+# Change Katib image tags to the new release tag.
 echo -e "\nUpdating Katib image tags to ${TAG}\n"
 # For MacOS we should set -i '' to avoid temp files from sed.
 if [[ $(uname) == "Darwin" ]]; then
@@ -78,7 +77,7 @@ fi
 echo -e "Katib images have been updated\n"
 
 # ------------------ Publish Katib SDK ------------------
-# Remove first "v" from the Katib version for the SDK version.
+# Remove first "v" from the Katib release version for the SDK version.
 sdk_version=${TAG:1}
 echo -e "Publishing Katib Python SDK, version: ${sdk_version}\n"
 # Run generate script.
@@ -100,14 +99,14 @@ echo -e "Katib Python SDK ${SDK_VERSION} has been published\n"
 
 # ------------------ Commit changes ------------------
 git commit -a -m "Katib official release ${TAG}"
-# Create new tag.
+# Create a new tag.
 git tag ${TAG}
 
 # ------------------ Publish Katib images ------------------
 # Publish images to the registry with 2 tags: ${TAG} and v1beta1-<commit-sha>
 echo -e "Publishing Katib images\n"
 make push-tag TAG=${TAG}
-echo -e "Katib images has been published\n"
+echo -e "Katib images have been published\n"
 
 # ------------------ Push to upstream ------------------
 read -p "Do you want to push Katib ${TAG} version to the upstream? [y|n] "

--- a/scripts/v1beta1/release.sh
+++ b/scripts/v1beta1/release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 The Kubeflow Authors.
+# Copyright 2021 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,114 +14,89 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script is used to release all Katib images in docker.io/kubeflowkatib registry
-# It adds "v1beta1-<commit-SHA>" and "latest" tag to them.
-
 set -e
 
-COMMIT=$(git rev-parse --short=7 HEAD)
-REGISTRY="docker.io/kubeflowkatib"
-VERSION="v1beta1"
-TAG=${VERSION}-${COMMIT}
+usage() {
+  echo "Usage: $0 [-b <BRANCH>] [-t <TAG>]" 1>&2
+  echo "You must follow this format, Branch: release-X.Y, Tag: vX.Y.Z"
+  exit 1
+}
 
-echo "Releasing images for Katib ${VERSION}..."
-echo "Commit SHA: ${COMMIT}"
-echo "Image registry: ${REGISTRY}"
-echo -e "Image tag: ${TAG}\n"
+while getopts ":b::t:" opt; do
+  case $opt in
+  b)
+    BRANCH=${OPTARG}
+    ;;
+  t)
+    TAG=${OPTARG}
+    ;;
+  *)
+    usage
+    ;;
+  esac
+done
 
-SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/../..
-cd ${SCRIPT_ROOT}
+if [[ -z "$BRANCH" || -z "$TAG" ]]; then
+  echo "Branch and Tag must be set"
+  echo "Usage: $0 [-b <BRANCH>] [-t <TAG>]" 1>&2
+  echo "You must follow this format, Branch: release-X.Y, Tag: vX.Y.Z"
+  exit 1
+fi
 
-# Building the images
-make build REGISTRY=${REGISTRY} TAG=${TAG}
+# Clone Katib repo to temp dir.
+temp_dir=$(mktemp -d)
+git clone "git@github.com:andreyvelich/test-argocd.git" ${temp_dir}""
+cd $temp_dir
 
-# Releasing the images
-echo -e "\nAll Katib images have been successfully built\n"
+# Check if tag exists.
+if [[ ! -z $(git tag --list ${TAG}) ]]; then
+  echo "Tag: ${TAG} exists. Release can't be published"
+  exit 1
+fi
 
-# Katib core images
-echo -e "\nPushing Katib controller image...\n"
-docker push ${REGISTRY}/katib-controller:${TAG}
-docker push ${REGISTRY}/katib-controller:latest
+echo -e "\nCreating new release. Branch: ${BRANCH}, TAG: ${TAG}\n"
 
-echo -e "\nPushing Katib DB manager image...\n"
-docker push ${REGISTRY}/katib-db-manager:${TAG}
-docker push ${REGISTRY}/katib-db-manager:latest
+# Create or use the branch.
+if [[ -z $(git branch -r -l origin/${BRANCH}) ]]; then
+  echo "Branch: ${BRANCH} does not exist. Creating a new minor release"
+  git checkout -b ${BRANCH}
+else
+  echo "Branch: ${BRANCH} exists. Creating a new patch release"
+  git checkout ${BRANCH}
+  read -p "Did you cherry pick all commits from the master to the ${BRANCH} branch? [y|n] "
+  if [ "$REPLY" != "y" ]; then
+    exit 1
+  fi
+fi
 
-echo -e "\nPushing Katib UI image...\n"
-docker push ${REGISTRY}/katib-ui:${TAG}
-docker push ${REGISTRY}/katib-ui:latest
+# Change Katib image tags to the release ${TAG}.
+# Get current image tag.
+current_tag=$(cat ./manifests/v1beta1/installs/katib-standalone/kustomization.yaml | grep -m 1 "newTag:" | awk '{print $2}')
+echo -e "\nUpdating Katib image tags from ${current_tag} to ${TAG}"
 
-echo -e "\nPushing Katib cert generator image...\n"
-docker push ${REGISTRY}/cert-generator:${TAG}
-docker push ${REGISTRY}/cert-generator:latest
+# For MacOS we should set -i '' to avoid temp files from sed.
+if [[ $(uname) == "Darwin" ]]; then
+  find ./manifests/v1beta1/installs -regex ".*\.yaml" -exec sed -i '' -e "s@${current_tag}@${TAG}@" {} \;
+else
+  find ./manifests/v1beta1/installs -regex ".*\.yaml" -exec sed -i -e "s@${current_tag}@${TAG}@" {} \;
+fi
+echo -e "Katib images have been updated\n"
 
-echo -e "\nPushing file metrics collector image...\n"
-docker push ${REGISTRY}/file-metrics-collector:${TAG}
-docker push ${REGISTRY}/file-metrics-collector:latest
+git commit -a -m "Katib official release ${TAG}"
 
-echo -e "\nPushing TF Event metrics collector image...\n"
-docker push ${REGISTRY}/tfevent-metrics-collector:${TAG}
-docker push ${REGISTRY}/tfevent-metrics-collector:latest
+# Create new tag.
+git tag ${TAG}
 
-# Suggestion images
-echo -e "\nPushing suggestion images..."
+# Publish images to the registry with 2 tags: ${TAG} and v1beta1-<commit-sha>.
+# ---------------------------------
 
-echo -e "\nPushing hyperopt suggestion...\n"
-docker push ${REGISTRY}/suggestion-hyperopt:${TAG}
-docker push ${REGISTRY}/suggestion-hyperopt:latest
+read -p "Do you want to push Katib ${TAG} version to upstream? [y|n] "
+if [ "$REPLY" != "y" ]; then
+  exit 1
+fi
 
-echo -e "\nPushing chocolate suggestion...\n"
-docker push ${REGISTRY}/suggestion-chocolate:${TAG}
-docker push ${REGISTRY}/suggestion-chocolate:latest
+# Push a new Branch and Tag.
+git push -u origin ${BRANCH}
+git push -u origin ${TAG}
 
-echo -e "\nPushing hyperband suggestion...\n"
-docker push ${REGISTRY}/suggestion-hyperband:${TAG}
-docker push ${REGISTRY}/suggestion-hyperband:latest
-
-echo -e "\nPushing skopt suggestion...\n"
-docker push ${REGISTRY}/suggestion-skopt:${TAG}
-docker push ${REGISTRY}/suggestion-skopt:latest
-
-echo -e "\nPushing goptuna suggestion...\n"
-docker push ${REGISTRY}/suggestion-goptuna:${TAG}
-docker push ${REGISTRY}/suggestion-goptuna:latest
-
-echo -e "\nPushing ENAS suggestion...\n"
-docker push ${REGISTRY}/suggestion-enas:${TAG}
-docker push ${REGISTRY}/suggestion-enas:latest
-
-echo -e "\nPushing DARTS suggestion...\n"
-docker push ${REGISTRY}/suggestion-darts:${TAG}
-docker push ${REGISTRY}/suggestion-darts:latest
-
-# Early stopping images
-echo -e "\nPushing early stopping images...\n"
-
-echo -e "\nPushing median stopping rule...\n"
-docker push ${REGISTRY}/earlystopping-medianstop:${TAG}
-docker push ${REGISTRY}/earlystopping-medianstop:latest
-
-# Training container images
-echo -e "\nPushing training container images..."
-
-echo -e "\nPushing mxnet mnist training container example...\n"
-docker push ${REGISTRY}/mxnet-mnist:${TAG}
-docker push ${REGISTRY}/mxnet-mnist:latest
-
-echo -e "\nPushing PyTorch mnist training container example...\n"
-docker push ${REGISTRY}/pytorch-mnist:${TAG}
-docker push ${REGISTRY}/pytorch-mnist:latest
-
-echo -e "\nPushing Keras CIFAR-10 CNN training container example for ENAS with GPU support...\n"
-docker push ${REGISTRY}/enas-cnn-cifar10-gpu:${TAG}
-docker push ${REGISTRY}/enas-cnn-cifar10-gpu:latest
-
-echo -e "\nPushing Keras CIFAR-10 CNN training container example for ENAS with CPU support...\n"
-docker push ${REGISTRY}/enas-cnn-cifar10-cpu:${TAG}
-docker push ${REGISTRY}/enas-cnn-cifar10-cpu:latest
-
-echo -e "\nPushing PyTorch CIFAR-10 CNN training container example for DARTS...\n"
-docker push ${REGISTRY}/darts-cnn-cifar10:${TAG}
-docker push ${REGISTRY}/darts-cnn-cifar10:latest
-
-echo -e "\nKatib ${VERSION} for commit SHA: ${COMMIT} has been released successfully!"
+echo -e "\nKatib ${TAG} has been released"


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1466.

I added Katib release script.
In `Makefile` we currently have:
1. `push-latest` to publish images to the registry with the latest and commit tags from the master branch.
2. `push-tag` to publish image to the registry with the release and commit tags from the release branch.
3. `release` to make a new Katib release.

I changed `build.sh` and `push.sh` scripts to use them when publishing `latest` images and `release` images.

Release script follows this (e.g. Branch = `release-0.11`, Tag = `v0.11.0`):
1. Clone Katib repo to the temp dir.
2. Create a new branch (`release-0.11`), if it doesn't exist or use the existing branch.
3. Change image tags to the `v0.11.0` in the Katib installs.
4. Publish Katib SDK with version - `0.11.0`.
5. Commit changes in the `release-0.11` branch and add `v0.11.0` tag to this commit.
6. Publish Katib images with 2 tags: `v1beta1-<commit-SHA>` and `v0.11.0`.
7. Push `release-0.11` branch and `v0.11.0` tag to the upstream.

Please take a look.
/assign @yanniszark @gaocegege @johnugeorge 
