### PR TITLE
Switch to charmcraft snap for CI

### DIFF
--- a/.github/workflows/test-charmed-katib.yaml
+++ b/.github/workflows/test-charmed-katib.yaml
@@ -44,7 +44,7 @@ jobs:
           sudo snap install juju --classic
           sudo snap install juju-helpers --classic
           sudo snap install juju-wait --classic
-          sudo pip3 install charmcraft
+          sudo snap install charmcraft --classic
 
       - name: Build Docker images
         run: |


### PR DESCRIPTION
The snap store is now the preferred place for obtaining charmcraft, as opposed to pypi.org.

**What this PR does / why we need it**:

Fixes broken CI process