### PR TITLE
Fix a link to Kustomize manifest for new Katib UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ missing functionalities are the ability to edit the TrialTemplate ConfigMaps.
 While this UI is not ready to replace the current one we would like to
 encourage users to also give it a try and provide us with feedback. To try it
 out the user has to update the Katib UI image `newName` with the new registry
-`docker.io/kubeflowkatib/katib-new-ui` in the [Kustomize](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/installs/katib-standalone/kustomization.yaml#L43)
+`docker.io/kubeflowkatib/katib-new-ui` in the [Kustomize](https://github.com/kubeflow/katib/blob/54854c1bb/manifests/v1beta1/installs/katib-standalone/kustomization.yaml#L29)
 manifests.
 
 ![newkatibui](./docs/images/katib-new-ui.png)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

The link to the Kustomization's manifest to use the new Katib UI is broken like:
https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/installs/katib-standalone/kustomization.yaml#L43

This PR fixes the link by specifying the latest commit revision on master branch.

cc @kimwnasptd

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:

None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
