### PR TITLE
Allow to remove each resource in Katib config

### DIFF
--- a/pkg/util/v1beta1/katibconfig/config.go
+++ b/pkg/util/v1beta1/katibconfig/config.go
@@ -283,23 +283,30 @@ func setResourceRequirements(configResource corev1.ResourceRequirements) corev1.
 	}
 
 	// If user explicitly sets CPU value to -1, nuke it.
-	if cpuLimit.Sign() == -1 && cpuRequest.Sign() == -1 {
+	if cpuLimit.Sign() == -1 {
 		delete(configResource.Limits, corev1.ResourceCPU)
+	}
+	if cpuRequest.Sign() == -1 {
 		delete(configResource.Requests, corev1.ResourceCPU)
 	}
 
 	// If user explicitly sets Memory value to -1, nuke it.
-	if memLimit.Sign() == -1 && memRequest.Sign() == -1 {
+	if memLimit.Sign() == -1 {
 		delete(configResource.Limits, corev1.ResourceMemory)
+	}
+	if memRequest.Sign() == -1 {
 		delete(configResource.Requests, corev1.ResourceMemory)
 	}
 
 	// If user explicitly sets ephemeral-storage value to something negative, nuke it.
 	// This enables compatibility with the GKE nodepool autoscalers, which cannot scale
 	// pods which define ephemeral-storage resource constraints.
-	if diskLimit.Sign() == -1 && diskRequest.Sign() == -1 {
+	if diskLimit.Sign() == -1 {
 		delete(configResource.Limits, corev1.ResourceEphemeralStorage)
+	}
+	if diskRequest.Sign() == -1 {
 		delete(configResource.Requests, corev1.ResourceEphemeralStorage)
 	}
+
 	return configResource
 }


### PR DESCRIPTION
This PR: https://github.com/kubeflow/katib/pull/1564 allows user to nuke resource for Suggestion and Metrics Collector, but user has to set `limits` and `requests` as `-1` to nuke it.

For some use-cases, users want to remove only `limits` or `requests` for `resources`.
After this PR they can do it.


/assign @gaocegege @johnugeorge @sravi999 @tenzen-y @anencore94