### PR TITLE
Fix readme in examples directory

### DIFF
--- a/examples/v1beta1/README.md
+++ b/examples/v1beta1/README.md
@@ -14,16 +14,8 @@ A Minikube cluster and Katib components will be deployed! You can check them wit
 
 Then, start port-forward for katib UI `8080 -> UI`.
 
-kubectl v1.10~:
-
 ```
 $ kubectl -n kubeflow port-forward svc/katib-ui 8080:80
-```
-
-kubectl ~v1.9:
-
-```
-& kubectl -n kubeflow port-forward $(kubectl -n kubeflow get pod -o=name | grep katib-ui | sed -e "s@pods\/@@") 8080:80
 ```
 
 ## Create Experiment
@@ -52,7 +44,7 @@ $ kubectl apply -f bayesianoptimization-example.yaml
 $ kubectl apply -f hyperband-example.yaml
 ```
 
-#### Run trial evaluation job by [PyTorchJob](https://github.com/kubeflow/pytorch-operator)
+#### Run trial evaluation job by [PyTorchJob](https://github.com/kubeflow/tf-operator)
 
 ```
 $ kubectl apply -f pytorchjob-example.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

- FIx the hyperlink for PytorchJob because [pytorch-operator](https://github.com/kubeflow/pytorch-operator) was integrated [tf-operator](https://github.com/kubeflow/tf-operator).
- Remove the description of how to access Katib UI for users using Kubernetes <= 1.9 because Katib supports Kubernetes >= 1.17.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #
