### PR TITLE
[bugfix]: absolute value and typo

### DIFF
--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/algorithm/algorithm.component.html
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/algorithm/algorithm.component.html
@@ -39,7 +39,7 @@
   <!--step info-->
   <div class="lib-step-info-wrapper">
     <lib-step-info header="Search Algorithm">
-      The <em>Search Algorithm</em> is responsible for navigating throught the
+      The <em>Search Algorithm</em> is responsible for navigating through the
       optimization search space and creating <em>Trial CRs</em> for each step.
       The algorithms' code will be executed from the underlying
       <em>Suggestion CR.</em>

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/hyper-parameters/hyper-parameters.component.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/hyper-parameters/hyper-parameters.component.ts
@@ -52,7 +52,9 @@ export class FormHyperParametersComponent {
         }
 
         currentConfs =
-          Math.ceil((parseFloat(max) - parseFloat(min)) / parseFloat(step)) + 1;
+          Math.abs(
+            Math.ceil((parseFloat(max) - parseFloat(min)) / parseFloat(step)),
+          ) + 1;
       }
 
       if (currentConfs === 0) {


### PR DESCRIPTION
Signed-off-by: Jaeyeon Kim <anencore94@gmail.com>
Co-authored-by: Seongjin Kim <seongjinkim1123@gmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
![image](https://user-images.githubusercontent.com/37469330/134633930-ad8ceca5-f1e8-4a17-9e08-713cdaa8e6af.png)

1) There was a bug when handling odd number of parameters with negative step. For above example, the number of combination should be `64`, not `-62`.
2) minor typo

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
