### PR TITLE
fix mysql version in docker image

### DIFF
--- a/manifests/v1beta1/components/mysql/mysql.yaml
+++ b/manifests/v1beta1/components/mysql/mysql.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: katib-mysql
-          image: mysql:8
+          image: mysql:8.0.26
           args:
             - --datadir
             - /var/lib/mysql/datadir


### PR DESCRIPTION
**What this PR does / why we need it**:

- This PR fixes the mysql version to a constant tag.

The current image `mysql:8` is mutable tag. Every time an update is made this points to a new version. I.e it could point to 8.0.1 or 8.0.2 or 8.0.26. [SQL upgrades are one-way it is not possible to downgrade](https://www.percona.com/blog/2020/01/10/mysql-8-minor-version-upgrades-are-one-way-only/). 

This leads to errors if the image is already cached on kubernetes node. For example node already has 8.0.2 image cached, but 8.0.26 on was used on another node.
```
[InnoDB] Cannot boot server version 80017 on data directory built by version 80018. Downgrade is not supported
```

Another possible alternative would be to set image pull policy to Always.

```
imagePullPolicy: Always
```

