### PR TITLE
Switch to sdi

### DIFF
--- a/operators/katib-controller/requirements.txt
+++ b/operators/katib-controller/requirements.txt
@@ -1,2 +1,2 @@
-ops==1.0.1
-git+git://github.com/juju-solutions/resource-oci-image.git#egg=oci_image
+ops==1.2.0
+oci-image==1.0.0

--- a/operators/katib-db-manager/requirements.txt
+++ b/operators/katib-db-manager/requirements.txt
@@ -1,2 +1,2 @@
-ops==1.0.1
-git+git://github.com/juju-solutions/resource-oci-image.git#egg=oci_image
+ops==1.2.0
+oci-image==1.0.0

--- a/operators/katib-ui/metadata.yaml
+++ b/operators/katib-ui/metadata.yaml
@@ -19,8 +19,10 @@ resources:
     auto-fetch: true
     upstream-source: docker.io/kubeflowkatib/katib-ui:v1beta1-a96ff59
 requires:
-  service-mesh:
-    interface: service-mesh
+  ingress:
+    interface: ingress
+    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress.yaml
+    versions: [v1]
 provides:
   katib-ui:
     interface: http

--- a/operators/katib-ui/requirements.txt
+++ b/operators/katib-ui/requirements.txt
@@ -1,2 +1,3 @@
-ops==1.0.1
-git+git://github.com/juju-solutions/resource-oci-image.git#egg=oci_image
+ops==1.2.0
+oci-image==1.0.0
+serialized-data-interface==0.2.2


### PR DESCRIPTION
**What this PR does / why we need it**:

Switches the `katib-ui` operator to the `serialized-data-interface` library, which provides a way to declaratively define relationships.

**Release note**:
```release-note
NONE
```
