### PR TITLE
[enh]: validate for bayesian optimization algorithm settings

### DIFF
--- a/test/suggestion/v1beta1/test_skopt_service.py
+++ b/test/suggestion/v1beta1/test_skopt_service.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import grpc
-import grpc_testing
 import unittest
 
-from pkg.apis.manager.v1beta1.python import api_pb2
+import grpc
+import grpc_testing
 
+from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.suggestion.v1beta1.skopt.service import SkoptService
 
 
@@ -177,8 +177,8 @@ class TestSkopt(unittest.TestCase):
 
         get_suggestion = self.test_server.invoke_unary_unary(
             method_descriptor=(api_pb2.DESCRIPTOR
-                               .services_by_name['Suggestion']
-                               .methods_by_name['GetSuggestions']),
+                .services_by_name['Suggestion']
+                .methods_by_name['GetSuggestions']),
             invocation_metadata={},
             request=request, timeout=1)
 
@@ -186,6 +186,117 @@ class TestSkopt(unittest.TestCase):
         print(response.parameter_assignments)
         self.assertEqual(code, grpc.StatusCode.OK)
         self.assertEqual(2, len(response.parameter_assignments))
+
+    def test_validate_algorithm_settings(self):
+        experiment_spec = [None]
+
+        def call_validate():
+            experiment = api_pb2.Experiment(name="test", spec=experiment_spec[0])
+            request = api_pb2.ValidateAlgorithmSettingsRequest(experiment=experiment)
+
+            validate_algorithm_settings = self.test_server.invoke_unary_unary(
+                method_descriptor=(api_pb2.DESCRIPTOR
+                    .services_by_name['Suggestion']
+                    .methods_by_name['ValidateAlgorithmSettings']),
+                invocation_metadata={},
+                request=request, timeout=1)
+
+            return validate_algorithm_settings.termination()
+
+        # valid cases
+        algorithm_spec = api_pb2.AlgorithmSpec(
+            algorithm_name="bayesianoptimization",
+            algorithm_settings=[
+                api_pb2.AlgorithmSetting(
+                    name="random_state",
+                    value="10"
+                )
+            ],
+        )
+        experiment_spec[0] = api_pb2.ExperimentSpec(algorithm=algorithm_spec)
+        self.assertEqual(call_validate()[2], grpc.StatusCode.OK)
+
+        # invalid cases
+        # unknown algorithm name
+        experiment_spec[0] = api_pb2.ExperimentSpec(
+            algorithm=api_pb2.AlgorithmSpec(algorithm_name="unknown"))
+        _, _, code, details = call_validate()
+        self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
+        self.assertEqual(details, 'unknown algorithm name unknown')
+
+        # unknown config name
+        experiment_spec[0] = api_pb2.ExperimentSpec(
+            algorithm=api_pb2.AlgorithmSpec(
+                algorithm_name="bayesianoptimization",
+                algorithm_settings=[
+                    api_pb2.AlgorithmSetting(name="unknown_conf", value="1111")]
+            ))
+        _, _, code, details = call_validate()
+        self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
+        self.assertEqual(details, 'unknown setting unknown_conf for algorithm bayesianoptimization')
+
+        # unknown base_estimator
+        experiment_spec[0] = api_pb2.ExperimentSpec(
+            algorithm=api_pb2.AlgorithmSpec(
+                algorithm_name="bayesianoptimization",
+                algorithm_settings=[
+                    api_pb2.AlgorithmSetting(name="base_estimator", value="unknown estimator")]
+            ))
+        _, _, code, details = call_validate()
+        wrong_algorithm_setting = experiment_spec[0].algorithm.algorithm_settings[0]
+        self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
+        self.assertEqual(details,
+                         f'{wrong_algorithm_setting.name} {wrong_algorithm_setting.value} is not supported in katib')
+
+        # wrong n_initial_points
+        experiment_spec[0] = api_pb2.ExperimentSpec(
+            algorithm=api_pb2.AlgorithmSpec(
+                algorithm_name="bayesianoptimization",
+                algorithm_settings=[
+                    api_pb2.AlgorithmSetting(name="n_initial_points", value="-1")]
+            ))
+        _, _, code, details = call_validate()
+        wrong_algorithm_setting = experiment_spec[0].algorithm.algorithm_settings[0]
+        self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
+        self.assertEqual(details, f'{wrong_algorithm_setting.name} should be great or equal than zero')
+
+        # unknown acq_func
+        experiment_spec[0] = api_pb2.ExperimentSpec(
+            algorithm=api_pb2.AlgorithmSpec(
+                algorithm_name="bayesianoptimization",
+                algorithm_settings=[
+                    api_pb2.AlgorithmSetting(name="acq_func", value="unknown")]
+            ))
+        _, _, code, details = call_validate()
+        wrong_algorithm_setting = experiment_spec[0].algorithm.algorithm_settings[0]
+        self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
+        self.assertEqual(details,
+                         f'{wrong_algorithm_setting.name} {wrong_algorithm_setting.value} is not supported in katib')
+
+        # unknown acq_optimizer
+        experiment_spec[0] = api_pb2.ExperimentSpec(
+            algorithm=api_pb2.AlgorithmSpec(
+                algorithm_name="bayesianoptimization",
+                algorithm_settings=[
+                    api_pb2.AlgorithmSetting(name="acq_optimizer", value="unknown")]
+            ))
+        _, _, code, details = call_validate()
+        wrong_algorithm_setting = experiment_spec[0].algorithm.algorithm_settings[0]
+        self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
+        self.assertEqual(details,
+                         f'{wrong_algorithm_setting.name} {wrong_algorithm_setting.value} is not supported in katib')
+
+        # wrong random_state
+        experiment_spec[0] = api_pb2.ExperimentSpec(
+            algorithm=api_pb2.AlgorithmSpec(
+                algorithm_name="bayesianoptimization",
+                algorithm_settings=[
+                    api_pb2.AlgorithmSetting(name="random_state", value="-1")]
+            ))
+        _, _, code, details = call_validate()
+        wrong_algorithm_setting = experiment_spec[0].algorithm.algorithm_settings[0]
+        self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
+        self.assertEqual(details, f'{wrong_algorithm_setting.name} should be great or equal than zero')
 
 
 if __name__ == '__main__':

--- a/test/suggestion/v1beta1/test_skopt_service.py
+++ b/test/suggestion/v1beta1/test_skopt_service.py
@@ -246,7 +246,9 @@ class TestSkopt(unittest.TestCase):
         wrong_algorithm_setting = experiment_spec[0].algorithm.algorithm_settings[0]
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
         self.assertEqual(details,
-                         f'{wrong_algorithm_setting.name} {wrong_algorithm_setting.value} is not supported in katib')
+                         "{name} {value} is not supported in Bayesian optimization".format(
+                             name=wrong_algorithm_setting.name,
+                             value=wrong_algorithm_setting.value))
 
         # wrong n_initial_points
         experiment_spec[0] = api_pb2.ExperimentSpec(
@@ -258,7 +260,7 @@ class TestSkopt(unittest.TestCase):
         _, _, code, details = call_validate()
         wrong_algorithm_setting = experiment_spec[0].algorithm.algorithm_settings[0]
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
-        self.assertEqual(details, f'{wrong_algorithm_setting.name} should be great or equal than zero')
+        self.assertEqual(details, "{name} should be great or equal than zero".format(name=wrong_algorithm_setting.name))
 
         # unknown acq_func
         experiment_spec[0] = api_pb2.ExperimentSpec(
@@ -271,7 +273,10 @@ class TestSkopt(unittest.TestCase):
         wrong_algorithm_setting = experiment_spec[0].algorithm.algorithm_settings[0]
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
         self.assertEqual(details,
-                         f'{wrong_algorithm_setting.name} {wrong_algorithm_setting.value} is not supported in katib')
+                         "{name} {value} is not supported in Bayesian optimization".format(
+                             name=wrong_algorithm_setting.name,
+                             value=wrong_algorithm_setting.value
+                         ))
 
         # unknown acq_optimizer
         experiment_spec[0] = api_pb2.ExperimentSpec(
@@ -284,7 +289,10 @@ class TestSkopt(unittest.TestCase):
         wrong_algorithm_setting = experiment_spec[0].algorithm.algorithm_settings[0]
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
         self.assertEqual(details,
-                         f'{wrong_algorithm_setting.name} {wrong_algorithm_setting.value} is not supported in katib')
+                         "{name} {value} is not supported in Bayesian optimization".format(
+                             name=wrong_algorithm_setting.name,
+                             value=wrong_algorithm_setting.value
+                         ))
 
         # wrong random_state
         experiment_spec[0] = api_pb2.ExperimentSpec(
@@ -296,7 +304,7 @@ class TestSkopt(unittest.TestCase):
         _, _, code, details = call_validate()
         wrong_algorithm_setting = experiment_spec[0].algorithm.algorithm_settings[0]
         self.assertEqual(code, grpc.StatusCode.INVALID_ARGUMENT)
-        self.assertEqual(details, f'{wrong_algorithm_setting.name} should be great or equal than zero')
+        self.assertEqual(details, "{name} should be great or equal than zero".format(name=wrong_algorithm_setting.name))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**What this PR does / why we need it**:
- support validating for bayesianoptimization algorithm settings (skopt)
  - validation criteria were referenced by https://scikit-optimize.github.io/stable/modules/generated/skopt.Optimizer.html
- we need it since for fast fail since user could mistake

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
fixes part of #1126

**Checklist:**

- [X] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing

**How I Test**
- we could check with unit-test code
- Also, I've checked in my katib cluster with new skopt image with this yaml
```
apiVersion: kubeflow.org/v1beta1
kind: Experiment
metadata:
  name: random-example-3
  namespace: kubeflow
spec:
  algorithm:
    algorithmName: bayesianoptimization
    algorithmSettings:
      - name: "unknown"
        value: "10"
  maxFailedTrialCount: 1
  maxTrialCount: 1
  parallelTrialCount: 1
  metricsCollectorSpec:
    collector:
      kind: StdOut
  objective:
    additionalMetricNames:
    - Train-accuracy
    goal: 0.99
    metricStrategies:
    - name: Validation-accuracy
      value: max
    - name: Train-accuracy
      value: max
    objectiveMetricName: Validation-accuracy
    type: maximize
  parameters:
  - feasibleSpace:
      max: "0.03"
      min: "0.01"
    name: lr
    parameterType: double
  - feasibleSpace:
      max: "2"
      min: "1"
    name: num-layers
    parameterType: int
  - feasibleSpace:
      list:
      - sgd
      - adam
      - ftrl
    name: optimizer
    parameterType: categorical
  resumePolicy: LongRunning
  trialTemplate:
    failureCondition: status.conditions.#(type=="Failed")#|#(status=="True")#
    primaryContainerName: training-container
    successCondition: status.conditions.#(type=="Complete")#|#(status=="True")#
    trialParameters:
    - description: Learning rate for the training model
      name: learningRate
      reference: lr
    - description: Number of training model layers
      name: numberLayers
      reference: num-layers
    - description: Training model optimizer (sdg, adam or ftrl)
      name: optimizer
      reference: optimizer
    trialSpec:
      apiVersion: batch/v1
      kind: Job
      spec:
        template:
          spec:
            containers:
            - command:
              - python3
              - /opt/mxnet-mnist/mnist.py
              - --batch-size=256
              - --lr=${trialParameters.learningRate}
              - --num-layers=${trialParameters.numberLayers}
              - --optimizer=${trialParameters.optimizer}
              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-e294a90
              name: training-container
            restartPolicy: Never
```

- And expected error msg was printed
![image](https://user-images.githubusercontent.com/37469330/127728684-f7335cde-8f41-4d83-8ab2-69b3acebe4d1.png)

- However, I'm afraid even if suggestion and experiment failed, corresponding deployment/pod stays in running... I'm not sure why does it happens, but I guess it is a bug and should be handled with another PR.