### PR TITLE
feat: add naming regex check on validating webhook

### DIFF
--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -67,6 +67,15 @@ func (g *DefaultValidator) InjectClient(c client.Client) {
 // ValidateExperiment validates experiment for the given instance.
 // oldInst is specified when experiment is edited.
 func (g *DefaultValidator) ValidateExperiment(instance, oldInst *experimentsv1beta1.Experiment) error {
+	namingConvention, _ := regexp.Compile("^[a-z]([-a-z0-9]*[a-z0-9])?")
+	if !namingConvention.MatchString(instance.Name) {
+		msg :="Name must consist of lower case alphanumeric characters or '-'," +
+			" start with an alphabetic character, and end with an alphanumeric character" +
+			" (e.g. 'my-name', or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?)'"
+
+		return fmt.Errorf(msg)
+	}
+
 	if instance.Spec.MaxFailedTrialCount != nil && *instance.Spec.MaxFailedTrialCount < 0 {
 		return fmt.Errorf("spec.maxFailedTrialCount should not be less than 0")
 	}

--- a/pkg/webhook/v1beta1/experiment/validator/validator_test.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator_test.go
@@ -68,6 +68,16 @@ func TestValidateExperiment(t *testing.T) {
 		oldInstance     *experimentsv1beta1.Experiment
 		testDescription string
 	}{
+		// Name
+		{
+			Instance: func() *experimentsv1beta1.Experiment {
+				i := newFakeInstance()
+				i.Name = "1234-test"
+				return i
+			}(),
+			Err:             true,
+			testDescription: "Name is invalid",
+		},
 		//Objective
 		{
 			Instance: func() *experimentsv1beta1.Experiment {


### PR DESCRIPTION

**What this PR does / why we need it**:

When invalid-named experiment CREATE API was requested, such experiment status was shown as CREATED, but in fact it was not created.
Therefore, naming convention should be checked in validating webhook

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #1538

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
