### PR TITLE
Bump Katib Python SDK to 0.12.0rc0 version

### DIFF
--- a/sdk/python/v1beta1/setup.py
+++ b/sdk/python/v1beta1/setup.py
@@ -19,7 +19,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name='kubeflow-katib',
-    version='0.10.1',
+    version='0.12.0rc0',
     author="Kubeflow Authors",
     author_email='premnath.vel@gmail.com',
     license="Apache License Version 2.0",


### PR DESCRIPTION
We should update our SDK version to the latest in the `master` branch.

/assign @gaocegege @johnugeorge 