### PR TITLE
Draft: Support log-uniform scale in search space definition

### DIFF
--- a/pkg/apis/controller/experiments/v1beta1/experiment_types.go
+++ b/pkg/apis/controller/experiments/v1beta1/experiment_types.go
@@ -199,11 +199,19 @@ const (
 	ParameterTypeCategorical ParameterType = "categorical"
 )
 
+type ParameterDistribution string
+
+const (
+	Uniform    ParameterDistribution = "uniform"
+	LogUniform ParameterDistribution = "log-uniform"
+)
+
 type FeasibleSpace struct {
 	Max  string   `json:"max,omitempty"`
 	Min  string   `json:"min,omitempty"`
 	List []string `json:"list,omitempty"`
 	Step string   `json:"step,omitempty"`
+	Distribution ParameterDistribution `json:"distribution,omitempty"`
 }
 
 // TrialTemplate describes structure of trial template

--- a/pkg/suggestion/v1beta1/goptuna/converter.go
+++ b/pkg/suggestion/v1beta1/goptuna/converter.go
@@ -122,9 +122,16 @@ func toGoptunaSearchSpace(parameters []*api_v1_beta1.ParameterSpec) (map[string]
 
 			stepstr := p.GetFeasibleSpace().GetStep()
 			if stepstr == "" {
-				searchSpace[p.Name] = goptuna.UniformDistribution{
-					High: high,
-					Low:  low,
+			    if p.GetFeasibleSpace().GetDistribution() == "uniform"{
+                    searchSpace[p.Name] = goptuna.UniformDistribution{
+                        High: high,
+                        Low:  low,
+                    }
+				}else if p.GetFeasibleSpace().GetDistribution() == "log-uniform"{
+                    searchSpace[p.Name] = goptuna.LogUniformDistribution{
+                        High: high,
+                        Low:  low,
+                    }
 				}
 			} else {
 				step, err := strconv.ParseFloat(stepstr, 64)

--- a/pkg/suggestion/v1beta1/hyperopt/base_service.py
+++ b/pkg/suggestion/v1beta1/hyperopt/base_service.py
@@ -62,10 +62,16 @@ class BaseHyperoptService(object):
                     float(param.max),
                     float(param.step))
             elif param.type == DOUBLE:
-                hyperopt_search_space[param.name] = hyperopt.hp.uniform(
-                    param.name,
-                    float(param.min),
-                    float(param.max))
+                if param.distribution == "uniform":
+                    hyperopt_search_space[param.name] = hyperopt.hp.uniform(
+                        param.name,
+                        float(param.min),
+                        float(param.max))
+                elif param.distribution == "log-uniform":
+                    hyperopt_search_space[param.name] = hyperopt.hp.loguniform(
+                        param.name,
+                        float(param.min),
+                        float(param.max))
             elif param.type == CATEGORICAL or param.type == DISCRETE:
                 hyperopt_search_space[param.name] = hyperopt.hp.choice(
                     param.name, param.list)

--- a/pkg/suggestion/v1beta1/internal/search_space.py
+++ b/pkg/suggestion/v1beta1/internal/search_space.py
@@ -52,7 +52,8 @@ class HyperParameterSearchSpace(object):
                 step = p.feasible_space.step
             return HyperParameter.int(p.name, p.feasible_space.min, p.feasible_space.max, step)
         elif p.parameter_type == api.DOUBLE:
-            return HyperParameter.double(p.name, p.feasible_space.min, p.feasible_space.max, p.feasible_space.step)
+            return HyperParameter.double(p.name, p.feasible_space.min, p.feasible_space.max, p.feasible_space.step,
+                                         p.feasible_space.distribution)
         elif p.parameter_type == api.CATEGORICAL:
             return HyperParameter.categorical(p.name, p.feasible_space.list)
         elif p.parameter_type == api.DISCRETE:
@@ -63,34 +64,38 @@ class HyperParameterSearchSpace(object):
 
 
 class HyperParameter(object):
-    def __init__(self, name, type_, min_, max_, list_, step):
+    def __init__(self, name, type_, min_, max_, list_, step, distribution):
         self.name = name
         self.type = type_
         self.min = min_
         self.max = max_
         self.list = list_
         self.step = step
+        self.distribution = distribution
 
     def __str__(self):
-        if self.type == INTEGER or self.type == DOUBLE:
+        if self.type == INTEGER:
             return "HyperParameter(name: {}, type: {}, min: {}, max: {}, step: {})".format(
                 self.name, self.type, self.min, self.max, self.step)
+        elif self.type == DOUBLE:
+            return "HyperParameter(name: {}, type: {}, min: {}, max: {}, step: {}, distribution: {})".format(
+                self.name, self.type, self.min, self.max, self.step, self.distribution)
         else:
             return "HyperParameter(name: {}, type: {}, list: {})".format(
                 self.name, self.type, ", ".join(self.list))
 
     @staticmethod
     def int(name, min_, max_, step):
-        return HyperParameter(name, INTEGER, min_, max_, [], step)
+        return HyperParameter(name, INTEGER, min_, max_, [], step, None)
 
     @staticmethod
-    def double(name, min_, max_, step):
-        return HyperParameter(name, DOUBLE, min_, max_, [], step)
+    def double(name, min_, max_, step, distribution):
+        return HyperParameter(name, DOUBLE, min_, max_, [], step, distribution)
 
     @staticmethod
     def categorical(name, lst):
-        return HyperParameter(name, CATEGORICAL, 0, 0, [str(e) for e in lst], 0)
+        return HyperParameter(name, CATEGORICAL, 0, 0, [str(e) for e in lst], 0, None)
 
     @staticmethod
     def discrete(name, lst):
-        return HyperParameter(name, DISCRETE, 0, 0, [str(e) for e in lst], 0)
+        return HyperParameter(name, DISCRETE, 0, 0, [str(e) for e in lst], 0, None)

--- a/pkg/suggestion/v1beta1/optuna/service.py
+++ b/pkg/suggestion/v1beta1/optuna/service.py
@@ -151,7 +151,12 @@ class OptunaService(api_pb2_grpc.SuggestionServicer, HealthServicer):
             if param.type == INTEGER:
                 search_space[param.name] = optuna.distributions.IntUniformDistribution(int(param.min), int(param.max))
             elif param.type == DOUBLE:
-                search_space[param.name] = optuna.distributions.UniformDistribution(float(param.min), float(param.max))
+                if param.distribution == "uniform":
+                    search_space[param.name] = optuna.distributions.UniformDistribution(float(param.min),
+                                                                                        float(param.max))
+                elif param.distribution == "log-uniform":
+                    search_space[param.name] = optuna.distributions.LogUniformDistribution(float(param.min),
+                                                                                           float(param.max))
             elif param.type == CATEGORICAL or param.type == DISCRETE:
                 search_space[param.name] = optuna.distributions.CategoricalDistribution(param.list)
         return search_space

--- a/pkg/suggestion/v1beta1/skopt/base_service.py
+++ b/pkg/suggestion/v1beta1/skopt/base_service.py
@@ -55,7 +55,7 @@ class BaseSkoptService(object):
                     int(param.min), int(param.max), name=param.name))
             elif param.type == DOUBLE:
                 skopt_search_space.append(skopt.space.Real(
-                    float(param.min), float(param.max), "log-uniform", name=param.name))
+                    float(param.min), float(param.max), prior=param.distribution, name=param.name))
             elif param.type == CATEGORICAL or param.type == DISCRETE:
                 skopt_search_space.append(
                     skopt.space.Categorical(param.list, name=param.name))

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -207,6 +207,11 @@ func (g *DefaultValidator) validateParameters(parameters []experimentsv1beta1.Pa
 			if param.FeasibleSpace.Max == "" && param.FeasibleSpace.Min == "" {
 				return fmt.Errorf("feasibleSpace.max or feasibleSpace.min must be specified for parameterType: %v in spec.parameters[%v]: %v", param.ParameterType, i, param)
 			}
+			if param.ParameterType == experimentsv1beta1.ParameterTypeDouble && param.FeasibleSpace.Distribution == ""{
+			    return fmt.Errorf("feasibleSpace.distribution must be specified for parameterType: double in spec.parameters[%v]: %v", i, param)
+			}else if param.ParameterType == experimentsv1beta1.ParameterTypeDouble && param.FeasibleSpace.Distribution != "uniform" && param.FeasibleSpace.Distribution != "log-uniform"{
+			    return fmt.Errorf("feasibleSpace.distribution must be one of 'uniform', 'log-uniform' for parameterType: double in spec.parameters[%v]: %v", i, param)
+			}
 
 		} else if param.ParameterType == experimentsv1beta1.ParameterTypeCategorical || param.ParameterType == experimentsv1beta1.ParameterTypeDiscrete {
 			if param.FeasibleSpace.Max != "" || param.FeasibleSpace.Min != "" || param.FeasibleSpace.Step != "" {


### PR DESCRIPTION
Hello everyone,

I would like to see some movement in #1207. I started by adding the distribution field everywhere I could find and already modifying the behaviour in the suggestion package at relevant places. 

I am guessing this PR is not even close to finished. Maybe someone can point out to me which parts are still missing(and or have to be adapated), or discuss if my approach to fixing #1207 is good. Perhaps one of the main contributors can also take over from here.
**What this PR does / why we need it**:
This adds a field distribution to SearchSpace which allows for the "log-uniform" scale (and possibly other scales) to be supported for sampling from parameter search spaces.

Fixes #1207

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
