### PR TITLE
Change the minimal kustomize version in the developer guide

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -16,7 +16,7 @@ see the following user guides:
 - [Docker](https://docs.docker.com/) (17.05 or later)
 - [Java](https://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html) (8 or later)
 - [Python](https://www.python.org/) (3.7 or later)
-- [kustomize](https://kustomize.io/) (3.2 or later)
+- [kustomize](https://kustomize.io/) (4.0.5 or later)
 
 ## Build from source code
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We will change the minimal kubectl version in #1667. So, we should change the minimal kustomize version in the developer guide.

Ref:  
  - [kubernetes v1.21 release note](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#kustomize-updates-in-kubectl)
  - https://github.com/kubeflow/website/pull/2962#issuecomment-922973501

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #
