### PR TITLE
Modify labels for controller resources

### DIFF
--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -50,11 +50,11 @@ const (
 	ConfigTrialResources = "trial-resources"
 
 	// LabelExperimentName is the label of experiment name.
-	LabelExperimentName = "experiment"
+	LabelExperimentName = "katib.kubeflow.org/experiment"
 	// LabelSuggestionName is the label of suggestion name.
-	LabelSuggestionName = "suggestion"
+	LabelSuggestionName = "katib.kubeflow.org/suggestion"
 	// LabelDeploymentName is the label of deployment name.
-	LabelDeploymentName = "deployment"
+	LabelDeploymentName = "katib.kubeflow.org/deployment"
 
 	// ContainerSuggestion is the container name to run Suggestion service.
 	ContainerSuggestion = "suggestion"

--- a/pkg/controller.v1beta1/suggestion/composer/composer_test.go
+++ b/pkg/controller.v1beta1/suggestion/composer/composer_test.go
@@ -69,10 +69,10 @@ var (
 	}
 
 	deploymentLabels = map[string]string{
-		"custom-label": "test",
-		"deployment":   suggestionName + "-" + suggestionAlgorithm,
-		"experiment":   suggestionName,
-		"suggestion":   suggestionName,
+		"custom-label":             "test",
+		consts.LabelDeploymentName: suggestionName + "-" + suggestionAlgorithm,
+		consts.LabelExperimentName: suggestionName,
+		consts.LabelSuggestionName: suggestionName,
 	}
 
 	podAnnotations = map[string]string{

--- a/pkg/controller.v1beta1/util/annotations.go
+++ b/pkg/controller.v1beta1/util/annotations.go
@@ -17,14 +17,8 @@ limitations under the License.
 package util
 
 import (
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
 	suggestionsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/suggestions/v1beta1"
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
-)
-
-var (
-	log = logf.Log.WithName("util-annotations")
 )
 
 // SuggestionAnnotations returns the expected suggestion annotations.


### PR DESCRIPTION
To be consistent with this PR: https://github.com/kubeflow/katib/pull/1611, we should also change our labels for Trials and Suggestion Deployment's Pod.

Please take a look @alculquicondor @gaocegege @johnugeorge 

/hold for the review