### PR TITLE
UI: Handle missing TrialTemplates

### DIFF
--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/trial-template/trial-template.component.html
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/trial-template/trial-template.component.html
@@ -37,7 +37,13 @@
     <mat-form-field appearance="outline" class="fit-content">
       <mat-label>Source Type</mat-label>
       <mat-select formControlName="type">
-        <mat-option value="configmap">ConfigMap</mat-option>
+        <mat-option
+          [disabled]="!templates.length"
+          [matTooltip]="!templates.length ? 'No TrialTemplates found' : ''"
+          value="configmap"
+        >
+          ConfigMap
+        </mat-option>
         <mat-option value="yaml">YAML</mat-option>
       </mat-select>
     </mat-form-field>
@@ -90,7 +96,7 @@
     <mat-divider class="margin-bottom margin-top"></mat-divider>
 
     <app-trial-parameter
-      *ngFor="let ctrl of trialParameters.controls"
+      *ngFor="let ctrl of trialParameters?.controls"
       [formGroup]="ctrl"
     ></app-trial-parameter>
   </div>

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/trial-template/trial-template.component.html
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/trial-template/trial-template.component.html
@@ -39,7 +39,7 @@
       <mat-select formControlName="type">
         <mat-option
           [disabled]="!templates.length"
-          [matTooltip]="!templates.length ? 'No TrialTemplates found' : ''"
+          [matTooltip]="!templates.length ? 'No Trial templates found' : ''"
           value="configmap"
         >
           ConfigMap

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/trial-template/trial-template.component.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/trial-template/trial-template.component.ts
@@ -18,7 +18,7 @@ export class FormTrialTemplateComponent implements OnInit, OnDestroy {
   public templates: ConfigMapResponse[] = [];
   public configmaps: ConfigMapBody[] = [];
   public paths: string[] = [];
-  public trialParameters: FormArray;
+  public trialParameters = new FormArray([]);
   private selectedConfigMap: ConfigMapBody;
   private subs = new Subscription();
   private yamlPrv = '';
@@ -53,6 +53,12 @@ export class FormTrialTemplateComponent implements OnInit, OnDestroy {
       this.backend.getTrialTemplates('').subscribe(templates => {
         this.templates = templates.Data;
         this.formGroup.get('cmNamespace').setValue('kubeflow');
+
+        // Use the ConfigMap option if the TrialTemplates were successfully
+        // fetched
+        if (this.templates && this.templates.length) {
+          this.formGroup.get('type').setValue('configmap');
+        }
       }),
     );
 

--- a/pkg/new-ui/v1beta1/frontend/src/app/services/experiment-form.service.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/services/experiment-form.service.ts
@@ -212,7 +212,7 @@ export class ExperimentFormService {
 
   createTrialTemplateForm(): FormGroup {
     return this.builder.group({
-      type: 'configmap',
+      type: 'yaml',
       podLabels: this.builder.array([]),
       containerName: 'training-container',
       successCond: 'status.conditions.#(type=="Complete")#|#(status=="True")#',


### PR DESCRIPTION
closes https://github.com/kubeflow/katib/issues/1620

This is also part of the 0.12 release effort https://github.com/kubeflow/katib/issues/1597

The UI should gracefully handle the case of missing TrialParameters. 
I changed the UI to use `yaml` input by default and if no TrialTemplates were found then the `ConfigMap` option would be disabled. If the TrialTemplates were fetched correctly, and are not an empty list, then the UI will select the `ConfigMap` option.

![Screenshot from 2021-09-01 19-30-43](https://user-images.githubusercontent.com/11134742/131708856-65efa462-6c72-4d99-a7a0-317c1287076f.png)


**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing

/cc @andreyvelich 
/assign @kimwnasptd 