### PR TITLE
Add cert manager install to the release script

### DIFF
--- a/scripts/v1beta1/release.sh
+++ b/scripts/v1beta1/release.sh
@@ -74,11 +74,13 @@ if [[ $(uname) == "Darwin" ]]; then
   sed -i '' -e "s@:[^[:space:]].*\"@:${TAG}\"@" ./manifests/v1beta1/installs/katib-standalone/katib-config-patch.yaml
   sed -i '' -e "s@newTag: .*@newTag: ${TAG}@" ./manifests/v1beta1/installs/katib-standalone/kustomization.yaml
   sed -i '' -e "s@newTag: .*@newTag: ${TAG}@" ./manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
+  sed -i '' -e "s@newTag: .*@newTag: ${TAG}@" ./manifests/v1beta1/installs/katib-with-kubeflow-cert-manager/kustomization.yaml
 else
   sed -i -e "s@newTag: .*@newTag: ${TAG}@" ./manifests/v1beta1/installs/katib-external-db/kustomization.yaml
   sed -i -e "s@:[^[:space:]].*\"@:${TAG}\"@" ./manifests/v1beta1/installs/katib-standalone/katib-config-patch.yaml
   sed -i -e "s@newTag: .*@newTag: ${TAG}@" ./manifests/v1beta1/installs/katib-standalone/kustomization.yaml
   sed -i -e "s@newTag: .*@newTag: ${TAG}@" ./manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
+  sed -i -e "s@newTag: .*@newTag: ${TAG}@" ./manifests/v1beta1/installs/katib-with-kubeflow-cert-manager/kustomization.yaml
 fi
 echo -e "Katib images have been updated\n"
 

--- a/test/e2e/v1beta1/run-e2e-experiment.go
+++ b/test/e2e/v1beta1/run-e2e-experiment.go
@@ -199,7 +199,7 @@ func main() {
 
 func waitExperimentFinish(kclient katibclient.Client, exp *experimentsv1beta1.Experiment) (*experimentsv1beta1.Experiment, error) {
 	// Experiment should be completed before the timeout.
-	timeout := 30 * time.Minute
+	timeout := 50 * time.Minute
 	for endTime := time.Now().Add(timeout); time.Now().Before(endTime); {
 		exp, err := kclient.GetExperiment(exp.Name, exp.Namespace)
 		if err != nil {


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1505.
We should add `katib-with-kubeflow-cert-manager` install to release script for updating the images.

/cc @yanniszark @gaocegege @johnugeorge 