### PR TITLE
Fix setup Katib script to work on the release branch

### DIFF
--- a/test/scripts/v1beta1/setup-katib.sh
+++ b/test/scripts/v1beta1/setup-katib.sh
@@ -42,8 +42,8 @@ KUSTOMIZE_PATH="manifests/v1beta1/installs/katib-standalone/kustomization.yaml"
 CONFIG_PATCH="manifests/v1beta1/installs/katib-standalone/katib-config-patch.yaml"
 
 # Change tag to all images in kustomization and katib-config patch files.
-sed -i -e "s@latest@${VERSION}@" ${KUSTOMIZE_PATH}
-sed -i -e "s@latest@${VERSION}@" ${CONFIG_PATCH}
+sed -i -e "s@newTag: .*@newTag: ${VERSION}@" ${KUSTOMIZE_PATH}
+sed -i -e "s@:[^[:space:]].*\"@:${VERSION}\"@" ${CONFIG_PATCH}
 
 # Change Katib controller image.
 sed -i -e "s@newName: docker.io/kubeflowkatib/katib-controller@newName: ${ECR_REGISTRY}/${REPO_NAME}/v1beta1/katib-controller@" ${KUSTOMIZE_PATH}


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1504.
We should replace any tag in the `setup-katib.sh` script.
/cc @gaocegege @johnugeorge @yanniszark 