### PR TITLE
Upgrade CRDs to apiextensions.k8s.io/v1

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -37,9 +37,9 @@ jobs:
         run: |
           go mod download
 
-          curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v1.0.7/kubebuilder_1.0.7_linux_amd64.tar.gz"
-          tar -zxvf kubebuilder_1.0.7_linux_amd64.tar.gz
-          sudo mv kubebuilder_1.0.7_linux_amd64 /usr/local/kubebuilder
+          curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.0/kubebuilder_2.3.0_linux_amd64.tar.gz"
+          tar -zxvf kubebuilder_2.3.0_linux_amd64.tar.gz
+          sudo mv kubebuilder_2.3.0_linux_amd64 /usr/local/kubebuilder
           export PATH=$PATH:/usr/local/kubebuilder/bin
 
           make check

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ KATIB_REGISTRY := docker.io/kubeflowkatib
 # Run tests
 .PHONY: test
 test:
-	go test ./pkg/... ./cmd/... -coverprofile coverage.out
+	go test ./pkg/... ./cmd/... -count=1 -coverprofile coverage.out
 
 check: generate fmt vet lint
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ KATIB_REGISTRY := docker.io/kubeflowkatib
 # Run tests
 .PHONY: test
 test:
-	go test ./pkg/... ./cmd/... -count=1 -coverprofile coverage.out
+	go test ./pkg/... ./cmd/... -coverprofile coverage.out
 
 check: generate fmt vet lint
 

--- a/manifests/v1beta1/components/crd/experiment.yaml
+++ b/manifests/v1beta1/components/crd/experiment.yaml
@@ -21,6 +21,10 @@ spec:
           jsonPath: .metadata.creationTimestamp
       subresources:
         status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
   names:
     kind: Experiment
     singular: experiment

--- a/manifests/v1beta1/components/crd/experiment.yaml
+++ b/manifests/v1beta1/components/crd/experiment.yaml
@@ -1,23 +1,26 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: experiments.kubeflow.org
 spec:
-  additionalPrinterColumns:
-    - JSONPath: .status.conditions[-1:].type
-      name: Type
-      type: string
-    - JSONPath: .status.conditions[-1:].status
-      name: Status
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: Age
-      type: date
   group: kubeflow.org
-  version: v1beta1
   scope: Namespaced
-  subresources:
-    status: {}
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Type
+          type: string
+          jsonPath: .status.conditions[-1:].type
+        - name: Status
+          type: string
+          jsonPath: .status.conditions[-1:].status
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}
   names:
     kind: Experiment
     singular: experiment

--- a/manifests/v1beta1/components/crd/suggestion.yaml
+++ b/manifests/v1beta1/components/crd/suggestion.yaml
@@ -27,6 +27,10 @@ spec:
           jsonPath: .metadata.creationTimestamp
       subresources:
         status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
   names:
     kind: Suggestion
     singular: suggestion

--- a/manifests/v1beta1/components/crd/suggestion.yaml
+++ b/manifests/v1beta1/components/crd/suggestion.yaml
@@ -1,29 +1,32 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: suggestions.kubeflow.org
 spec:
-  additionalPrinterColumns:
-    - JSONPath: .status.conditions[-1:].type
-      name: Type
-      type: string
-    - JSONPath: .status.conditions[-1:].status
-      name: Status
-      type: string
-    - JSONPath: .spec.requests
-      name: Requested
-      type: string
-    - JSONPath: .status.suggestionCount
-      name: Assigned
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: Age
-      type: date
   group: kubeflow.org
-  version: v1beta1
   scope: Namespaced
-  subresources:
-    status: {}
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Type
+          type: string
+          jsonPath: .status.conditions[-1:].type
+        - name: Status
+          type: string
+          jsonPath: .status.conditions[-1:].status
+        - name: Requested
+          type: string
+          jsonPath: .spec.requests
+        - name: Assigned
+          type: string
+          jsonPath: .status.suggestionCount
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}
   names:
     kind: Suggestion
     singular: suggestion

--- a/manifests/v1beta1/components/crd/trial.yaml
+++ b/manifests/v1beta1/components/crd/trial.yaml
@@ -1,23 +1,26 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: trials.kubeflow.org
 spec:
-  additionalPrinterColumns:
-    - JSONPath: .status.conditions[-1:].type
-      name: Type
-      type: string
-    - JSONPath: .status.conditions[-1:].status
-      name: Status
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: Age
-      type: date
   group: kubeflow.org
-  version: v1beta1
   scope: Namespaced
-  subresources:
-    status: {}
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Type
+          type: string
+          jsonPath: .status.conditions[-1:].type
+        - name: Status
+          type: string
+          jsonPath: .status.conditions[-1:].status
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}
   names:
     kind: Trial
     singular: trial

--- a/manifests/v1beta1/components/crd/trial.yaml
+++ b/manifests/v1beta1/components/crd/trial.yaml
@@ -21,6 +21,10 @@ spec:
           jsonPath: .metadata.creationTimestamp
       subresources:
         status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
   names:
     kind: Trial
     singular: trial


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1581, https://github.com/kubeflow/katib/issues/1354.

I upgraded `apiextensions.k8s.io/v1` since `v1beta1` was deprecated long time ago.

We still need to do some work to generate `openAPIV3Schema`, that can be done in the future PRs.

/assign @gaocegege @johnugeorge 
/cc @daftping