### PR TITLE
fix: close mysql statement and rows resources when sql exec end

### DIFF
--- a/pkg/db/v1beta1/mysql/mysql.go
+++ b/pkg/db/v1beta1/mysql/mysql.go
@@ -132,6 +132,9 @@ func (d *dbConn) RegisterObservationLog(trialName string, observationLog *v1beta
 		return fmt.Errorf("Pepare SQL statement failed: %v", err)
 	}
 
+	// Close the statement
+	defer stmt.Close()
+
 	// Execute INSERT
 	_, err = stmt.Exec(values...)
 	if err != nil {
@@ -179,6 +182,8 @@ func (d *dbConn) GetObservationLog(trialName string, metricName string, startTim
 	result := &v1beta1.ObservationLog{
 		MetricLogs: []*v1beta1.MetricLog{},
 	}
+	// Close the rows
+	defer rows.Close()
 	for rows.Next() {
 		var mname, mvalue, sqlTimeStr string
 		err := rows.Scan(&sqlTimeStr, &mname, &mvalue)

--- a/pkg/db/v1beta1/mysql/mysql.go
+++ b/pkg/db/v1beta1/mysql/mysql.go
@@ -129,7 +129,7 @@ func (d *dbConn) RegisterObservationLog(trialName string, observationLog *v1beta
 	// Prepare the statement
 	stmt, err := d.db.Prepare(sqlQuery)
 	if err != nil {
-		return fmt.Errorf("Pepare SQL statement failed: %v", err)
+		return fmt.Errorf("Prepare SQL statement failed: %v", err)
 	}
 
 	// Close the statement

--- a/pkg/db/v1beta1/mysql/mysql.go
+++ b/pkg/db/v1beta1/mysql/mysql.go
@@ -179,11 +179,11 @@ func (d *dbConn) GetObservationLog(trialName string, metricName string, startTim
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get ObservationLogs %v", err)
 	}
+	// Close the rows
+	defer rows.Close()
 	result := &v1beta1.ObservationLog{
 		MetricLogs: []*v1beta1.MetricLog{},
 	}
-	// Close the rows
-	defer rows.Close()
 	for rows.Next() {
 		var mname, mvalue, sqlTimeStr string
 		err := rows.Scan(&sqlTimeStr, &mname, &mvalue)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
close mysql statement and rows resources when sql exec end, reslove mysql statement leak

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #1719 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
