### PR TITLE
new-ui: Show the Namespace Selector when app is deployed as standalone

### DIFF
--- a/cmd/new-ui/v1beta1/Dockerfile
+++ b/cmd/new-ui/v1beta1/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install git -y
 WORKDIR /kf
 RUN git clone https://github.com/kubeflow/kubeflow.git && \
     cd kubeflow && \
-    git checkout a349284
+    git checkout 24bcb8e
 
 # --- Build the frontend kubeflow library ---
 FROM node:12 AS frontend-kubeflow-lib

--- a/pkg/new-ui/v1beta1/README.md
+++ b/pkg/new-ui/v1beta1/README.md
@@ -42,7 +42,7 @@ You can build the common library with:
 ```bash
 cd /tmp && git clone https://github.com/kubeflow/kubeflow.git \
   && cd kubeflow \
-  && git checkout a349284 \
+  && git checkout 24bcb8e \
   && cd components/crud-web-apps/common/frontend/kubeflow-common-lib
 
 # build the common library module

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/experiments.component.html
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/experiments.component.html
@@ -1,5 +1,5 @@
 <lib-namespace-select
-  *ngIf="!env.production"
+  *ngIf="(ns.dashboardConnected$ | async) === dashboardDisconnectedState"
   namespacesUrl="/katib/fetch_namespaces"
 ></lib-namespace-select>
 

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/experiments.component.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/experiments.component.ts
@@ -17,6 +17,7 @@ import {
   NamespaceService,
   TemplateValue,
   ActionEvent,
+  DashboardState,
 } from 'kubeflow';
 
 import { KWABackendService } from 'src/app/services/backend.service';
@@ -36,6 +37,7 @@ export class ExperimentsComponent implements OnInit, OnDestroy {
   currNamespace: string;
   config = experimentsTableConfig;
   env = environment;
+  dashboardDisconnectedState = DashboardState.Disconnected;
 
   private subs = new Subscription();
   private poller: ExponentialBackoff;
@@ -43,8 +45,8 @@ export class ExperimentsComponent implements OnInit, OnDestroy {
   constructor(
     private backend: KWABackendService,
     private confirmDialog: ConfirmDialogService,
-    private namespaceService: NamespaceService,
     private router: Router,
+    public ns: NamespaceService,
   ) {}
 
   ngOnInit() {
@@ -52,7 +54,7 @@ export class ExperimentsComponent implements OnInit, OnDestroy {
 
     // Reset the poller whenever the selected namespace changes
     this.subs.add(
-      this.namespaceService.getSelectedNamespace().subscribe(nameSpace => {
+      this.ns.getSelectedNamespace().subscribe(nameSpace => {
         this.currNamespace = nameSpace;
         this.poller.reset();
       }),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the UI code, for the new UI #1421, to
1. detect if the dashboard is present
2. if it's not then show the namespace selector component

This is a first step for #1437. With this fix the new UI will be able to also be deployed as a standalone app and not always rely on the Central Dashboard to be present, to allow the users to navigate and inspect namespaces.

This brings the app at the same state and with the same behavior for the standalone mode with the current UI. Next steps would be to extend the current backend to use `SubjectAccessReviews` to perform authorization checks, if the app is deployed in kubeflow mode. But we can coordinate on this effort in our tracking issue #1437.

**Which issue(s) this PR fixes**:
This is a first step for #1437

**Special notes for your reviewer**:

This PR also updates the base commit to use for the common ui code, that lives in `kubeflow/kubeflow`. In order to check the changes locally you will need to follow the [updated instructions](https://github.com/kubeflow/katib/blob/e7ea4476b98f85878f9870db8c5e12cc805ff288/pkg/new-ui/v1beta1/README.md#serve-only-the-frontend), which are based on the newer commit.

But you could also build the oci image from the updated dockerfile as well
