### PR TITLE
Modify Labels for Katib Components

### DIFF
--- a/examples/v1beta1/trial-configmap-source.yaml
+++ b/examples/v1beta1/trial-configmap-source.yaml
@@ -48,6 +48,6 @@ spec:
         description: Training model optimizer (sdg, adam or ftrl)
         reference: optimizer
     configMap:
-      configMapName: trial-template
+      configMapName: trial-templates
       configMapNamespace: kubeflow
       templatePath: defaultTrialTemplate.yaml

--- a/manifests/v1beta1/components/cert-generator/cert-generator.yaml
+++ b/manifests/v1beta1/components/cert-generator/cert-generator.yaml
@@ -3,6 +3,8 @@ kind: Job
 metadata:
   name: katib-cert-generator
   namespace: kubeflow
+  labels:
+    katib.kubeflow.org/component: cert-generator
 spec:
   template:
     metadata:

--- a/manifests/v1beta1/components/controller/controller.yaml
+++ b/manifests/v1beta1/components/controller/controller.yaml
@@ -3,18 +3,17 @@ kind: Deployment
 metadata:
   name: katib-controller
   namespace: kubeflow
-  # TODO (andreyvelich): Modify labels to follow k8s guidelines.
   labels:
-    app: katib-controller
+    katib.kubeflow.org/component: controller
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: katib-controller
+      katib.kubeflow.org/component: controller
   template:
     metadata:
       labels:
-        app: katib-controller
+        katib.kubeflow.org/component: controller
       annotations:
         prometheus.io/scrape: "true"
         sidecar.istio.io/inject: "false"

--- a/manifests/v1beta1/components/controller/service.yaml
+++ b/manifests/v1beta1/components/controller/service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: katib-controller
   namespace: kubeflow
+  labels:
+    katib.kubeflow.org/component: controller
   annotations:
     prometheus.io/port: "8080"
     prometheus.io/scheme: http
@@ -17,4 +19,4 @@ spec:
       port: 8080
       targetPort: 8080
   selector:
-    app: katib-controller
+    katib.kubeflow.org/component: controller

--- a/manifests/v1beta1/components/controller/trial-templates.yaml
+++ b/manifests/v1beta1/components/controller/trial-templates.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: trial-template
+  name: trial-templates
   namespace: kubeflow
   labels:
-    app: katib-trial-templates
+    katib.kubeflow.org/component: trial-templates
 data:
   defaultTrialTemplate.yaml: |-
     apiVersion: batch/v1

--- a/manifests/v1beta1/components/db-manager/db-manager.yaml
+++ b/manifests/v1beta1/components/db-manager/db-manager.yaml
@@ -3,18 +3,17 @@ kind: Deployment
 metadata:
   name: katib-db-manager
   namespace: kubeflow
-  # TODO (andreyvelich): Modify labels to follow k8s guidelines.
   labels:
-    app: katib-db-manager
+    katib.kubeflow.org/component: db-manager
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: katib-db-manager
+      katib.kubeflow.org/component: db-manager
   template:
     metadata:
       labels:
-        app: katib-db-manager
+        katib.kubeflow.org/component: db-manager
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/manifests/v1beta1/components/db-manager/service.yaml
+++ b/manifests/v1beta1/components/db-manager/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: katib-db-manager
   namespace: kubeflow
   labels:
-    app: katib-db-manager
+    katib.kubeflow.org/component: db-manager
 spec:
   type: ClusterIP
   ports:
@@ -12,4 +12,4 @@ spec:
       protocol: TCP
       name: api
   selector:
-    app: katib-db-manager
+    katib.kubeflow.org/component: db-manager

--- a/manifests/v1beta1/components/mysql/mysql.yaml
+++ b/manifests/v1beta1/components/mysql/mysql.yaml
@@ -3,20 +3,19 @@ kind: Deployment
 metadata:
   name: katib-mysql
   namespace: kubeflow
-  # TODO (andreyvelich): Modify labels to follow k8s guidelines.
   labels:
-    app: katib-mysql
+    katib.kubeflow.org/component: mysql
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: katib-mysql
+      katib.kubeflow.org/component: mysql
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: katib-mysql
+        katib.kubeflow.org/component: mysql
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/manifests/v1beta1/components/mysql/service.yaml
+++ b/manifests/v1beta1/components/mysql/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: katib-mysql
   namespace: kubeflow
   labels:
-    app: katib-mysql
+    katib.kubeflow.org/component: mysql
 spec:
   type: ClusterIP
   ports:
@@ -12,4 +12,4 @@ spec:
       protocol: TCP
       name: dbapi
   selector:
-    app: katib-mysql
+    katib.kubeflow.org/component: mysql

--- a/manifests/v1beta1/components/ui/service.yaml
+++ b/manifests/v1beta1/components/ui/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: katib-ui
   namespace: kubeflow
   labels:
-    app: katib-ui
+    katib.kubeflow.org/component: ui
 spec:
   type: ClusterIP
   ports:
@@ -13,4 +13,4 @@ spec:
       name: ui
       targetPort: 8080
   selector:
-    app: katib-ui
+    katib.kubeflow.org/component: ui

--- a/manifests/v1beta1/components/ui/ui.yaml
+++ b/manifests/v1beta1/components/ui/ui.yaml
@@ -3,18 +3,17 @@ kind: Deployment
 metadata:
   name: katib-ui
   namespace: kubeflow
-  # TODO (andreyvelich): Modify labels to follow k8s guidelines.
   labels:
-    app: katib-ui
+    katib.kubeflow.org/component: ui
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: katib-ui
+      katib.kubeflow.org/component: ui
   template:
     metadata:
       labels:
-        app: katib-ui
+        katib.kubeflow.org/component: ui
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -142,9 +142,9 @@ const (
 	AnnotationIstioSidecarInjectValue = "false"
 
 	// LabelTrialTemplateConfigMapName is the label name for the Trial templates configMap
-	LabelTrialTemplateConfigMapName = "app"
+	LabelTrialTemplateConfigMapName = "katib.kubeflow.org/component"
 	// LabelTrialTemplateConfigMapValue is the label value for the Trial templates configMap
-	LabelTrialTemplateConfigMapValue = "katib-trial-templates"
+	LabelTrialTemplateConfigMapValue = "trial-templates"
 
 	// TrialTemplateParamReplaceFormat is the format to make substitution in Trial template from Names in TrialParameters
 	// E.g if Name = learningRate, according value in Trial template must be ${trialParameters.learningRate}


### PR DESCRIPTION
See discussion: https://github.com/kubeflow/common/issues/148#issuecomment-893826133.

I modified labels for Katib components to follow Kubernetes guidelines.

Probably, we should also think about renaming [`katib-metricscollector-injection: enabled`](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/components/namespace/namespace.yaml#L6) to `katib.kubeflow.org/metricscollector-injection: true`

/cc @gaocegege @johnugeorge @alculquicondor