### PR TITLE
Add missing omitempty parameter to APIs

### DIFF
--- a/pkg/apis/controller/common/v1beta1/common_types.go
+++ b/pkg/apis/controller/common/v1beta1/common_types.go
@@ -150,7 +150,7 @@ type Metric struct {
 // +k8s:deepcopy-gen=true
 type Observation struct {
 	// Key-value pairs for metric names and values
-	Metrics []Metric `json:"metrics"`
+	Metrics []Metric `json:"metrics,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true
@@ -220,7 +220,7 @@ const (
 
 // +k8s:deepcopy-gen=true
 type CollectorSpec struct {
-	Kind CollectorKind `json:"kind"`
+	Kind CollectorKind `json:"kind,omitempty"`
 	// When kind is "customCollector", this field will be used
 	CustomCollector *v1.Container `json:"customCollector,omitempty"`
 }

--- a/pkg/apis/controller/experiments/v1beta1/experiment_types.go
+++ b/pkg/apis/controller/experiments/v1beta1/experiment_types.go
@@ -125,9 +125,9 @@ type ExperimentStatus struct {
 // OptimalTrial is the metrics and assignments of the best trial.
 type OptimalTrial struct {
 	// BestTrialName is the name of the best trial.
-	BestTrialName string `json:"bestTrialName"`
+	BestTrialName string `json:"bestTrialName,omitempty"`
 	// Key-value pairs for hyperparameters and assignment values.
-	ParameterAssignments []common.ParameterAssignment `json:"parameterAssignments"`
+	ParameterAssignments []common.ParameterAssignment `json:"parameterAssignments,omitempty"`
 
 	// Observation for this trial
 	Observation common.Observation `json:"observation,omitempty"`

--- a/pkg/apis/controller/suggestions/v1beta1/suggestion_types.go
+++ b/pkg/apis/controller/suggestions/v1beta1/suggestion_types.go
@@ -28,7 +28,7 @@ import (
 // SuggestionSpec is the specification of a Suggestion.
 type SuggestionSpec struct {
 	// Algorithm describes HP or NAS algorithm that suggestion is used.
-	Algorithm *common.AlgorithmSpec `json:"algorithm"`
+	Algorithm *common.AlgorithmSpec `json:"algorithm,omitempty"`
 
 	// EarlyStopping describes early stopping algorithm that suggestion is used.
 	EarlyStopping *common.EarlyStoppingSpec `json:"earlyStopping,omitempty"`

--- a/pkg/apis/controller/trials/v1beta1/trial_types.go
+++ b/pkg/apis/controller/trials/v1beta1/trial_types.go
@@ -29,7 +29,7 @@ type TrialSpec struct {
 	Objective *common.ObjectiveSpec `json:"objective,omitempty"`
 
 	// Key-value pairs for hyperparameters and assignment values.
-	ParameterAssignments []common.ParameterAssignment `json:"parameterAssignments"`
+	ParameterAssignments []common.ParameterAssignment `json:"parameterAssignments,omitempty"`
 
 	// Rules for early stopping techniques.
 	// Each rule should be met to early stop Trial.

--- a/pkg/apis/v1beta1/openapi_generated.go
+++ b/pkg/apis/v1beta1/openapi_generated.go
@@ -144,9 +144,8 @@ func schema_apis_controller_common_v1beta1_CollectorSpec(ref common.ReferenceCal
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"customCollector": {
@@ -156,7 +155,6 @@ func schema_apis_controller_common_v1beta1_CollectorSpec(ref common.ReferenceCal
 						},
 					},
 				},
-				Required: []string{"kind"},
 			},
 		},
 		Dependencies: []string{
@@ -489,7 +487,6 @@ func schema_apis_controller_common_v1beta1_Observation(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"metrics"},
 			},
 		},
 		Dependencies: []string{
@@ -1197,7 +1194,6 @@ func schema_apis_controller_experiments_v1beta1_OptimalTrial(ref common.Referenc
 					"bestTrialName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "BestTrialName is the name of the best trial.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1224,7 +1220,6 @@ func schema_apis_controller_experiments_v1beta1_OptimalTrial(ref common.Referenc
 						},
 					},
 				},
-				Required: []string{"bestTrialName", "parameterAssignments"},
 			},
 		},
 		Dependencies: []string{
@@ -1600,7 +1595,6 @@ func schema_apis_controller_suggestions_v1beta1_SuggestionSpec(ref common.Refere
 						},
 					},
 				},
-				Required: []string{"algorithm"},
 			},
 		},
 		Dependencies: []string{
@@ -1995,7 +1989,6 @@ func schema_apis_controller_trials_v1beta1_TrialSpec(ref common.ReferenceCallbac
 						},
 					},
 				},
-				Required: []string{"parameterAssignments"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/apis/v1beta1/swagger.json
+++ b/pkg/apis/v1beta1/swagger.json
@@ -102,9 +102,6 @@
     ".v1beta1.SuggestionSpec": {
       "description": "SuggestionSpec is the specification of a Suggestion.",
       "type": "object",
-      "required": [
-        "algorithm"
-      ],
       "properties": {
         "algorithm": {
           "description": "Algorithm describes HP or NAS algorithm that suggestion is used.",
@@ -293,9 +290,6 @@
     ".v1beta1.TrialSpec": {
       "description": "TrialSpec is the specification of a Trial.",
       "type": "object",
-      "required": [
-        "parameterAssignments"
-      ],
       "properties": {
         "earlyStoppingRules": {
           "description": "Rules for early stopping techniques. Each rule should be met to early stop Trial.",
@@ -416,17 +410,13 @@
     },
     "v1beta1.CollectorSpec": {
       "type": "object",
-      "required": [
-        "kind"
-      ],
       "properties": {
         "customCollector": {
           "description": "When kind is \"customCollector\", this field will be used",
           "$ref": "#/definitions/v1.Container"
         },
         "kind": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         }
       }
     },
@@ -929,9 +919,6 @@
     },
     "v1beta1.Observation": {
       "type": "object",
-      "required": [
-        "metrics"
-      ],
       "properties": {
         "metrics": {
           "description": "Key-value pairs for metric names and values",
@@ -962,15 +949,10 @@
     "v1beta1.OptimalTrial": {
       "description": "OptimalTrial is the metrics and assignments of the best trial.",
       "type": "object",
-      "required": [
-        "bestTrialName",
-        "parameterAssignments"
-      ],
       "properties": {
         "bestTrialName": {
           "description": "BestTrialName is the name of the best trial.",
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "observation": {
           "description": "Observation for this trial",

--- a/sdk/python/v1beta1/docs/V1beta1CollectorSpec.md
+++ b/sdk/python/v1beta1/docs/V1beta1CollectorSpec.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **custom_collector** | [**V1Container**](https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1Container.md) |  | [optional] 
-**kind** | **str** |  | [default to '']
+**kind** | **str** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/sdk/python/v1beta1/docs/V1beta1Observation.md
+++ b/sdk/python/v1beta1/docs/V1beta1Observation.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**metrics** | [**list[V1beta1Metric]**](V1beta1Metric.md) | Key-value pairs for metric names and values | 
+**metrics** | [**list[V1beta1Metric]**](V1beta1Metric.md) | Key-value pairs for metric names and values | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/sdk/python/v1beta1/docs/V1beta1OptimalTrial.md
+++ b/sdk/python/v1beta1/docs/V1beta1OptimalTrial.md
@@ -4,9 +4,9 @@ OptimalTrial is the metrics and assignments of the best trial.
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**best_trial_name** | **str** | BestTrialName is the name of the best trial. | [default to '']
+**best_trial_name** | **str** | BestTrialName is the name of the best trial. | [optional] 
 **observation** | [**V1beta1Observation**](V1beta1Observation.md) |  | [optional] 
-**parameter_assignments** | [**list[V1beta1ParameterAssignment]**](V1beta1ParameterAssignment.md) | Key-value pairs for hyperparameters and assignment values. | 
+**parameter_assignments** | [**list[V1beta1ParameterAssignment]**](V1beta1ParameterAssignment.md) | Key-value pairs for hyperparameters and assignment values. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/sdk/python/v1beta1/docs/V1beta1SuggestionSpec.md
+++ b/sdk/python/v1beta1/docs/V1beta1SuggestionSpec.md
@@ -4,7 +4,7 @@ SuggestionSpec is the specification of a Suggestion.
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**algorithm** | [**V1beta1AlgorithmSpec**](V1beta1AlgorithmSpec.md) |  | 
+**algorithm** | [**V1beta1AlgorithmSpec**](V1beta1AlgorithmSpec.md) |  | [optional] 
 **early_stopping** | [**V1beta1EarlyStoppingSpec**](V1beta1EarlyStoppingSpec.md) |  | [optional] 
 **requests** | **int** | Number of suggestions requested. | [optional] 
 **resume_policy** | **str** | ResumePolicy describes resuming policy which usually take effect after experiment terminated. Default value is LongRunning. | [optional] 

--- a/sdk/python/v1beta1/docs/V1beta1TrialSpec.md
+++ b/sdk/python/v1beta1/docs/V1beta1TrialSpec.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **failure_condition** | **str** | Condition when trial custom resource is failed. Condition must be in GJSON format, ref https://github.com/tidwall/gjson. For example for BatchJob: status.conditions.#(type&#x3D;&#x3D;\&quot;Failed\&quot;)#|#(status&#x3D;&#x3D;\&quot;True\&quot;)# | [optional] 
 **metrics_collector** | [**V1beta1MetricsCollectorSpec**](V1beta1MetricsCollectorSpec.md) |  | [optional] 
 **objective** | [**V1beta1ObjectiveSpec**](V1beta1ObjectiveSpec.md) |  | [optional] 
-**parameter_assignments** | [**list[V1beta1ParameterAssignment]**](V1beta1ParameterAssignment.md) | Key-value pairs for hyperparameters and assignment values. | 
+**parameter_assignments** | [**list[V1beta1ParameterAssignment]**](V1beta1ParameterAssignment.md) | Key-value pairs for hyperparameters and assignment values. | [optional] 
 **primary_container_name** | **str** | Name of training container where actual model training is running | [optional] 
 **primary_pod_labels** | **dict(str, str)** | Label that determines if pod needs to be injected by Katib sidecar container | [optional] 
 **retain_run** | **bool** | Whether to retain the trial run object after completed. | [optional] 

--- a/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_collector_spec.py
+++ b/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_collector_spec.py
@@ -42,7 +42,7 @@ class V1beta1CollectorSpec(object):
         'kind': 'kind'
     }
 
-    def __init__(self, custom_collector=None, kind='', local_vars_configuration=None):  # noqa: E501
+    def __init__(self, custom_collector=None, kind=None, local_vars_configuration=None):  # noqa: E501
         """V1beta1CollectorSpec - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
@@ -54,7 +54,8 @@ class V1beta1CollectorSpec(object):
 
         if custom_collector is not None:
             self.custom_collector = custom_collector
-        self.kind = kind
+        if kind is not None:
+            self.kind = kind
 
     @property
     def custom_collector(self):
@@ -95,8 +96,6 @@ class V1beta1CollectorSpec(object):
         :param kind: The kind of this V1beta1CollectorSpec.  # noqa: E501
         :type: str
         """
-        if self.local_vars_configuration.client_side_validation and kind is None:  # noqa: E501
-            raise ValueError("Invalid value for `kind`, must not be `None`")  # noqa: E501
 
         self._kind = kind
 

--- a/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_observation.py
+++ b/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_observation.py
@@ -49,7 +49,8 @@ class V1beta1Observation(object):
         self._metrics = None
         self.discriminator = None
 
-        self.metrics = metrics
+        if metrics is not None:
+            self.metrics = metrics
 
     @property
     def metrics(self):
@@ -71,8 +72,6 @@ class V1beta1Observation(object):
         :param metrics: The metrics of this V1beta1Observation.  # noqa: E501
         :type: list[V1beta1Metric]
         """
-        if self.local_vars_configuration.client_side_validation and metrics is None:  # noqa: E501
-            raise ValueError("Invalid value for `metrics`, must not be `None`")  # noqa: E501
 
         self._metrics = metrics
 

--- a/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_optimal_trial.py
+++ b/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_optimal_trial.py
@@ -44,7 +44,7 @@ class V1beta1OptimalTrial(object):
         'parameter_assignments': 'parameterAssignments'
     }
 
-    def __init__(self, best_trial_name='', observation=None, parameter_assignments=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, best_trial_name=None, observation=None, parameter_assignments=None, local_vars_configuration=None):  # noqa: E501
         """V1beta1OptimalTrial - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
@@ -55,10 +55,12 @@ class V1beta1OptimalTrial(object):
         self._parameter_assignments = None
         self.discriminator = None
 
-        self.best_trial_name = best_trial_name
+        if best_trial_name is not None:
+            self.best_trial_name = best_trial_name
         if observation is not None:
             self.observation = observation
-        self.parameter_assignments = parameter_assignments
+        if parameter_assignments is not None:
+            self.parameter_assignments = parameter_assignments
 
     @property
     def best_trial_name(self):
@@ -80,8 +82,6 @@ class V1beta1OptimalTrial(object):
         :param best_trial_name: The best_trial_name of this V1beta1OptimalTrial.  # noqa: E501
         :type: str
         """
-        if self.local_vars_configuration.client_side_validation and best_trial_name is None:  # noqa: E501
-            raise ValueError("Invalid value for `best_trial_name`, must not be `None`")  # noqa: E501
 
         self._best_trial_name = best_trial_name
 
@@ -126,8 +126,6 @@ class V1beta1OptimalTrial(object):
         :param parameter_assignments: The parameter_assignments of this V1beta1OptimalTrial.  # noqa: E501
         :type: list[V1beta1ParameterAssignment]
         """
-        if self.local_vars_configuration.client_side_validation and parameter_assignments is None:  # noqa: E501
-            raise ValueError("Invalid value for `parameter_assignments`, must not be `None`")  # noqa: E501
 
         self._parameter_assignments = parameter_assignments
 

--- a/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_suggestion_spec.py
+++ b/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_suggestion_spec.py
@@ -58,7 +58,8 @@ class V1beta1SuggestionSpec(object):
         self._resume_policy = None
         self.discriminator = None
 
-        self.algorithm = algorithm
+        if algorithm is not None:
+            self.algorithm = algorithm
         if early_stopping is not None:
             self.early_stopping = early_stopping
         if requests is not None:
@@ -84,8 +85,6 @@ class V1beta1SuggestionSpec(object):
         :param algorithm: The algorithm of this V1beta1SuggestionSpec.  # noqa: E501
         :type: V1beta1AlgorithmSpec
         """
-        if self.local_vars_configuration.client_side_validation and algorithm is None:  # noqa: E501
-            raise ValueError("Invalid value for `algorithm`, must not be `None`")  # noqa: E501
 
         self._algorithm = algorithm
 

--- a/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_trial_spec.py
+++ b/sdk/python/v1beta1/kubeflow/katib/models/v1beta1_trial_spec.py
@@ -84,7 +84,8 @@ class V1beta1TrialSpec(object):
             self.metrics_collector = metrics_collector
         if objective is not None:
             self.objective = objective
-        self.parameter_assignments = parameter_assignments
+        if parameter_assignments is not None:
+            self.parameter_assignments = parameter_assignments
         if primary_container_name is not None:
             self.primary_container_name = primary_container_name
         if primary_pod_labels is not None:
@@ -204,8 +205,6 @@ class V1beta1TrialSpec(object):
         :param parameter_assignments: The parameter_assignments of this V1beta1TrialSpec.  # noqa: E501
         :type: list[V1beta1ParameterAssignment]
         """
-        if self.local_vars_configuration.client_side_validation and parameter_assignments is None:  # noqa: E501
-            raise ValueError("Invalid value for `parameter_assignments`, must not be `None`")  # noqa: E501
 
         self._parameter_assignments = parameter_assignments
 


### PR DESCRIPTION
I added missing `omitempty` parameter to our APIs.
For example, `Observation.Metrics` can be empty and our SDK might fail because of that.

/assign @gaocegege @johnugeorge 