### PR TITLE
Katib manifests fixes for 1.3

### DIFF
--- a/hack/cert-generator.sh
+++ b/hack/cert-generator.sh
@@ -68,7 +68,9 @@ fi
 set -e
 echo "INFO: Creating CSR: ${csr_name}"
 
-cat <<EOF | kubectl create -f -
+# signerName is not supported in Kubernetes <= 1.17
+# See: https://github.com/kubeflow/katib/issues/1500
+cat <<EOF | kubectl create --validate=false -f -
 apiVersion: certificates.k8s.io/v1beta1
 kind: CertificateSigningRequest
 metadata:

--- a/manifests/v1beta1/components/controller/controller.yaml
+++ b/manifests/v1beta1/components/controller/controller.yaml
@@ -17,6 +17,7 @@ spec:
         app: katib-controller
       annotations:
         prometheus.io/scrape: "true"
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: katib-controller
       containers:

--- a/manifests/v1beta1/components/db-manager/db-manager.yaml
+++ b/manifests/v1beta1/components/db-manager/db-manager.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         app: katib-db-manager
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: katib-db-manager

--- a/manifests/v1beta1/components/mysql/mysql.yaml
+++ b/manifests/v1beta1/components/mysql/mysql.yaml
@@ -17,6 +17,8 @@ spec:
     metadata:
       labels:
         app: katib-mysql
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: katib-mysql

--- a/manifests/v1beta1/components/ui/ui.yaml
+++ b/manifests/v1beta1/components/ui/ui.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         app: katib-ui
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: katib-ui

--- a/manifests/v1beta1/components/webhook/cert-generator.yaml
+++ b/manifests/v1beta1/components/webhook/cert-generator.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: kubeflow
 spec:
   template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: katib-cert-generator
       containers:

--- a/manifests/v1beta1/installs/katib-with-kubeflow-cert-manager/certificate.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow-cert-manager/certificate.yaml
@@ -1,0 +1,23 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: katib-webhook-cert
+spec:
+  isCA: true
+  commonName: $(KATIB_SERVICE_NAME).$(KATIB_NAMESPACE).svc
+  dnsNames:
+  - $(KATIB_SERVICE_NAME).$(KATIB_NAMESPACE).svc
+  - $(KATIB_SERVICE_NAME).$(KATIB_NAMESPACE).svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: katib-selfsigned-issuer
+  secretName: katib-webhook-cert
+
+---
+
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: katib-selfsigned-issuer
+spec:
+  selfSigned: {}

--- a/manifests/v1beta1/installs/katib-with-kubeflow-cert-manager/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow-cert-manager/kustomization.yaml
@@ -1,0 +1,96 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  # Katib controller.
+  - ../../components/controller/controller.yaml
+  - ../../components/controller/service.yaml
+  - ../../components/controller/rbac.yaml
+  - ../../components/controller/katib-config.yaml
+  - ../../components/controller/trial-templates.yaml
+  # Katib CRDs.
+  - ../../components/crd/experiment.yaml
+  - ../../components/crd/suggestion.yaml
+  - ../../components/crd/trial.yaml
+  # Katib DB manager.
+  - ../../components/db-manager/db-manager.yaml
+  - ../../components/db-manager/service.yaml
+  # Katib DB mysql.
+  - ../../components/mysql/mysql.yaml
+  - ../../components/mysql/service.yaml
+  - ../../components/mysql/pvc.yaml
+  - ../../components/mysql/secret.yaml
+  # Katib UI.
+  - ../../components/ui/ui.yaml
+  - ../../components/ui/service.yaml
+  - ../../components/ui/rbac.yaml
+  # Katib webhooks.
+  - ../../components/webhook/webhooks.yaml
+  # Cert-manager certificate for webhooks
+  - certificate.yaml
+  # Kubeflow Katib components.
+  - ../katib-with-kubeflow/katib-application.yaml
+  - ../katib-with-kubeflow/kubeflow-katib-roles.yaml
+  - ../katib-with-kubeflow/ui-virtual-service.yaml
+images:
+  - name: docker.io/kubeflowkatib/katib-controller
+    newTag: latest
+    newName: docker.io/kubeflowkatib/katib-controller
+  - name: docker.io/kubeflowkatib/katib-db-manager
+    newTag: latest
+    newName: docker.io/kubeflowkatib/katib-db-manager
+  - name: docker.io/kubeflowkatib/katib-ui
+    newTag: latest
+    newName: docker.io/kubeflowkatib/katib-ui
+  - name: docker.io/kubeflowkatib/cert-generator
+    newTag: latest
+    newName: docker.io/kubeflowkatib/cert-generator
+
+patchesStrategicMerge:
+  - ../katib-standalone/katib-config-patch.yaml
+  - patches/katib-cert-injection.yaml
+
+patchesJson6902:
+  - path: ../katib-with-kubeflow/patches/mysql-pvc.yaml
+    target:
+      version: v1
+      name: katib-mysql
+      kind: PersistentVolumeClaim
+      namespace: kubeflow
+
+commonLabels:
+  app.kubernetes.io/component: katib
+
+vars:
+- fieldref:
+    fieldPath: metadata.namespace
+  name: KATIB_UI_NAMESPACE
+  objref:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: katib-ui
+- fieldref:
+    fieldPath: metadata.namespace
+  name: KATIB_NAMESPACE
+  objref:
+    apiVersion: v1
+    kind: Service
+    name: katib-controller
+- fieldref:
+    fieldPath: metadata.name
+  name: KATIB_SERVICE_NAME
+  objref:
+    apiVersion: v1
+    kind: Service
+    name: katib-controller
+- name: KATIB_CERT_NAME
+  objref:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1alpha2
+      name: katib-webhook-cert
+  fieldref:
+    fieldpath: metadata.name
+
+configurations:
+  - params.yaml

--- a/manifests/v1beta1/installs/katib-with-kubeflow-cert-manager/params.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow-cert-manager/params.yaml
@@ -1,0 +1,20 @@
+varReference:
+- path: spec/http/route/destination/host
+  kind: VirtualService
+- path: spec/commonName
+  kind: Certificate
+- path: spec/dnsNames
+  kind: Certificate
+- path: spec/issuerRef/name
+  kind: Certificate
+- path: metadata/annotations
+  kind: MutatingWebhookConfiguration
+- path: metadata/annotations
+  kind: ValidatingWebhookConfiguration
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name

--- a/manifests/v1beta1/installs/katib-with-kubeflow-cert-manager/patches/katib-cert-injection.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow-cert-manager/patches/katib-cert-injection.yaml
@@ -1,0 +1,13 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: katib.kubeflow.org
+  annotations:
+    cert-manager.io/inject-ca-from: $(KATIB_NAMESPACE)/$(KATIB_CERT_NAME)
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: katib.kubeflow.org
+  annotations:
+    cert-manager.io/inject-ca-from: $(KATIB_NAMESPACE)/$(KATIB_CERT_NAME)

--- a/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
@@ -45,8 +45,18 @@ images:
   - name: docker.io/kubeflowkatib/cert-generator
     newTag: latest
     newName: docker.io/kubeflowkatib/cert-generator
+
 patchesStrategicMerge:
   - ../katib-standalone/katib-config-patch.yaml
+
+patchesJson6902:
+  - path: patches/mysql-pvc.yaml
+    target:
+      version: v1
+      name: katib-mysql
+      kind: PersistentVolumeClaim
+      namespace: kubeflow
+
 commonLabels:
   app.kubernetes.io/component: katib
 

--- a/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
@@ -49,5 +49,15 @@ patchesStrategicMerge:
   - ../katib-standalone/katib-config-patch.yaml
 commonLabels:
   app.kubernetes.io/component: katib
+
+vars:
+- fieldref:
+    fieldPath: metadata.namespace
+  name: KATIB_UI_NAMESPACE
+  objref:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: katib-ui
+
 configurations:
   - params.yaml

--- a/manifests/v1beta1/installs/katib-with-kubeflow/patches/mysql-pvc.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/patches/mysql-pvc.yaml
@@ -1,0 +1,6 @@
+[
+  {
+    "op": "remove",
+    "path": "/spec/storageClassName"
+  }
+]

--- a/manifests/v1beta1/installs/katib-with-kubeflow/ui-virtual-service.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/ui-virtual-service.yaml
@@ -15,6 +15,6 @@ spec:
         uri: /katib/
       route:
         - destination:
-            host: katib-ui.$(katib-ui-namespace).svc.$(clusterDomain)
+            host: katib-ui.$(KATIB_UI_NAMESPACE).svc.cluster.local
             port:
               number: 80


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubeflow/katib/issues/1499
Fixes https://github.com/kubeflow/katib/issues/1500
Fixes https://github.com/kubeflow/katib/issues/1501

**Special notes for your reviewer**:

@andreyvelich I made the changes needed for Kubeflow 1.3, as the aforementioned issues show.
In addition, I made sure that the VirtualService is deployable by default, as other components' manifests do.
After merging, I will create a cherry-pick PR.