### PR TITLE
fix broken links to kubeflow website

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -20,11 +20,11 @@ This developer guide is for people who want to contribute to the Katib project.
 If you're interesting in using Katib in your machine learning project,
 see the following user guides:
 
-- [Concepts](https://www.kubeflow.org/docs/components/hyperparameter-tuning/overview/)
+- [Concepts](https://www.kubeflow.org/docs/components/katib/overview/)
   in Katib, hyperparameter tuning, and neural architecture search.
-- [Getting started with Katib](https://kubeflow.org/docs/components/hyperparameter-tuning/hyperparameter/).
+- [Getting started with Katib](https://kubeflow.org/docs/components/katib/hyperparameter/).
 - Detailed guide to [configuring and running a Katib
-  experiment](https://kubeflow.org/docs/components/hyperparameter-tuning/experiment/).
+  experiment](https://kubeflow.org/docs/components/katib/experiment/).
 
 ## Requirements
 

--- a/examples/v1beta1/tekton/README.md
+++ b/examples/v1beta1/tekton/README.md
@@ -11,7 +11,7 @@ is completed. Metrics collector should not be stopped after training container i
 To avoid this problem, set `nop` image to metrics collector sidecar image.
 
 For example, if you are using
-[StdOut](https://www.kubeflow.org/docs/components/hyperparameter-tuning/experiment/#metrics-collector) metrics collector,
+[StdOut](https://www.kubeflow.org/docs/components/katib/experiment/#metrics-collector) metrics collector,
 `nop` image must be equal to `docker.io/kubeflowkatib/file-metrics-collector`.
 
 After deploying Tekton on your cluster, run bellow command to modify `nop` image:

--- a/pkg/ui/v1beta1/README.md
+++ b/pkg/ui/v1beta1/README.md
@@ -1,6 +1,6 @@
 # Katib User Interface
 
-This is the source code for the Katib UI. Current version of Katib UI is v1beta1. On the official Kubeflow website [here](https://www.kubeflow.org/docs/components/hyperparameter-tuning/experiment/#running-the-experiment-from-the-katib-ui) you can find information how to use Katib UI.
+This is the source code for the Katib UI. Current version of Katib UI is v1beta1. On the official Kubeflow website [here](https://www.kubeflow.org/docs/components/katib/experiment/#running-the-experiment-from-the-katib-ui) you can find information how to use Katib UI.
 We are using [React](https://reactjs.org/) framework to create frontend and Go as a backend.
 
 We are using [Material UI](https://material-ui.com/) to design frontend. Try to use Material UI components to implement new Katib UI features.
@@ -69,7 +69,7 @@ After that, you can access the UI using this URL: `http://localhost:8080/katib/`
 
 To run Katib UI in Production, after all changes in frontend and backend, you need to create an image for the UI. Under `/katib` directory run this: `docker build . -f cmd/ui/v1beta1/Dockerfile -t <name of your image>` to build the image. If Docker resources are not enough to build the frontend, you get `node` out of memory error. You can try to increase Docker resources or modify `package.json` as detailed [above](https://github.com/kubeflow/katib/tree/master/pkg/ui/v1beta1#serve-ui-frontend-and-backend) at step 1.
 
-After that, you can modify UI [deployment](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/components/ui/ui.yaml#L21) with your new image. Then, follow [these steps](https://www.kubeflow.org/docs/components/hyperparameter-tuning/hyperparameter/#accessing-the-katib-ui) to access Katib UI.
+After that, you can modify UI [deployment](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/components/ui/ui.yaml#L21) with your new image. Then, follow [these steps](https://www.kubeflow.org/docs/components/katib/hyperparameter/#accessing-the-katib-ui) to access Katib UI.
 
 ## Code style
 

--- a/pkg/ui/v1beta1/frontend/src/components/Menu/Main.jsx
+++ b/pkg/ui/v1beta1/frontend/src/components/Menu/Main.jsx
@@ -65,7 +65,7 @@ const Main = props => {
       <Typography variant={'h6'}>
         For usage instructions, see the{' '}
         <a
-          href="https://www.kubeflow.org/docs/components/hyperparameter-tuning/"
+          href="https://www.kubeflow.org/docs/components/katib/"
           target="_blank"
           rel="noopener noreferrer"
           className={classes.link}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the broken instructions link in the UI, also other references to the old kubeflow website structure.