### PR TITLE
Implement some unit tests for the katibconfig package

### DIFF
--- a/cmd/metricscollector/v1beta1/file-metricscollector/main.go
+++ b/cmd/metricscollector/v1beta1/file-metricscollector/main.go
@@ -159,7 +159,7 @@ func watchMetricsFile(mFile string, stopRules stopRulesFlag, filters []string) {
 	// Check that metric file exists.
 	checkMetricFile(mFile)
 
-	// Get Main proccess.
+	// Get Main process.
 	_, mainProcPid, err := common.GetMainProcesses(mFile)
 	if err != nil {
 		klog.Fatalf("GetMainProcesses failed: %v", err)
@@ -271,7 +271,7 @@ func watchMetricsFile(mFile string, stopRules stopRulesFlag, filters []string) {
 				klog.Fatalf("Write to file %v error: %v", markFile, err)
 			}
 
-			// Get child proccess from main PID.
+			// Get child process from main PID.
 			childProc, err := mainProc.Children()
 			if err != nil {
 				klog.Fatalf("Get children proceses for main PID: %v failed: %v", mainProcPid, err)
@@ -291,7 +291,7 @@ func watchMetricsFile(mFile string, stopRules stopRulesFlag, filters []string) {
 			// Report metrics to DB.
 			reportMetrics(filters)
 
-			// Wait until main proccess is completed.
+			// Wait until main process is completed.
 			timeout := 60 * time.Second
 			endTime := time.Now().Add(timeout)
 			isProcRunning := true

--- a/pkg/controller.v1beta1/experiment/manifest/generator_test.go
+++ b/pkg/controller.v1beta1/experiment/manifest/generator_test.go
@@ -126,7 +126,7 @@ func TestGetRunSpecWithHP(t *testing.T) {
 			Err:             true,
 			testDescription: "Number of parameter assignments is not equal to number of Trial parameters",
 		},
-		// Parameter from assignments not found in Trial paramters
+		// Parameter from assignments not found in Trial parameters
 		{
 			Instance: newFakeInstance(),
 			ParameterAssignments: func() []commonapiv1beta1.ParameterAssignment {

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller_test.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller_test.go
@@ -144,13 +144,12 @@ func TestReconcile(t *testing.T) {
 	suggestionDeploy := &appsv1.Deployment{}
 
 	// Expect that deployment with appropriate name and image is created
-	g.Eventually(func() bool {
+	g.Eventually(func() string {
 		if err = c.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: resourceName}, suggestionDeploy); err != nil {
-			return false
+			return ""
 		}
-		return len(suggestionDeploy.Spec.Template.Spec.Containers) > 0 &&
-			suggestionDeploy.Spec.Template.Spec.Containers[0].Image == suggestionImage
-	}, timeout).Should(gomega.BeTrue())
+		return suggestionDeploy.Spec.Template.Spec.Containers[0].Image
+	}, timeout).Should(gomega.Equal(suggestionImage))
 
 	// Expect that service with appropriate name is created
 	g.Eventually(func() error {
@@ -302,7 +301,7 @@ func newKatibConfigMapInstance() *corev1.ConfigMap {
 	// Create suggestion config
 	suggestionConfig := map[string]katibconfig.SuggestionConfig{
 		"random": {
-			Image: suggestionName,
+			Image: suggestionImage,
 		},
 	}
 	bSuggestionConfig, _ := json.Marshal(suggestionConfig)

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller_test.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller_test.go
@@ -300,8 +300,10 @@ func newFakeInstance() *suggestionsv1beta1.Suggestion {
 
 func newKatibConfigMapInstance() *corev1.ConfigMap {
 	// Create suggestion config
-	suggestionConfig := map[string]map[string]string{
-		"random": {"image": suggestionImage},
+	suggestionConfig := map[string]katibconfig.SuggestionConfig{
+		"random": {
+			Image: suggestionName,
+		},
 	}
 	bSuggestionConfig, _ := json.Marshal(suggestionConfig)
 

--- a/pkg/new-ui/v1beta1/util.go
+++ b/pkg/new-ui/v1beta1/util.go
@@ -255,7 +255,7 @@ func generateNNImage(architecture string, decoder string) string {
 		Embeding is a map: int to Parameter
 		Parameter has id, type, Option
 
-		Beforehand substite all ' to " and wrap the string in `
+		Beforehand substitute all ' to " and wrap the string in `
 	*/
 
 	replacedDecoder := strings.Replace(decoder, `'`, `"`, -1)

--- a/pkg/ui/v1beta1/util.go
+++ b/pkg/ui/v1beta1/util.go
@@ -242,7 +242,7 @@ func generateNNImage(architecture string, decoder string) string {
 		Embeding is a map: int to Parameter
 		Parameter has id, type, Option
 
-		Beforehand substite all ' to " and wrap the string in `
+		Beforehand substitute all ' to " and wrap the string in `
 	*/
 
 	replacedDecoder := strings.Replace(decoder, `'`, `"`, -1)

--- a/pkg/util/v1beta1/katibconfig/config_test.go
+++ b/pkg/util/v1beta1/katibconfig/config_test.go
@@ -348,7 +348,6 @@ func TestGetMetricsCollectorConfigData(t *testing.T) {
 				t.Errorf("want error: %v, actual: %v", tt.err, err)
 			} else if tt.expected != nil {
 				if !reflect.DeepEqual(actual, *tt.expected) {
-					//t.Errorf("%p, %p", &actual, tt.expected)
 					t.Errorf("Generated MetricsCollectorConfig is invalid.\n\nactual:\n%v\n\nexpected:\n%v\n\n", actual, *tt.expected)
 				}
 			}

--- a/pkg/util/v1beta1/katibconfig/config_test.go
+++ b/pkg/util/v1beta1/katibconfig/config_test.go
@@ -242,7 +242,7 @@ func TestGetEarlyStoppingConfigData(t *testing.T) {
 
 func TestGetMetricsCollectorConfigData(t *testing.T) {
 	const (
-		invalidCollectorKind commonv1beta1.CollectorKind = "invalid-collector-kind"
+		invalidCollectorKind commonv1beta1.CollectorKind = "invalidCollector"
 		testCollectorKind    commonv1beta1.CollectorKind = "testCollector"
 	)
 

--- a/pkg/util/v1beta1/katibconfig/config_test.go
+++ b/pkg/util/v1beta1/katibconfig/config_test.go
@@ -1,0 +1,333 @@
+package katibconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	commonv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
+	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
+)
+
+type katibConfig struct {
+	suggestion       map[string]*SuggestionConfig
+	earlyStopping    map[string]*EarlyStoppingConfig
+	metricsCollector map[string]*MetricsCollectorConfig
+}
+
+func TestGetSuggestionConfigData(t *testing.T) {
+	const testAlgorithmName = "test-suggestion"
+
+	tests := []struct {
+		testDescription          string
+		katibConfigMapSuggestion *SuggestionConfig
+		expected                 *SuggestionConfig
+		inputAlgorithmName       string
+		err                      bool
+		nonExistentSuggestion    bool
+	}{
+		{
+			testDescription: "All parameters are specified",
+			katibConfigMapSuggestion: func() *SuggestionConfig {
+				s := newFakeSuggestionConfig()
+				s.ImagePullPolicy = corev1.PullAlways
+				return s
+			}(),
+			expected: func() *SuggestionConfig {
+				s := newFakeSuggestionConfig()
+				s.ImagePullPolicy = corev1.PullAlways
+				return s
+			}(),
+			inputAlgorithmName: testAlgorithmName,
+			err:                false,
+		},
+		{
+			testDescription:       "There is not the suggestion field in katib-config configMap",
+			err:                   true,
+			nonExistentSuggestion: true,
+		},
+		{
+			testDescription:          "There is not the AlgorithmName",
+			katibConfigMapSuggestion: newFakeSuggestionConfig(),
+			inputAlgorithmName:       "invalid-algorithm-name",
+			err:                      true,
+		},
+		{
+			testDescription: "Image filed is empty in katib-config configMap",
+			katibConfigMapSuggestion: func() *SuggestionConfig {
+				s := newFakeSuggestionConfig()
+				s.Image = ""
+				return s
+			}(),
+			inputAlgorithmName: testAlgorithmName,
+			err:                true,
+		},
+		{
+			testDescription: fmt.Sprintf("GetSuggestionConfigData sets %s to imagePullPolicy", consts.DefaultImagePullPolicy),
+			katibConfigMapSuggestion: func() *SuggestionConfig {
+				s := newFakeSuggestionConfig()
+				s.ImagePullPolicy = ""
+				return s
+			}(),
+			expected:           newFakeSuggestionConfig(),
+			inputAlgorithmName: testAlgorithmName,
+			err:                false,
+		},
+		{
+			testDescription: "GetSuggestionConfigData sets resource.requests and resource.limits for the suggestion service",
+			katibConfigMapSuggestion: func() *SuggestionConfig {
+				s := newFakeSuggestionConfig()
+				s.Resource = corev1.ResourceRequirements{}
+				return s
+			}(),
+			expected:           newFakeSuggestionConfig(),
+			inputAlgorithmName: testAlgorithmName,
+			err:                false,
+		},
+		{
+			testDescription: fmt.Sprintf("GetSuggestionConfigData sets %s to volumeMountPath", consts.DefaultContainerSuggestionVolumeMountPath),
+			katibConfigMapSuggestion: func() *SuggestionConfig {
+				s := newFakeSuggestionConfig()
+				s.VolumeMountPath = ""
+				return s
+			}(),
+			expected:           newFakeSuggestionConfig(),
+			inputAlgorithmName: testAlgorithmName,
+			err:                false,
+		},
+		{
+			testDescription: "GetSuggestionConfigData sets accessMode and resource.requests for PVC",
+			katibConfigMapSuggestion: func() *SuggestionConfig {
+				s := newFakeSuggestionConfig()
+				s.PersistentVolumeClaimSpec = corev1.PersistentVolumeClaimSpec{}
+				return s
+			}(),
+			expected:           newFakeSuggestionConfig(),
+			inputAlgorithmName: testAlgorithmName,
+			err:                false,
+		},
+		{
+			testDescription: fmt.Sprintf("GetSuggestionConfigData does not set %s to persistentVolumeReclaimPolicy", corev1.PersistentVolumeReclaimDelete),
+			katibConfigMapSuggestion: func() *SuggestionConfig {
+				s := newFakeSuggestionConfig()
+				s.PersistentVolumeSpec = corev1.PersistentVolumeSpec{}
+				return s
+			}(),
+			expected: func() *SuggestionConfig {
+				s := newFakeSuggestionConfig()
+				s.PersistentVolumeSpec = corev1.PersistentVolumeSpec{}
+				return s
+			}(),
+			inputAlgorithmName: testAlgorithmName,
+			err:                false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testDescription, func(t *testing.T) {
+			// prepare test
+			config := &katibConfig{}
+			if !tt.nonExistentSuggestion {
+				config.suggestion = map[string]*SuggestionConfig{
+					testAlgorithmName: tt.katibConfigMapSuggestion,
+				}
+			}
+			c := newFakeKubeClient(newFakeKatibConfigMap(config))
+
+			// start test
+			actual, err := GetSuggestionConfigData(tt.inputAlgorithmName, c)
+			if (err != nil) != tt.err {
+				t.Errorf("want error: %v, actual: %v", tt.err, err)
+			} else if tt.expected != nil {
+				if !reflect.DeepEqual(actual, *tt.expected) {
+					t.Errorf("Generated SuggestionConfig is invalid.\n\nactual:\n%v\n\nexpected:\n%v\n\n", actual, *tt.expected)
+				}
+			}
+		})
+	}
+
+}
+
+func TestGetEarlyStoppingConfigData(t *testing.T) {
+	const testAlgorithmName = "test-early-stopping"
+
+	tests := []struct {
+		testDescription             string
+		katibConfigMapEarlyStopping *EarlyStoppingConfig
+		expected                    *EarlyStoppingConfig
+		inputAlgorithmName          string
+		err                         bool
+		nonExistentEarlyStopping    bool
+	}{
+		{},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testDescription, func(t *testing.T) {
+			// prepare test
+			config := &katibConfig{}
+			if !tt.nonExistentEarlyStopping {
+				config.earlyStopping = map[string]*EarlyStoppingConfig{
+					testAlgorithmName: tt.katibConfigMapEarlyStopping,
+				}
+			}
+			c := newFakeKubeClient(newFakeKatibConfigMap(config))
+
+			// start test
+			actual, err := GetEarlyStoppingConfigData(tt.inputAlgorithmName, c)
+			if (err != nil) != tt.err {
+				t.Errorf("want error: %v, actual: %v", tt.err, err)
+			} else if tt.expected != nil {
+				if !reflect.DeepEqual(actual, *tt.expected) {
+					t.Errorf("Generated EarlyStoppingConfig is invalid.\n\nactual:\n%v\n\nexpected:\n%v\n\n", actual, *tt.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestGetMetricsCollectorConfigData(t *testing.T) {
+	const testMetricsCollector = "test-metrics-collector"
+
+	tests := []struct {
+		testDescription                string
+		katibConfigMapMetricsCollector *MetricsCollectorConfig
+		expected           *MetricsCollectorConfig
+		inputCollectorKind commonv1beta1.CollectorKind
+		err                bool
+		nonExistentMetricsCollector    bool
+	}{
+		{},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testDescription, func(t *testing.T) {
+			// prepare test
+			config := &katibConfig{}
+			if !tt.nonExistentMetricsCollector {
+				config.metricsCollector = map[string]*MetricsCollectorConfig{
+					testMetricsCollector: tt.katibConfigMapMetricsCollector,
+				}
+			}
+			c := newFakeKubeClient(newFakeKatibConfigMap(config))
+
+			// start test
+			actual, err := GetMetricsCollectorConfigData(tt.inputCollectorKind, c)
+			if (err != nil) != tt.err {
+				t.Errorf("want error: %v, actual: %v", tt.err, err)
+			} else if tt.expected != nil {
+				if !reflect.DeepEqual(actual, *tt.expected) {
+					t.Errorf("Generated MetricsCollectorConfig is invalid.\n\nactual:\n%v\n\nexpected:\n%v\n\n", actual, *tt.expected)
+				}
+			}
+		})
+	}
+}
+
+func newFakeKubeClient(katibConfigMap *corev1.ConfigMap) client.Client {
+	fakeClientBuilder := fake.NewClientBuilder().WithScheme(scheme.Scheme)
+	if katibConfigMap != nil {
+		fakeClientBuilder.WithObjects(katibConfigMap)
+	}
+	return fakeClientBuilder.Build()
+}
+
+func newFakeKatibConfigMap(config *katibConfig) *corev1.ConfigMap {
+
+	suggestionConfig := ""
+	if config.suggestion != nil {
+		bSuggestionConfig, _ := json.Marshal(config.suggestion)
+		suggestionConfig = string(bSuggestionConfig)
+	}
+
+	earlyStoppingConfig := ""
+	if config.earlyStopping != nil {
+		bEarlyStoppingConfig, _ := json.Marshal(config.earlyStopping)
+		earlyStoppingConfig = string(bEarlyStoppingConfig)
+	}
+
+	metricsCollector := ""
+	if config.metricsCollector != nil {
+		bMetricsCollector, _ := json.Marshal(config.metricsCollector)
+		metricsCollector = string(bMetricsCollector)
+	}
+
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      consts.KatibConfigMapName,
+			Namespace: consts.DefaultKatibNamespace,
+		},
+		Data: map[string]string{
+			consts.LabelSuggestionTag:           suggestionConfig,
+			consts.LabelEarlyStoppingTag:        earlyStoppingConfig,
+			consts.LabelMetricsCollectorSidecar: metricsCollector,
+		},
+	}
+}
+
+func newFakeSuggestionConfig() *SuggestionConfig {
+	defaultCPURequest, _ := resource.ParseQuantity(consts.DefaultCPURequest)
+	defaultMemoryRequest, _ := resource.ParseQuantity(consts.DefaultMemRequest)
+	defaultEphemeralStorageRequest, _ := resource.ParseQuantity(consts.DefaultDiskRequest)
+
+	defaultCPULimit, _ := resource.ParseQuantity(consts.DefaultCPULimit)
+	defaultMemoryLimit, _ := resource.ParseQuantity(consts.DefaultMemLimit)
+	defaultEphemeralStorageLimit, _ := resource.ParseQuantity(consts.DefaultDiskLimit)
+
+	defaultVolumeStorage, _ := resource.ParseQuantity(consts.DefaultSuggestionVolumeStorage)
+
+	return &SuggestionConfig{
+		Image:           "suggestion-image",
+		ImagePullPolicy: consts.DefaultImagePullPolicy,
+		Resource: corev1.ResourceRequirements{
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:              defaultCPURequest,
+				corev1.ResourceMemory:           defaultMemoryRequest,
+				corev1.ResourceEphemeralStorage: defaultEphemeralStorageRequest,
+			},
+			Limits: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:              defaultCPULimit,
+				corev1.ResourceMemory:           defaultMemoryLimit,
+				corev1.ResourceEphemeralStorage: defaultEphemeralStorageLimit,
+			},
+		},
+		VolumeMountPath: consts.DefaultContainerSuggestionVolumeMountPath,
+		PersistentVolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				consts.DefaultSuggestionVolumeAccessMode,
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceStorage: defaultVolumeStorage,
+				},
+			},
+		},
+		PersistentVolumeSpec: corev1.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+		},
+	}
+}
+
+func newFakeEarlyStoppingConfig() *EarlyStoppingConfig {
+	return &EarlyStoppingConfig{
+		Image: "early-stopping-image",
+	}
+}
+
+func newFakeMetricsCollectorConfig() *MetricsCollectorConfig {
+	return &MetricsCollectorConfig{
+		Image: "metrics-collector-image",
+	}
+}

--- a/pkg/util/v1beta1/katibconfig/config_test.go
+++ b/pkg/util/v1beta1/katibconfig/config_test.go
@@ -38,11 +38,13 @@ func TestGetSuggestionConfigData(t *testing.T) {
 			katibConfig: func() *katibConfig {
 				kc := &katibConfig{suggestion: map[string]*SuggestionConfig{testAlgorithmName: newFakeSuggestionConfig()}}
 				kc.suggestion[testAlgorithmName].ImagePullPolicy = corev1.PullAlways
+				kc.suggestion[testAlgorithmName].Resource = *newFakeCustomResourceRequirements()
 				return kc
 			}(),
 			expected: func() *SuggestionConfig {
 				c := newFakeSuggestionConfig()
 				c.ImagePullPolicy = corev1.PullAlways
+				c.Resource = *newFakeCustomResourceRequirements()
 				return c
 			}(),
 			inputAlgorithmName: testAlgorithmName,
@@ -427,6 +429,29 @@ func setFakeResourceRequirements() *corev1.ResourceRequirements {
 	defaultCPULimit, _ := resource.ParseQuantity(consts.DefaultCPULimit)
 	defaultMemoryLimit, _ := resource.ParseQuantity(consts.DefaultMemLimit)
 	defaultEphemeralStorageLimit, _ := resource.ParseQuantity(consts.DefaultDiskLimit)
+
+	return &corev1.ResourceRequirements{
+		Requests: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceCPU:              defaultCPURequest,
+			corev1.ResourceMemory:           defaultMemoryRequest,
+			corev1.ResourceEphemeralStorage: defaultEphemeralStorageRequest,
+		},
+		Limits: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceCPU:              defaultCPULimit,
+			corev1.ResourceMemory:           defaultMemoryLimit,
+			corev1.ResourceEphemeralStorage: defaultEphemeralStorageLimit,
+		},
+	}
+}
+
+func newFakeCustomResourceRequirements() *corev1.ResourceRequirements {
+	defaultCPURequest, _ := resource.ParseQuantity("25m")
+	defaultMemoryRequest, _ := resource.ParseQuantity("200Mi")
+	defaultEphemeralStorageRequest, _ := resource.ParseQuantity("550Mi")
+
+	defaultCPULimit, _ := resource.ParseQuantity("250m")
+	defaultMemoryLimit, _ := resource.ParseQuantity("2Gi")
+	defaultEphemeralStorageLimit, _ := resource.ParseQuantity("15Gi")
 
 	return &corev1.ResourceRequirements{
 		Requests: map[corev1.ResourceName]resource.Quantity{

--- a/pkg/util/v1beta1/katibconfig/config_test.go
+++ b/pkg/util/v1beta1/katibconfig/config_test.go
@@ -349,7 +349,6 @@ func newFakeKubeClient(katibConfigMap *corev1.ConfigMap) client.Client {
 }
 
 func newFakeKatibConfigMap(config *katibConfig) *corev1.ConfigMap {
-
 	if config == nil {
 		return nil
 	}

--- a/pkg/util/v1beta1/katibconfig/config_test.go
+++ b/pkg/util/v1beta1/katibconfig/config_test.go
@@ -445,24 +445,24 @@ func setFakeResourceRequirements() *corev1.ResourceRequirements {
 }
 
 func newFakeCustomResourceRequirements() *corev1.ResourceRequirements {
-	defaultCPURequest, _ := resource.ParseQuantity("25m")
-	defaultMemoryRequest, _ := resource.ParseQuantity("200Mi")
-	defaultEphemeralStorageRequest, _ := resource.ParseQuantity("550Mi")
+	customCPURequest, _ := resource.ParseQuantity("25m")
+	customMemoryRequest, _ := resource.ParseQuantity("200Mi")
+	customEphemeralStorageRequest, _ := resource.ParseQuantity("550Mi")
 
-	defaultCPULimit, _ := resource.ParseQuantity("250m")
-	defaultMemoryLimit, _ := resource.ParseQuantity("2Gi")
-	defaultEphemeralStorageLimit, _ := resource.ParseQuantity("15Gi")
+	customCPULimit, _ := resource.ParseQuantity("250m")
+	customMemoryLimit, _ := resource.ParseQuantity("2Gi")
+	customEphemeralStorageLimit, _ := resource.ParseQuantity("15Gi")
 
 	return &corev1.ResourceRequirements{
 		Requests: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceCPU:              defaultCPURequest,
-			corev1.ResourceMemory:           defaultMemoryRequest,
-			corev1.ResourceEphemeralStorage: defaultEphemeralStorageRequest,
+			corev1.ResourceCPU:              customCPURequest,
+			corev1.ResourceMemory:           customMemoryRequest,
+			corev1.ResourceEphemeralStorage: customEphemeralStorageRequest,
 		},
 		Limits: map[corev1.ResourceName]resource.Quantity{
-			corev1.ResourceCPU:              defaultCPULimit,
-			corev1.ResourceMemory:           defaultMemoryLimit,
-			corev1.ResourceEphemeralStorage: defaultEphemeralStorageLimit,
+			corev1.ResourceCPU:              customCPULimit,
+			corev1.ResourceMemory:           customMemoryLimit,
+			corev1.ResourceEphemeralStorage: customEphemeralStorageLimit,
 		},
 	}
 }

--- a/pkg/util/v1beta1/katibconfig/config_test.go
+++ b/pkg/util/v1beta1/katibconfig/config_test.go
@@ -20,7 +20,7 @@ import (
 type katibConfig struct {
 	suggestion       map[string]*SuggestionConfig
 	earlyStopping    map[string]*EarlyStoppingConfig
-	metricsCollector map[string]*MetricsCollectorConfig
+	metricsCollector map[commonv1beta1.CollectorKind]*MetricsCollectorConfig
 }
 
 func TestGetSuggestionConfigData(t *testing.T) {
@@ -35,22 +35,22 @@ func TestGetSuggestionConfigData(t *testing.T) {
 		nonExistentSuggestion    bool
 	}{
 		{
-			testDescription: "All parameters are specified",
+			testDescription: "All parameters correctly are specified",
 			katibConfigMapSuggestion: func() *SuggestionConfig {
-				s := newFakeSuggestionConfig()
-				s.ImagePullPolicy = corev1.PullAlways
-				return s
+				c := newFakeSuggestionConfig()
+				c.ImagePullPolicy = corev1.PullAlways
+				return c
 			}(),
 			expected: func() *SuggestionConfig {
-				s := newFakeSuggestionConfig()
-				s.ImagePullPolicy = corev1.PullAlways
-				return s
+				c := newFakeSuggestionConfig()
+				c.ImagePullPolicy = corev1.PullAlways
+				return c
 			}(),
 			inputAlgorithmName: testAlgorithmName,
 			err:                false,
 		},
 		{
-			testDescription:       "There is not the suggestion field in katib-config configMap",
+			testDescription:       fmt.Sprintf("There is not %s field in katib-config configMap", consts.LabelSuggestionTag),
 			err:                   true,
 			nonExistentSuggestion: true,
 		},
@@ -63,9 +63,9 @@ func TestGetSuggestionConfigData(t *testing.T) {
 		{
 			testDescription: "Image filed is empty in katib-config configMap",
 			katibConfigMapSuggestion: func() *SuggestionConfig {
-				s := newFakeSuggestionConfig()
-				s.Image = ""
-				return s
+				c := newFakeSuggestionConfig()
+				c.Image = ""
+				return c
 			}(),
 			inputAlgorithmName: testAlgorithmName,
 			err:                true,
@@ -73,9 +73,9 @@ func TestGetSuggestionConfigData(t *testing.T) {
 		{
 			testDescription: fmt.Sprintf("GetSuggestionConfigData sets %s to imagePullPolicy", consts.DefaultImagePullPolicy),
 			katibConfigMapSuggestion: func() *SuggestionConfig {
-				s := newFakeSuggestionConfig()
-				s.ImagePullPolicy = ""
-				return s
+				c := newFakeSuggestionConfig()
+				c.ImagePullPolicy = ""
+				return c
 			}(),
 			expected:           newFakeSuggestionConfig(),
 			inputAlgorithmName: testAlgorithmName,
@@ -84,9 +84,9 @@ func TestGetSuggestionConfigData(t *testing.T) {
 		{
 			testDescription: "GetSuggestionConfigData sets resource.requests and resource.limits for the suggestion service",
 			katibConfigMapSuggestion: func() *SuggestionConfig {
-				s := newFakeSuggestionConfig()
-				s.Resource = corev1.ResourceRequirements{}
-				return s
+				c := newFakeSuggestionConfig()
+				c.Resource = corev1.ResourceRequirements{}
+				return c
 			}(),
 			expected:           newFakeSuggestionConfig(),
 			inputAlgorithmName: testAlgorithmName,
@@ -95,9 +95,9 @@ func TestGetSuggestionConfigData(t *testing.T) {
 		{
 			testDescription: fmt.Sprintf("GetSuggestionConfigData sets %s to volumeMountPath", consts.DefaultContainerSuggestionVolumeMountPath),
 			katibConfigMapSuggestion: func() *SuggestionConfig {
-				s := newFakeSuggestionConfig()
-				s.VolumeMountPath = ""
-				return s
+				c := newFakeSuggestionConfig()
+				c.VolumeMountPath = ""
+				return c
 			}(),
 			expected:           newFakeSuggestionConfig(),
 			inputAlgorithmName: testAlgorithmName,
@@ -106,9 +106,9 @@ func TestGetSuggestionConfigData(t *testing.T) {
 		{
 			testDescription: "GetSuggestionConfigData sets accessMode and resource.requests for PVC",
 			katibConfigMapSuggestion: func() *SuggestionConfig {
-				s := newFakeSuggestionConfig()
-				s.PersistentVolumeClaimSpec = corev1.PersistentVolumeClaimSpec{}
-				return s
+				c := newFakeSuggestionConfig()
+				c.PersistentVolumeClaimSpec = corev1.PersistentVolumeClaimSpec{}
+				return c
 			}(),
 			expected:           newFakeSuggestionConfig(),
 			inputAlgorithmName: testAlgorithmName,
@@ -117,14 +117,14 @@ func TestGetSuggestionConfigData(t *testing.T) {
 		{
 			testDescription: fmt.Sprintf("GetSuggestionConfigData does not set %s to persistentVolumeReclaimPolicy", corev1.PersistentVolumeReclaimDelete),
 			katibConfigMapSuggestion: func() *SuggestionConfig {
-				s := newFakeSuggestionConfig()
-				s.PersistentVolumeSpec = corev1.PersistentVolumeSpec{}
-				return s
+				c := newFakeSuggestionConfig()
+				c.PersistentVolumeSpec = corev1.PersistentVolumeSpec{}
+				return c
 			}(),
 			expected: func() *SuggestionConfig {
-				s := newFakeSuggestionConfig()
-				s.PersistentVolumeSpec = corev1.PersistentVolumeSpec{}
-				return s
+				c := newFakeSuggestionConfig()
+				c.PersistentVolumeSpec = corev1.PersistentVolumeSpec{}
+				return c
 			}(),
 			inputAlgorithmName: testAlgorithmName,
 			err:                false,
@@ -167,7 +167,53 @@ func TestGetEarlyStoppingConfigData(t *testing.T) {
 		err                         bool
 		nonExistentEarlyStopping    bool
 	}{
-		{},
+		{
+			testDescription: "All parameters correctly are specified",
+			katibConfigMapEarlyStopping: func() *EarlyStoppingConfig {
+				c := newFakeEarlyStoppingConfig()
+				c.ImagePullPolicy = corev1.PullIfNotPresent
+				return c
+			}(),
+			expected: func() *EarlyStoppingConfig {
+				c := newFakeEarlyStoppingConfig()
+				c.ImagePullPolicy = corev1.PullIfNotPresent
+				return c
+			}(),
+			inputAlgorithmName: testAlgorithmName,
+			err:                false,
+		},
+		{
+			testDescription:          fmt.Sprintf("There is not %s field in katib-config configMap", consts.LabelEarlyStoppingTag),
+			err:                      true,
+			nonExistentEarlyStopping: true,
+		},
+		{
+			testDescription:             "There is not the AlgorithmName",
+			katibConfigMapEarlyStopping: newFakeEarlyStoppingConfig(),
+			inputAlgorithmName:          "invalid-algorithm-name",
+			err:                         true,
+		},
+		{
+			testDescription: "Image filed is empty in katib-config configMap",
+			katibConfigMapEarlyStopping: func() *EarlyStoppingConfig {
+				c := newFakeEarlyStoppingConfig()
+				c.Image = ""
+				return c
+			}(),
+			inputAlgorithmName: testAlgorithmName,
+			err:                true,
+		},
+		{
+			testDescription: fmt.Sprintf("GetEarlyStoppingConfigData sets %s to imagePullPolicy", consts.DefaultImagePullPolicy),
+			katibConfigMapEarlyStopping: func() *EarlyStoppingConfig {
+				c := newFakeEarlyStoppingConfig()
+				c.ImagePullPolicy = ""
+				return c
+			}(),
+			expected:           newFakeEarlyStoppingConfig(),
+			inputAlgorithmName: testAlgorithmName,
+			err:                false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -195,17 +241,94 @@ func TestGetEarlyStoppingConfigData(t *testing.T) {
 }
 
 func TestGetMetricsCollectorConfigData(t *testing.T) {
-	const testMetricsCollector = "test-metrics-collector"
+	const (
+		invalidCollectorKind commonv1beta1.CollectorKind = "invalid-collector-kind"
+		testCollectorKind    commonv1beta1.CollectorKind = "testCollector"
+	)
+
+	nukeResource, _ := resource.ParseQuantity("-1")
+	nukeResourceRequirements := map[corev1.ResourceName]resource.Quantity{
+		corev1.ResourceCPU:              nukeResource,
+		corev1.ResourceMemory:           nukeResource,
+		corev1.ResourceEphemeralStorage: nukeResource,
+	}
 
 	tests := []struct {
 		testDescription                string
 		katibConfigMapMetricsCollector *MetricsCollectorConfig
-		expected           *MetricsCollectorConfig
-		inputCollectorKind commonv1beta1.CollectorKind
-		err                bool
+		expected                       *MetricsCollectorConfig
+		inputCollectorKind             commonv1beta1.CollectorKind
+		err                            bool
 		nonExistentMetricsCollector    bool
 	}{
-		{},
+		{
+			testDescription: "All parameters correctly are specified",
+			katibConfigMapMetricsCollector: func() *MetricsCollectorConfig {
+				c := newFakeMetricsCollectorConfig()
+				c.ImagePullPolicy = corev1.PullNever
+				return c
+			}(),
+			expected: func() *MetricsCollectorConfig {
+				c := newFakeMetricsCollectorConfig()
+				c.ImagePullPolicy = corev1.PullNever
+				return c
+			}(),
+			inputCollectorKind: testCollectorKind,
+			err:                false,
+		},
+		{
+			testDescription:             fmt.Sprintf("There is not %s field in katib-config configMap", consts.LabelMetricsCollectorSidecar),
+			err:                         true,
+			nonExistentMetricsCollector: true,
+		},
+		{
+			testDescription:                "There is not the cKind",
+			katibConfigMapMetricsCollector: newFakeMetricsCollectorConfig(),
+			inputCollectorKind:             invalidCollectorKind,
+			err:                            true,
+		},
+		{
+			testDescription: "Image filed is empty in katib-config configMap",
+			katibConfigMapMetricsCollector: func() *MetricsCollectorConfig {
+				c := newFakeMetricsCollectorConfig()
+				c.Image = ""
+				return c
+			}(),
+			inputCollectorKind: testCollectorKind,
+			err:                true,
+		},
+		{
+			testDescription: fmt.Sprintf("GetMetricsConfigData sets %s to imagePullPolicy", consts.DefaultImagePullPolicy),
+			katibConfigMapMetricsCollector: func() *MetricsCollectorConfig {
+				c := newFakeMetricsCollectorConfig()
+				c.ImagePullPolicy = ""
+				return c
+			}(),
+			expected:           newFakeMetricsCollectorConfig(),
+			inputCollectorKind: testCollectorKind,
+			err:                false,
+		},
+		{
+			testDescription: "GetMetricsConfigData nukes resource.requests and resource.limits for the metrics collector",
+			katibConfigMapMetricsCollector: func() *MetricsCollectorConfig {
+				c := newFakeMetricsCollectorConfig()
+				c.Resource = corev1.ResourceRequirements{
+					Requests: nukeResourceRequirements,
+					Limits:   nukeResourceRequirements,
+				}
+				return c
+			}(),
+			expected: func() *MetricsCollectorConfig {
+				c := newFakeMetricsCollectorConfig()
+				c.Resource = corev1.ResourceRequirements{
+					Requests: map[corev1.ResourceName]resource.Quantity{},
+					Limits:   map[corev1.ResourceName]resource.Quantity{},
+				}
+				return c
+			}(),
+			inputCollectorKind: testCollectorKind,
+			err:                false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -213,8 +336,8 @@ func TestGetMetricsCollectorConfigData(t *testing.T) {
 			// prepare test
 			config := &katibConfig{}
 			if !tt.nonExistentMetricsCollector {
-				config.metricsCollector = map[string]*MetricsCollectorConfig{
-					testMetricsCollector: tt.katibConfigMapMetricsCollector,
+				config.metricsCollector = map[commonv1beta1.CollectorKind]*MetricsCollectorConfig{
+					testCollectorKind: tt.katibConfigMapMetricsCollector,
 				}
 			}
 			c := newFakeKubeClient(newFakeKatibConfigMap(config))
@@ -225,6 +348,7 @@ func TestGetMetricsCollectorConfigData(t *testing.T) {
 				t.Errorf("want error: %v, actual: %v", tt.err, err)
 			} else if tt.expected != nil {
 				if !reflect.DeepEqual(actual, *tt.expected) {
+					//t.Errorf("%p, %p", &actual, tt.expected)
 					t.Errorf("Generated MetricsCollectorConfig is invalid.\n\nactual:\n%v\n\nexpected:\n%v\n\n", actual, *tt.expected)
 				}
 			}
@@ -242,22 +366,18 @@ func newFakeKubeClient(katibConfigMap *corev1.ConfigMap) client.Client {
 
 func newFakeKatibConfigMap(config *katibConfig) *corev1.ConfigMap {
 
-	suggestionConfig := ""
+	data := map[string]string{}
 	if config.suggestion != nil {
 		bSuggestionConfig, _ := json.Marshal(config.suggestion)
-		suggestionConfig = string(bSuggestionConfig)
+		data[consts.LabelSuggestionTag] = string(bSuggestionConfig)
 	}
-
-	earlyStoppingConfig := ""
 	if config.earlyStopping != nil {
 		bEarlyStoppingConfig, _ := json.Marshal(config.earlyStopping)
-		earlyStoppingConfig = string(bEarlyStoppingConfig)
+		data[consts.LabelEarlyStoppingTag] = string(bEarlyStoppingConfig)
 	}
-
-	metricsCollector := ""
 	if config.metricsCollector != nil {
 		bMetricsCollector, _ := json.Marshal(config.metricsCollector)
-		metricsCollector = string(bMetricsCollector)
+		data[consts.LabelMetricsCollectorSidecar] = string(bMetricsCollector)
 	}
 
 	return &corev1.ConfigMap{
@@ -269,40 +389,17 @@ func newFakeKatibConfigMap(config *katibConfig) *corev1.ConfigMap {
 			Name:      consts.KatibConfigMapName,
 			Namespace: consts.DefaultKatibNamespace,
 		},
-		Data: map[string]string{
-			consts.LabelSuggestionTag:           suggestionConfig,
-			consts.LabelEarlyStoppingTag:        earlyStoppingConfig,
-			consts.LabelMetricsCollectorSidecar: metricsCollector,
-		},
+		Data: data,
 	}
 }
 
 func newFakeSuggestionConfig() *SuggestionConfig {
-	defaultCPURequest, _ := resource.ParseQuantity(consts.DefaultCPURequest)
-	defaultMemoryRequest, _ := resource.ParseQuantity(consts.DefaultMemRequest)
-	defaultEphemeralStorageRequest, _ := resource.ParseQuantity(consts.DefaultDiskRequest)
-
-	defaultCPULimit, _ := resource.ParseQuantity(consts.DefaultCPULimit)
-	defaultMemoryLimit, _ := resource.ParseQuantity(consts.DefaultMemLimit)
-	defaultEphemeralStorageLimit, _ := resource.ParseQuantity(consts.DefaultDiskLimit)
-
 	defaultVolumeStorage, _ := resource.ParseQuantity(consts.DefaultSuggestionVolumeStorage)
 
 	return &SuggestionConfig{
 		Image:           "suggestion-image",
 		ImagePullPolicy: consts.DefaultImagePullPolicy,
-		Resource: corev1.ResourceRequirements{
-			Requests: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU:              defaultCPURequest,
-				corev1.ResourceMemory:           defaultMemoryRequest,
-				corev1.ResourceEphemeralStorage: defaultEphemeralStorageRequest,
-			},
-			Limits: map[corev1.ResourceName]resource.Quantity{
-				corev1.ResourceCPU:              defaultCPULimit,
-				corev1.ResourceMemory:           defaultMemoryLimit,
-				corev1.ResourceEphemeralStorage: defaultEphemeralStorageLimit,
-			},
-		},
+		Resource:        *setFakeResourceRequirements(),
 		VolumeMountPath: consts.DefaultContainerSuggestionVolumeMountPath,
 		PersistentVolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{
@@ -322,12 +419,38 @@ func newFakeSuggestionConfig() *SuggestionConfig {
 
 func newFakeEarlyStoppingConfig() *EarlyStoppingConfig {
 	return &EarlyStoppingConfig{
-		Image: "early-stopping-image",
+		Image:           "early-stopping-image",
+		ImagePullPolicy: consts.DefaultImagePullPolicy,
 	}
 }
 
 func newFakeMetricsCollectorConfig() *MetricsCollectorConfig {
 	return &MetricsCollectorConfig{
-		Image: "metrics-collector-image",
+		Image:           "metrics-collector-image",
+		ImagePullPolicy: consts.DefaultImagePullPolicy,
+		Resource:        *setFakeResourceRequirements(),
+	}
+}
+
+func setFakeResourceRequirements() *corev1.ResourceRequirements {
+	defaultCPURequest, _ := resource.ParseQuantity(consts.DefaultCPURequest)
+	defaultMemoryRequest, _ := resource.ParseQuantity(consts.DefaultMemRequest)
+	defaultEphemeralStorageRequest, _ := resource.ParseQuantity(consts.DefaultDiskRequest)
+
+	defaultCPULimit, _ := resource.ParseQuantity(consts.DefaultCPULimit)
+	defaultMemoryLimit, _ := resource.ParseQuantity(consts.DefaultMemLimit)
+	defaultEphemeralStorageLimit, _ := resource.ParseQuantity(consts.DefaultDiskLimit)
+
+	return &corev1.ResourceRequirements{
+		Requests: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceCPU:              defaultCPURequest,
+			corev1.ResourceMemory:           defaultMemoryRequest,
+			corev1.ResourceEphemeralStorage: defaultEphemeralStorageRequest,
+		},
+		Limits: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceCPU:              defaultCPULimit,
+			corev1.ResourceMemory:           defaultMemoryLimit,
+			corev1.ResourceEphemeralStorage: defaultEphemeralStorageLimit,
+		},
 	}
 }

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -359,7 +359,7 @@ func validatePatchJob(runSpec *unstructured.Unstructured, job interface{}, jobTy
 	// Not necessary to check error job must be valid JSON
 	runSpecAfter, _ := json.Marshal(job)
 
-	// Create Patch on tranformed Job (e.g: Job) using unstructured JSON
+	// Create Patch on transformed Job (e.g: Job) using unstructured JSON
 	runSpecPatchOperations, err := jsonPatch.CreatePatch(runSpecAfter, runSpecBefore)
 	if err != nil {
 		return fmt.Errorf("create patch error: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Implement some unit tests for the following functions in the katibconfig package since it has not been sufficiently tested. 
In addition, fix some mistyped comments and envtest for suggestion-controller.

- [x] [`GetSuggestionConfigData(algorithmName string, client client.Client) (SuggestionConfig, error)`](https://github.com/kubeflow/katib/blob/29409198ff7a13d1984e48a0b14d6954296950d6/pkg/util/v1beta1/katibconfig/config.go#L61-L143)
- [x] [`GetEarlyStoppingConfigData(algorithmName string, client client.Client) (EarlyStoppingConfig, error)`](https://github.com/kubeflow/katib/blob/29409198ff7a13d1984e48a0b14d6954296950d6/pkg/util/v1beta1/katibconfig/config.go#L145-L188)
- [x] [`GetMetricsCollectorConfigData(cKind common.CollectorKind, client client.Client) (MetricsCollectorConfig, error)`](https://github.com/kubeflow/katib/blob/29409198ff7a13d1984e48a0b14d6954296950d6/pkg/util/v1beta1/katibconfig/config.go#L190-L236)

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #
Ref https://github.com/kubeflow/katib/issues/1680#issuecomment-930407734

/assign
/cc @andreyvelich 
