### PR TITLE
Fix release script to replace Katib image tags

### DIFF
--- a/scripts/v1beta1/release.sh
+++ b/scripts/v1beta1/release.sh
@@ -70,9 +70,15 @@ fi
 echo -e "\nUpdating Katib image tags to ${TAG}\n"
 # For MacOS we should set -i '' to avoid temp files from sed.
 if [[ $(uname) == "Darwin" ]]; then
-  find ./manifests/v1beta1/installs -regex ".*\.yaml" -exec sed -i '' -e "s@newTag: .*@newTag: ${TAG}@" {} \;
+  sed -i '' -e "s@newTag: .*@newTag: ${TAG}@" ./manifests/v1beta1/installs/katib-external-db/kustomization.yaml
+  sed -i '' -e "s@:[^[:space:]].*\"@:${TAG}\"@" ./manifests/v1beta1/installs/katib-standalone/katib-config-patch.yaml
+  sed -i '' -e "s@newTag: .*@newTag: ${TAG}@" ./manifests/v1beta1/installs/katib-standalone/kustomization.yaml
+  sed -i '' -e "s@newTag: .*@newTag: ${TAG}@" ./manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
 else
-  find ./manifests/v1beta1/installs -regex ".*\.yaml" -exec sed -i -e "s@newTag: .*@newTag: ${TAG}@" {} \;
+  sed -i -e "s@newTag: .*@newTag: ${TAG}@" ./manifests/v1beta1/installs/katib-external-db/kustomization.yaml
+  sed -i -e "s@:[^[:space:]].*\"@:${TAG}\"@" ./manifests/v1beta1/installs/katib-standalone/katib-config-patch.yaml
+  sed -i -e "s@newTag: .*@newTag: ${TAG}@" ./manifests/v1beta1/installs/katib-standalone/kustomization.yaml
+  sed -i -e "s@newTag: .*@newTag: ${TAG}@" ./manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
 fi
 echo -e "Katib images have been updated\n"
 
@@ -95,7 +101,7 @@ python3 setup.py sdist bdist_wheel
 twine upload dist/*
 rm -r dist/ build/
 cd ../../..
-echo -e "Katib Python SDK ${SDK_VERSION} has been published\n"
+echo -e "\nKatib Python SDK ${sdk_version} has been published\n"
 
 # ------------------ Commit changes ------------------
 git commit -a -m "Katib official release ${TAG}"
@@ -104,7 +110,7 @@ git tag ${TAG}
 
 # ------------------ Publish Katib images ------------------
 # Publish images to the registry with 2 tags: ${TAG} and v1beta1-<commit-sha>
-echo -e "Publishing Katib images\n"
+echo -e "\nPublishing Katib images\n"
 make push-tag TAG=${TAG}
 echo -e "Katib images have been published\n"
 

--- a/test/e2e/v1beta1/run-e2e-experiment.go
+++ b/test/e2e/v1beta1/run-e2e-experiment.go
@@ -128,7 +128,7 @@ func main() {
 			exp.Name, maxTrials, parallelTrials)
 
 		// Wait until Experiment is restarted.
-		timeout := 10 * time.Second
+		timeout := 60 * time.Second
 		endTime := time.Now().Add(timeout)
 		for time.Now().Before(endTime) {
 			exp, err = kclient.GetExperiment(exp.Name, exp.Namespace)


### PR DESCRIPTION
I fixed incorrect replace for the Katib image tags in the release script.
The current script replaces `mysql` image tag for the [`katib-ibm` install](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/installs/katib-ibm/kustomization.yaml#L9) and doesn't replace tags in the `katib-config-patch.yaml`, which is not correct.

I make the explicit replace in the `katib-external-db/kustomization.yaml`, `katib-config-patch.yaml`, `katib-standalone/kustomization.yaml` and `katib-with-kubeflow/kustomization.yaml` files to make sure that we don't replace tags in the other places.

Please take a look.


/assign @yanniszark @gaocegege @johnugeorge 