### PR TITLE
Add gRPC build script to CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,19 @@ deploy:
 undeploy:
 	bash scripts/v1beta1/undeploy.sh
 
-# Generate deepcopy, clientset, listers, informers, open-api and python SDK for APIs.
 # Run this if you update any existing controller APIs.
+# 1. Genereate deepcopy, clientset, listers, informers for the APIs (hack/update-codegen.sh).
+# 2. Generate open-api for the APIs (hack/update-openapigen).
+# 3. Generate Python SDK for Katib (hack/gen-python-sdk/gen-sdk.sh)
+# 4. Generate gRPC manager APIs. (pkg/apis/manager/v1beta1/build.sh and pkg/apis/manager/health/build.sh)
 generate:
 ifndef GOPATH
 	$(error GOPATH not defined, please define GOPATH. Run "go help gopath" to learn more about GOPATH)
 endif
 	go generate ./pkg/... ./cmd/...
 	hack/gen-python-sdk/gen-sdk.sh
+	cd ./pkg/apis/manager/v1beta1 && ./build.sh
+	cd ./pkg/apis/manager/health && ./build.sh
 
 # Build images for the Katib v1beta1 components.
 build: generate

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ undeploy:
 	bash scripts/v1beta1/undeploy.sh
 
 # Run this if you update any existing controller APIs.
-# 1. Genereate deepcopy, clientset, listers, informers for the APIs (hack/update-codegen.sh).
-# 2. Generate open-api for the APIs (hack/update-openapigen).
+# 1. Genereate deepcopy, clientset, listers, informers for the APIs (hack/update-codegen.sh)
+# 2. Generate open-api for the APIs (hack/update-openapigen)
 # 3. Generate Python SDK for Katib (hack/gen-python-sdk/gen-sdk.sh)
-# 4. Generate gRPC manager APIs. (pkg/apis/manager/v1beta1/build.sh and pkg/apis/manager/health/build.sh)
+# 4. Generate gRPC manager APIs (pkg/apis/manager/v1beta1/build.sh and pkg/apis/manager/health/build.sh)
 generate:
 ifndef GOPATH
 	$(error GOPATH not defined, please define GOPATH. Run "go help gopath" to learn more about GOPATH)

--- a/pkg/apis/manager/health/build.sh
+++ b/pkg/apis/manager/health/build.sh
@@ -18,5 +18,5 @@ set -x
 set -e
 
 proto="health.proto"
-docker run -it --rm -v $PWD:$(pwd) -w $(pwd) znly/protoc --python_out=plugins=grpc:./python --go_out=plugins=grpc:. -I. $proto
-docker run -it --rm -v $PWD:$(pwd) -w $(pwd) znly/protoc --plugin=protoc-gen-grpc=/usr/bin/grpc_python_plugin --python_out=./python --grpc_out=./python -I. $proto
+docker run -i --rm -v $PWD:$(pwd) -w $(pwd) znly/protoc --python_out=plugins=grpc:./python --go_out=plugins=grpc:. -I. $proto
+docker run -i --rm -v $PWD:$(pwd) -w $(pwd) znly/protoc --plugin=protoc-gen-grpc=/usr/bin/grpc_python_plugin --python_out=./python --grpc_out=./python -I. $proto

--- a/pkg/apis/manager/v1beta1/build.sh
+++ b/pkg/apis/manager/v1beta1/build.sh
@@ -18,8 +18,8 @@ set -x
 set -e
 
 for proto in api.proto; do
-  docker run -it --rm -v $PWD:$(pwd) -w $(pwd) znly/protoc --python_out=plugins=grpc:./python --go_out=plugins=grpc:. -I. $proto
-  docker run -it --rm -v $PWD:$(pwd) -w $(pwd) znly/protoc --plugin=protoc-gen-grpc=/usr/bin/grpc_python_plugin --python_out=./python --grpc_out=./python -I. $proto
+  docker run -i --rm -v $PWD:$(pwd) -w $(pwd) znly/protoc --python_out=plugins=grpc:./python --go_out=plugins=grpc:. -I. $proto
+  docker run -i --rm -v $PWD:$(pwd) -w $(pwd) znly/protoc --plugin=protoc-gen-grpc=/usr/bin/grpc_python_plugin --python_out=./python --grpc_out=./python -I. $proto
 done
 docker build -t protoc-gen-doc gen-doc/
 docker run --rm -v $PWD/gen-doc:/out -v $PWD:/apiprotos protoc-gen-doc --doc_opt=markdown,api.md -I /protobuf -I /apiprotos api.proto


### PR DESCRIPTION
To avoid problems like this: https://github.com/kubeflow/katib/pull/1492, I added gRPC build script to the CI.

/assign @gaocegege @johnugeorge 