### PR TITLE
Fix clusterrole of katib-controller to access image pull secrets

### DIFF
--- a/manifests/v1beta1/components/controller/rbac.yaml
+++ b/manifests/v1beta1/components/controller/rbac.yaml
@@ -16,6 +16,7 @@ rules:
       - pods
       - pods/log
       - pods/status
+      - secrets
     verbs:
       - "*"
   - apiGroups:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

To pull remote image using `imagePullSecrets`, 
`katib-controller` should be able to access the secrets in other namespaces.
- https://github.com/kubeflow/katib/blob/master/pkg/webhook/v1beta1/pod/utils.go#L62-L66

We experienced the below error when we tried to pull images with `imagePullSecrets`. 

```
Error creating: admission webhook "mutator.pod.katib.kubeflow.org" denied the request: Failed to create k8schain: secrets "secret" is forbidden: User "system:serviceaccount:kubeflow:katib-controller" cannot get resource "secrets" in API group "" in the namespace "test"
```

The above error disappeared after adding `secrets` resource to ClusterRole.

Please take a look, thanks
