### PR TITLE
Disable default PV for Experiment with resume from volume

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.8
+          go-version: 1.15.13
 
       # Verify that go.mod and go.sum is synchronized
       - name: Check Go modules

--- a/go.sum
+++ b/go.sum
@@ -1368,6 +1368,7 @@ k8s.io/csi-translation-lib v0.20.4/go.mod h1:WisLItCdoDKB4lr6nkhzQsfgBNBJDI/TD9m
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20201113003025-83324d819ded h1:JApXBKYyB7l9xx+DK7/+mFjC7A9Bt5A93FPvFD0HIFE=
 k8s.io/gengo v0.0.0-20201113003025-83324d819ded/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/heapster v1.2.0-beta.1/go.mod h1:h1uhptVXMwC8xtZBYsPXKVi8fpdlYkTs6k949KozGrM=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=

--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -119,18 +119,11 @@ const (
 	// DefaultContainerSuggestionVolumeMountPath is the default mount path in suggestion container
 	DefaultContainerSuggestionVolumeMountPath = "/opt/katib/data"
 
-	// DefaultSuggestionStorageClassName is the default value for suggestion's volume storage class name
-	DefaultSuggestionStorageClassName = "katib-suggestion"
-
 	// DefaultSuggestionVolumeStorage is the default value for suggestion's volume storage
 	DefaultSuggestionVolumeStorage = "1Gi"
 
 	// DefaultSuggestionVolumeAccessMode is the default value for suggestion's volume access mode
 	DefaultSuggestionVolumeAccessMode = corev1.ReadWriteOnce
-
-	// DefaultSuggestionVolumeLocalPathPrefix is the default cluster local path prefix for suggestion volume
-	// Full default local path = /tmp/katib/suggestions/<suggestion-name>-<suggestion-algorithm>-<suggestion-namespace>
-	DefaultSuggestionVolumeLocalPathPrefix = "/tmp/katib/suggestions/"
 
 	// ReconcileErrorReason is the reason when there is a reconcile error.
 	ReconcileErrorReason = "ReconcileError"

--- a/pkg/controller.v1beta1/suggestion/composer/composer.go
+++ b/pkg/controller.v1beta1/suggestion/composer/composer.go
@@ -259,7 +259,7 @@ func (g *General) desiredContainers(s *suggestionsv1beta1.Suggestion,
 }
 
 // DesiredVolume returns desired PVC and PV for Suggestion.
-// If PV doesn't exist in Katib config return null for PV.
+// If PV doesn't exist in Katib config return nil for PV.
 func (g *General) DesiredVolume(s *suggestionsv1beta1.Suggestion) (*corev1.PersistentVolumeClaim, *corev1.PersistentVolume, error) {
 
 	suggestionConfigData, err := katibconfig.GetSuggestionConfigData(s.Spec.Algorithm.AlgorithmName, g.Client)

--- a/pkg/controller.v1beta1/suggestion/composer/composer.go
+++ b/pkg/controller.v1beta1/suggestion/composer/composer.go
@@ -23,6 +23,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -257,16 +258,14 @@ func (g *General) desiredContainers(s *suggestionsv1beta1.Suggestion,
 	return containers
 }
 
-// DesiredVolume returns desired PVC and PV for suggestion.
-// If StorageClassName != DefaultSuggestionStorageClassName returns only PVC.
+// DesiredVolume returns desired PVC and PV for Suggestion.
+// If PV doesn't exist in Katib config return null for PV.
 func (g *General) DesiredVolume(s *suggestionsv1beta1.Suggestion) (*corev1.PersistentVolumeClaim, *corev1.PersistentVolume, error) {
 
 	suggestionConfigData, err := katibconfig.GetSuggestionConfigData(s.Spec.Algorithm.AlgorithmName, g.Client)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	persistentVolumeName := util.GetSuggestionPersistentVolumeName(s)
 
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
@@ -282,24 +281,19 @@ func (g *General) DesiredVolume(s *suggestionsv1beta1.Suggestion) (*corev1.Persi
 	}
 
 	var pv *corev1.PersistentVolume
-	// Create PV with local hostPath by default
-	if *pvc.Spec.StorageClassName == consts.DefaultSuggestionStorageClassName {
-		localLabel := map[string]string{"type": "local"}
+	// Create PV if Katib config contains it.
+	if !equality.Semantic.DeepEqual(suggestionConfigData.PersistentVolumeSpec, corev1.PersistentVolumeSpec{}) {
+
+		persistentVolumeName := util.GetSuggestionPersistentVolumeName(s)
 
 		pv = &corev1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   persistentVolumeName,
-				Labels: localLabel,
+				Labels: suggestionConfigData.PersistentVolumeLabels,
 			},
 			Spec: suggestionConfigData.PersistentVolumeSpec,
 		}
 
-		// If default host path is specified attach pv name to the path.
-		// Full default local path = DefaultSuggestionVolumeLocalPathPrefix<suggestion-name>-<suggestion-algorithm>-<suggestion-namespace>
-		if pv.Spec.PersistentVolumeSource.HostPath != nil &&
-			pv.Spec.PersistentVolumeSource.HostPath.Path == consts.DefaultSuggestionVolumeLocalPathPrefix {
-			pv.Spec.PersistentVolumeSource.HostPath.Path = pv.Spec.PersistentVolumeSource.HostPath.Path + persistentVolumeName
-		}
 	}
 
 	return pvc, pv, nil

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller_test.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller_test.go
@@ -164,11 +164,6 @@ func TestReconcile(t *testing.T) {
 		return c.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: resourceName}, &corev1.Service{})
 	}, timeout).Should(gomega.Succeed())
 
-	// Expect that PV with appropriate name is created
-	g.Eventually(func() error {
-		return c.Get(context.TODO(), types.NamespacedName{Name: resourceName + "-" + namespace}, &corev1.PersistentVolume{})
-	}, timeout).Should(gomega.Succeed())
-
 	// Expect that PVC with appropriate name is created
 	g.Eventually(func() error {
 		return c.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: resourceName}, &corev1.PersistentVolumeClaim{})

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller_util.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller_util.go
@@ -65,13 +65,13 @@ func (r *ReconcileSuggestion) reconcileVolume(
 	foundPVC := &corev1.PersistentVolumeClaim{}
 	foundPV := &corev1.PersistentVolume{}
 
-	// Try to find/create PV, if PV has to be created
+	// Try to find/create PV, if PV has to be created.
 	if pv != nil {
 		err := r.Get(context.TODO(), types.NamespacedName{Name: pv.Name}, foundPV)
 		if err != nil && errors.IsNotFound(err) {
 			logger.Info("Creating Persistent Volume", "name", pv.Name)
 			err = r.Create(context.TODO(), pv)
-			// Return only if Create was failed, otherwise try to find/create PVC
+			// Return only if Create was failed, otherwise try to find/create PVC.
 			if err != nil {
 				return nil, nil, err
 			}
@@ -80,7 +80,7 @@ func (r *ReconcileSuggestion) reconcileVolume(
 		}
 	}
 
-	// Try to find/create PVC
+	// Try to find/create PVC.
 	err := r.Get(context.TODO(), types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, foundPVC)
 	if err != nil && errors.IsNotFound(err) {
 		logger.Info("Creating Persistent Volume Claim", "name", pvc.Name)

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -109,9 +109,8 @@ func (g *DefaultValidator) ValidateExperiment(instance, oldInst *experimentsv1be
 		oldInst.Spec.MaxTrialCount = instance.Spec.MaxTrialCount
 		oldInst.Spec.ParallelTrialCount = instance.Spec.ParallelTrialCount
 		if !equality.Semantic.DeepEqual(instance.Spec, oldInst.Spec) {
-			return fmt.Errorf("Only spec.parallelTrialCount, spec.maxTrialCount and spec.maxFailedTrialCount are editable")
+			return fmt.Errorf("only spec.parallelTrialCount, spec.maxTrialCount and spec.maxFailedTrialCount are editable")
 		}
-		return nil
 	}
 	if err := g.validateObjective(instance.Spec.Objective); err != nil {
 		return err

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -168,7 +168,7 @@ func (g *DefaultValidator) validateAlgorithm(ag *commonapiv1beta1.AlgorithmSpec)
 	}
 
 	if _, err := g.GetSuggestionConfigData(ag.AlgorithmName); err != nil {
-		return fmt.Errorf("Don't support algorithm %s: %v.", ag.AlgorithmName, err)
+		return fmt.Errorf("unable to get Suggestion config data for algorithm %s: %v.", ag.AlgorithmName, err)
 	}
 
 	return nil

--- a/test/e2e/v1beta1/run-e2e-experiment.go
+++ b/test/e2e/v1beta1/run-e2e-experiment.go
@@ -332,20 +332,13 @@ func verifySuggestion(kclient katibclient.Client, exp *experimentsv1beta1.Experi
 			return fmt.Errorf("Suggestion deployment: %v is still alive while ResumePolicy: %v, error: %v", deploymentName, exp.Spec.ResumePolicy, err)
 		}
 
-		// PV and PVC should not be deleted for Suggestion with resume policy FromVolume.
+		// PVC should not be deleted for Suggestion with resume policy FromVolume.
 		if exp.Spec.ResumePolicy == experimentsv1beta1.FromVolume {
 			pvcName := controllerUtil.GetSuggestionPersistentVolumeClaimName(sug)
 			namespacedName = types.NamespacedName{Name: pvcName, Namespace: sug.Namespace}
 			err = kclient.GetClient().Get(context.TODO(), namespacedName, &corev1.PersistentVolumeClaim{})
 			if errors.IsNotFound(err) {
-				return fmt.Errorf("Suggestion PVC: %v is not alive while ResumePolicy: %v", pvcName, exp.Spec.ResumePolicy)
-			}
-
-			pvName := controllerUtil.GetSuggestionPersistentVolumeName(sug)
-			namespacedName = types.NamespacedName{Name: pvName}
-			err = kclient.GetClient().Get(context.TODO(), namespacedName, &corev1.PersistentVolume{})
-			if errors.IsNotFound(err) {
-				return fmt.Errorf("Suggestion PV: %v is not alive while ResumePolicy: %v", pvName, experimentsv1beta1.FromVolume)
+				return fmt.Errorf("suggestion PVC: %v is not alive while ResumePolicy: %v", pvcName, exp.Spec.ResumePolicy)
 			}
 		}
 	}


### PR DESCRIPTION
Related: https://github.com/kubeflow/katib/issues/1479.

I disabled default PV creation for Experiment with from volume `resumePolicy`.

As discussed here: https://github.com/kubeflow/katib/issues/1479#issuecomment-805319555, it is very uncommon to create custom PV for the Experiment.

/cc @gaocegege @johnugeorge @maanur @heilerich