### PR TITLE
Fix Metrics Collector error in case of non-existing Process

### DIFF
--- a/pkg/metricscollector/v1beta1/common/pns.go
+++ b/pkg/metricscollector/v1beta1/common/pns.go
@@ -91,10 +91,12 @@ func GetMainProcesses(completedMarkedDirPath string) (map[int]bool, int, error) 
 			continue
 		}
 
-		// Command line contains completed marker for the main pid.
+		// By default mainPid is the first process.
+		// In addition to that, command line contains completed marker for the main pid
 		// For example: echo completed > /var/log/katib/$$$$.pid
 		// completedMarkedDirPath is the directory for completed marker, e.g. /var/log/katib
-		if strings.Contains(cmdline, fmt.Sprintf("echo %s > %s", TrainingCompleted, completedMarkedDirPath)) {
+		if mainPid == 0 ||
+			strings.Contains(cmdline, fmt.Sprintf("echo %s > %s", TrainingCompleted, completedMarkedDirPath)) {
 			mainPid = int(pid)
 		}
 

--- a/pkg/metricscollector/v1beta1/common/pns.go
+++ b/pkg/metricscollector/v1beta1/common/pns.go
@@ -68,7 +68,7 @@ func GetMainProcesses(completedMarkedDirPath string) (map[int]bool, int, error) 
 		// Create process object from pid
 		proc, err := psutil.NewProcess(pid)
 		if err != nil {
-			klog.Info("Skip Process with pid: %v, error: %v", pid, err)
+			klog.Infof("Skip Process with pid: %v, error: %v", pid, err)
 			continue
 		}
 

--- a/pkg/metricscollector/v1beta1/common/pns.go
+++ b/pkg/metricscollector/v1beta1/common/pns.go
@@ -68,14 +68,15 @@ func GetMainProcesses(completedMarkedDirPath string) (map[int]bool, int, error) 
 		// Create process object from pid
 		proc, err := psutil.NewProcess(pid)
 		if err != nil {
-			klog.Infof("Skip Process with pid: %v, error: %v", pid, err)
+			klog.Infof("Unable to create new process from pid: %v, error: %v. Continue to next pid", pid, err)
 			continue
 		}
 
 		// Get parent process
 		ppid, err := proc.Ppid()
 		if err != nil {
-			return nil, 0, fmt.Errorf("unable to get parent pid for pid: %v, error: %v", ppid, err)
+			klog.Infof("Unable to get parent process for pid: %v, error: %v. Continue to next pid", pid, err)
+			continue
 		}
 
 		// Ignore the pause container, our own pid, and non-root processes (parent pid != 0)
@@ -86,7 +87,8 @@ func GetMainProcesses(completedMarkedDirPath string) (map[int]bool, int, error) 
 		// Read the process command line
 		cmdline, err := proc.Cmdline()
 		if err != nil {
-			return nil, 0, fmt.Errorf("unable to get cmdline from pid %v, error: %v", pid, err)
+			klog.Infof("Unable to get cmdline from pid: %v, error: %v. Continue to next pid", pid, err)
+			continue
 		}
 
 		// Command line contains completed marker for the main pid.

--- a/pkg/metricscollector/v1beta1/common/pns.py
+++ b/pkg/metricscollector/v1beta1/common/pns.py
@@ -54,10 +54,11 @@ def GetMainProcesses(completed_marked_dir):
         # Read the process command line, join all cmdlines in one string
         cmd_lind = " ".join(proc.cmdline())
 
-        # Command line contains completed marker for the main pid.
+        # By default main_pid is the first process.
+        # In addition to that, command line contains completed marker for the main pid.
         # For example: echo completed > /var/log/katib/$$$$.pid
         # completed_marked_dir is the directory for completed marker, e.g. /var/log/katib
-        if "echo {} > {}".format(const.TRAINING_COMPLETED, completed_marked_dir) in cmd_lind:
+        if main_pid == 0 or ("echo {} > {}".format(const.TRAINING_COMPLETED, completed_marked_dir) in cmd_lind):
             main_pid = pid
 
         pids.add(pid)

--- a/pkg/metricscollector/v1beta1/common/pns.py
+++ b/pkg/metricscollector/v1beta1/common/pns.py
@@ -54,14 +54,17 @@ def GetMainProcesses(completed_marked_dir):
         # Read the process command line, join all cmdlines in one string
         cmd_lind = " ".join(proc.cmdline())
 
-        # By default main_pid is the first process.
-        # Command line contains completed marker for the main pid
+        # Command line contains completed marker for the main pid.
         # For example: echo completed > /var/log/katib/$$$$.pid
         # completed_marked_dir is the directory for completed marker, e.g. /var/log/katib
-        if main_pid == 0 or ("echo {} > {}".format(const.TRAINING_COMPLETED, completed_marked_dir) in cmd_lind):
+        if "echo {} > {}".format(const.TRAINING_COMPLETED, completed_marked_dir) in cmd_lind:
             main_pid = pid
 
         pids.add(pid)
+
+    # If mainPid has not been found, return an error.
+    if main_pid == 0:
+        raise Exception("Unable to find main pid from the process list {}".format(pids))
 
     return pids, main_pid
 


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1576.

This fix should help with the non-existing process error.
I noticed that other steps (`proc.Ppid()` and `proc.Cmdline()`) can also be failed.
I skipped error for them as well.

/cc @gaocegege @chenwenjun-github @johnugeorge 