### PR TITLE
Fix hyperlink for build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <br>
 </h1>
 
-[![Build Status](https://travis-ci.com/kubeflow/katib.svg?branch=master)](https://travis-ci.com/kubeflow/katib)
+[![Build Status](https://github.com/kubeflow/katib/actions/workflows/test-go.yaml/badge.svg)](https://github.com/kubeflow/katib/actions/workflows/test-go.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/kubeflow/katib/badge.svg?branch=master)](https://coveralls.io/github/kubeflow/katib?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubeflow/katib)](https://goreportcard.com/report/github.com/kubeflow/katib)
 [![Releases](https://img.shields.io/github/release-pre/kubeflow/katib.svg?sort=semver)](https://github.com/kubeflow/katib/releases)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <br>
 </h1>
 
-[![Build Status](https://github.com/kubeflow/katib/actions/workflows/test-go.yaml/badge.svg)](https://github.com/kubeflow/katib/actions/workflows/test-go.yaml)
+[![Build Status](https://github.com/kubeflow/katib/actions/workflows/test-go.yaml/badge.svg?branch=master)](https://github.com/kubeflow/katib/actions/workflows/test-go.yaml?branch=master)
 [![Coverage Status](https://coveralls.io/repos/github/kubeflow/katib/badge.svg?branch=master)](https://coveralls.io/github/kubeflow/katib?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubeflow/katib)](https://goreportcard.com/report/github.com/kubeflow/katib)
 [![Releases](https://img.shields.io/github/release-pre/kubeflow/katib.svg?sort=semver)](https://github.com/kubeflow/katib/releases)


### PR DESCRIPTION
**What this PR does / why we need it**:

Change hyperlink for build status from travis ci to github actions.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

/assign
/assign @andreyvelich @gaocegege @johnugeorge 
