### PR TITLE
fix: check if parameter references exist in experiment parameters

### DIFF
--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -288,12 +288,13 @@ func (g *DefaultValidator) validateTrialTemplate(instance *experimentsv1beta1.Ex
 		if _, ok := trialParametersRefs[parameter.Reference]; ok {
 			return fmt.Errorf("parameter reference %v can't be duplicated in spec.trialTemplate.trialParameters: %v", parameter.Reference, trialTemplate.TrialParameters)
 		}
-		// Check if parameter references exist in experiment parameters
-		if _, ok := experimentParameterNames[parameter.Reference]; !ok {
-			return fmt.Errorf("parameter reference %v does not exists in spec.Parameters: %v", parameter.Reference, instance.Spec.Parameters)
-		}
 		trialParametersNames[parameter.Name] = true
 		trialParametersRefs[parameter.Reference] = true
+
+		// Check if parameter reference exist in experiment parameters
+		if _, ok := experimentParameterNames[parameter.Reference]; !ok {
+			return fmt.Errorf("parameter reference %v does not exist in spec.parameters: %v", parameter.Reference, instance.Spec.Parameters)
+		}
 
 		// Check if trialParameters contains all substitution for Trial template
 		if !strings.Contains(trialTemplateStr, fmt.Sprintf(consts.TrialTemplateParamReplaceFormat, parameter.Name)) {

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -265,6 +265,11 @@ func (g *DefaultValidator) validateTrialTemplate(instance *experimentsv1beta1.Ex
 		return fmt.Errorf("unable to parse spec.trialTemplate: %v", err)
 	}
 
+	experimentParameterNames := make(map[string]bool)
+	for _, parameter := range instance.Spec.Parameters {
+		experimentParameterNames[parameter.Name] = true
+	}
+
 	trialParametersNames := make(map[string]bool)
 	trialParametersRefs := make(map[string]bool)
 
@@ -282,6 +287,10 @@ func (g *DefaultValidator) validateTrialTemplate(instance *experimentsv1beta1.Ex
 		// Check if parameter references are not duplicated
 		if _, ok := trialParametersRefs[parameter.Reference]; ok {
 			return fmt.Errorf("parameter reference %v can't be duplicated in spec.trialTemplate.trialParameters: %v", parameter.Reference, trialTemplate.TrialParameters)
+		}
+		// Check if parameter references exist in experiment parameters
+		if _, ok := experimentParameterNames[parameter.Reference]; !ok {
+			return fmt.Errorf("parameter reference %v does not exists in spec.Parameters: %v", parameter.Reference, instance.Spec.Parameters)
 		}
 		trialParametersNames[parameter.Name] = true
 		trialParametersRefs[parameter.Reference] = true

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -292,8 +292,10 @@ func (g *DefaultValidator) validateTrialTemplate(instance *experimentsv1beta1.Ex
 		trialParametersRefs[parameter.Reference] = true
 
 		// Check if parameter reference exist in experiment parameters
-		if _, ok := experimentParameterNames[parameter.Reference]; !ok {
-			return fmt.Errorf("parameter reference %v does not exist in spec.parameters: %v", parameter.Reference, instance.Spec.Parameters)
+		if len(experimentParameterNames) > 0 {
+			if _, ok := experimentParameterNames[parameter.Reference]; !ok {
+				return fmt.Errorf("parameter reference %v does not exist in spec.parameters: %v", parameter.Reference, instance.Spec.Parameters)
+			}
 		}
 
 		// Check if trialParameters contains all substitution for Trial template

--- a/pkg/webhook/v1beta1/experiment/validator/validator_test.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator_test.go
@@ -393,6 +393,7 @@ spec:
 	validTemplate3 := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(validJobStr, nil)
 	validTemplate4 := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(validJobStr, nil)
 	validTemplate5 := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(validJobStr, nil)
+	validTemplate6 := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(validJobStr, nil)
 
 	missedParameterTemplate := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(missedParameterJobStr, nil)
 	oddParameterTemplate := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(oddParameterJobStr, nil)
@@ -408,6 +409,7 @@ spec:
 		validTemplate3,
 		validTemplate4,
 		validTemplate5,
+		validTemplate6,
 		missedParameterTemplate,
 		oddParameterTemplate,
 		invalidParameterTemplate,
@@ -535,6 +537,17 @@ spec:
 			}(),
 			Err:             true,
 			testDescription: "Trial template contains Trial parameters which weren't referenced from spec.parameters",
+		},
+		// Trial template contains Trial parameters when spec.parameters is empty
+		{
+			Instance: func() *experimentsv1beta1.Experiment {
+				i := newFakeInstance()
+				i.Spec.Parameters = nil
+				i.Spec.TrialTemplate.TrialParameters[1].Reference = "wrong-ref"
+				return i
+			}(),
+			Err:             false,
+			testDescription: "Trial template contains Trial parameters when spec.parameters is empty",
 		},
 		// Trial Template doesn't contain parameter from trialParameters
 		// missedParameterTemplate case

--- a/pkg/webhook/v1beta1/experiment/validator/validator_test.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator_test.go
@@ -526,7 +526,7 @@ spec:
 			Err:             true,
 			testDescription: "Duplicate reference in Trial parameters",
 		},
-		// Wrong parameter reference in trialParameters
+		// Trial template contains Trial parameters which weren't referenced from spec.parameters
 		{
 			Instance: func() *experimentsv1beta1.Experiment {
 				i := newFakeInstance()
@@ -534,7 +534,7 @@ spec:
 				return i
 			}(),
 			Err:             true,
-			testDescription: "Wrong reference in Trial parameters",
+			testDescription: "Trial template contains Trial parameters which weren't referenced from spec.parameters",
 		},
 		// Trial Template doesn't contain parameter from trialParameters
 		// missedParameterTemplate case

--- a/pkg/webhook/v1beta1/experiment/validator/validator_test.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator_test.go
@@ -392,6 +392,7 @@ spec:
 	validTemplate2 := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(validJobStr, nil)
 	validTemplate3 := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(validJobStr, nil)
 	validTemplate4 := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(validJobStr, nil)
+	validTemplate5 := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(validJobStr, nil)
 
 	missedParameterTemplate := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(missedParameterJobStr, nil)
 	oddParameterTemplate := p.EXPECT().GetTrialTemplate(gomock.Any()).Return(oddParameterJobStr, nil)
@@ -406,6 +407,7 @@ spec:
 		validTemplate2,
 		validTemplate3,
 		validTemplate4,
+		validTemplate5,
 		missedParameterTemplate,
 		oddParameterTemplate,
 		invalidParameterTemplate,
@@ -523,6 +525,16 @@ spec:
 			}(),
 			Err:             true,
 			testDescription: "Duplicate reference in Trial parameters",
+		},
+		// Wrong parameter reference in trialParameters
+		{
+			Instance: func() *experimentsv1beta1.Experiment {
+				i := newFakeInstance()
+				i.Spec.TrialTemplate.TrialParameters[1].Reference = "wrong-ref"
+				return i
+			}(),
+			Err:             true,
+			testDescription: "Wrong reference in Trial parameters",
 		},
 		// Trial Template doesn't contain parameter from trialParameters
 		// missedParameterTemplate case
@@ -1019,6 +1031,7 @@ func newFakeInstance() *experimentsv1beta1.Experiment {
 			},
 			Parameters: []experimentsv1beta1.ParameterSpec{
 				{
+					Name:          "lr",
 					ParameterType: experimentsv1beta1.ParameterTypeInt,
 					FeasibleSpace: experimentsv1beta1.FeasibleSpace{
 						Max: "5",
@@ -1026,6 +1039,7 @@ func newFakeInstance() *experimentsv1beta1.Experiment {
 					},
 				},
 				{
+					Name:          "num-layers",
 					ParameterType: experimentsv1beta1.ParameterTypeCategorical,
 					FeasibleSpace: experimentsv1beta1.FeasibleSpace{
 						List: []string{"1", "2", "3"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Hi, we experienced that the users tend to make mistakes like below when creating experiments using new UI (Thanks for the nice UI update!)

When users set parameter references in trial templates like below,

![image](https://user-images.githubusercontent.com/16417183/139370623-843893fe-e4b5-44df-9d5c-10020d477382.png)

they need to enter the parameter reference as same as the hyperparameter defined in the experiment spec. 
The experiment is created without errors even if the users mistakenly set the wrong parameter reference.

I think it would be better to check the wrong parameter reference in the validating webhook
so that experiments are not created with the wrong parameter reference.

Please take a look, thanks!