### PR TITLE
Enhance/UI feasible space

### DIFF
--- a/pkg/new-ui/v1beta1/frontend/src/app/services/experiment-form.service.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/services/experiment-form.service.ts
@@ -240,8 +240,13 @@ export class ExperimentFormService {
       return param;
     }
 
-    if ((param.feasibleSpace as FeasibleSpaceMinMax).step === '') {
+    const step = (param.feasibleSpace as FeasibleSpaceMinMax).step;
+    if (step === '' || step === null) {
       delete (param.feasibleSpace as FeasibleSpaceMinMax).step;
+    }
+
+    for (const key in param.feasibleSpace) {
+      param.feasibleSpace[key] = param.feasibleSpace[key].toString();
     }
 
     return param;

--- a/pkg/new-ui/v1beta1/frontend/src/app/shared/params-list/add-modal/add-modal.component.html
+++ b/pkg/new-ui/v1beta1/frontend/src/app/shared/params-list/add-modal/add-modal.component.html
@@ -27,17 +27,17 @@
       <div class="range-wrapper" [formGroup]="formGroup.get('feasibleSpace')">
         <mat-form-field appearance="outline">
           <mat-label>Min</mat-label>
-          <input matInput formControlName="min" />
+          <input matInput formControlName="min" type="number" />
         </mat-form-field>
 
         <mat-form-field appearance="outline">
           <mat-label>Max</mat-label>
-          <input matInput formControlName="max" />
+          <input matInput formControlName="max" type="number" />
         </mat-form-field>
 
         <mat-form-field appearance="outline">
           <mat-label>Step (optional)</mat-label>
-          <input matInput formControlName="step" />
+          <input matInput formControlName="step" type="number" />
         </mat-form-field>
       </div>
     </ng-container>

--- a/pkg/new-ui/v1beta1/frontend/src/app/shared/params-list/add-modal/add-modal.component.scss
+++ b/pkg/new-ui/v1beta1/frontend/src/app/shared/params-list/add-modal/add-modal.component.scss
@@ -21,3 +21,8 @@
     margin: 0 12px;
   }
 }
+
+input[type='number']::-webkit-outer-spin-button,
+input[type='number']::-webkit-inner-spin-button {
+  display: none;
+}

--- a/pkg/new-ui/v1beta1/frontend/src/app/shared/params-list/add-modal/add-modal.component.scss
+++ b/pkg/new-ui/v1beta1/frontend/src/app/shared/params-list/add-modal/add-modal.component.scss
@@ -21,8 +21,3 @@
     margin: 0 12px;
   }
 }
-
-input[type='number']::-webkit-outer-spin-button,
-input[type='number']::-webkit-inner-spin-button {
-  display: none;
-}

--- a/pkg/new-ui/v1beta1/frontend/src/app/shared/utils.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/shared/utils.ts
@@ -1,5 +1,13 @@
 import lowerCase from 'lodash-es/lowerCase';
-import { FormControl, FormGroup, Validators, FormArray } from '@angular/forms';
+import {
+  FormControl,
+  FormGroup,
+  Validators,
+  FormArray,
+  ValidatorFn,
+  AbstractControl,
+  ValidationErrors,
+} from '@angular/forms';
 import {
   ParameterSpec,
   FeasibleSpaceMinMax,
@@ -31,7 +39,7 @@ export function createFeasibleSpaceGroup(
     return new FormGroup({
       min: new FormControl(fs.min, Validators.required),
       max: new FormControl(fs.max, Validators.required),
-      step: new FormControl(fs.step, []),
+      step: new FormControl(fs.step, checkIfZero()),
     });
   }
 
@@ -133,3 +141,12 @@ export const safeMultiplication = (
   multiplicand: number,
   multiplier: number,
 ): number => Math.round(multiplicand * 10000.0 * multiplier) / 10000;
+
+export const checkIfZero = (): ValidatorFn => {
+  return (control: AbstractControl): ValidationErrors | null => {
+    if (control.value === null || control.value === '') return null;
+
+    const isZero = !/[^0.]/g.test(control.value.toString());
+    return isZero ? { mustNotBeZero: { value: control.value } } : null;
+  };
+};


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

<img src='https://user-images.githubusercontent.com/52827441/138638483-f918434a-54f6-497b-85f1-1ddd8d89ebed.png' width='400' />

In parameter modal ui,
- this PR restricts the type of `Min`, `Max` and `Step` inputs as `number`, since `string` type of input must not be passed.
- this PR prevents the `Step` input from being `0` or `0.0000...`, since the step `0` does not make sense in the min-max range.


**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
