### PR TITLE
Add Cert Generator to prow include dirs

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -15,6 +15,7 @@ workflows:
       - pkg/apis/manager/health/*
       - pkg/apis/manager/v1beta1/*
       - pkg/apis/v1beta1/*
+      - pkg/cert-generator/v1beta1/*
       - pkg/common/v1beta1/*
       - pkg/controller.v1beta1/*
       - pkg/db/v1beta1/*


### PR DESCRIPTION
We should trigger prow for changes in `pkg/cert-generator/v1beta1`.

/cc @tenzen-y 