### PR TITLE
Use kustomize v4 or later.

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -32,7 +32,7 @@ see the following user guides:
 
 - [Go](https://golang.org/) (1.13 or later)
 - [Docker](https://docs.docker.com/) (17.05 or later.)
-- [kustomize](https://kustomize.io/) (3.2 or later)
+- [kustomize](https://kustomize.io/) (4.0 or later)
 
 ## Build from source code
 

--- a/scripts/v1beta1/deploy.sh
+++ b/scripts/v1beta1/deploy.sh
@@ -19,4 +19,4 @@ set -o xtrace
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/../..
 
 cd ${SCRIPT_ROOT}
-kustomize build manifests/v1beta1/installs/katib-standalone --load_restrictor none | kubectl apply -f -
+kustomize build manifests/v1beta1/installs/katib-standalone --load-restrictor LoadRestrictionsNone | kubectl apply -f -

--- a/scripts/v1beta1/undeploy.sh
+++ b/scripts/v1beta1/undeploy.sh
@@ -23,4 +23,4 @@ sleep 10
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/../..
 
 cd ${SCRIPT_ROOT}
-kustomize build manifests/v1beta1/installs/katib-standalone --load_restrictor none | kubectl delete -f -
+kustomize build manifests/v1beta1/installs/katib-standalone --load-restrictor LoadRestrictionsNone | kubectl delete -f -


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
`--load_restrictor none` does not work on the latest version of kustomize.

```
$ make deploy
bash scripts/v1beta1/deploy.sh
++ dirname scripts/v1beta1/deploy.sh
+ SCRIPT_ROOT=scripts/v1beta1/../..
+ cd scripts/v1beta1/../..
+ kustomize build manifests/v1beta1/installs/katib-standalone --load_restrictor none
+ kubectl apply -f -
Error: unknown flag: --load_restrictor
error: no objects passed to apply
make: *** [deploy] Error 1
```

According to the following issue, the flag is hyphenated from v4+ and `none` is invalid (legal values are ` [LoadRestrictionsRootOnly LoadRestrictionsNone]`).
https://github.com/kubernetes-sigs/kustomize/issues/3746



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:

None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
