### PR TITLE
Fix Range for Int and Double values in Grid

### DIFF
--- a/pkg/suggestion/v1beta1/chocolate/base_service.py
+++ b/pkg/suggestion/v1beta1/chocolate/base_service.py
@@ -61,12 +61,13 @@ class BaseChocolateService(object):
 
         for param in self.search_space.params:
             key = BaseChocolateService.encode(param.name)
+            # Chocolate quantized_uniform distribution uses half-open interval: [low, high).
             if param.type == INTEGER:
                 chocolate_search_space[key] = choco.quantized_uniform(
-                    int(param.min), int(param.max), int(param.step))
+                    int(param.min), int(param.max) + int(param.step), int(param.step))
             elif param.type == DOUBLE:
                 chocolate_search_space[key] = choco.quantized_uniform(
-                    float(param.min), float(param.max), float(param.step))
+                    float(param.min), float(param.max) + float(param.step), float(param.step))
             # For Categorical and Discrete insert indexes to DB from list of values
             elif param.type == CATEGORICAL or param.type == DISCRETE:
                 chocolate_search_space[key] = choco.choice(

--- a/pkg/suggestion/v1beta1/internal/search_space.py
+++ b/pkg/suggestion/v1beta1/internal/search_space.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import logging
-from pkg.apis.manager.v1beta1.python import api_pb2 as api
 
-from pkg.suggestion.v1beta1.internal.constant import *
+from pkg.apis.manager.v1beta1.python import api_pb2 as api
+import pkg.suggestion.v1beta1.internal.constant as constant
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -31,9 +31,9 @@ class HyperParameterSearchSpace(object):
     def convert(experiment):
         search_space = HyperParameterSearchSpace()
         if experiment.spec.objective.type == api.MAXIMIZE:
-            search_space.goal = MAX_GOAL
+            search_space.goal = constant.MAX_GOAL
         elif experiment.spec.objective.type == api.MINIMIZE:
-            search_space.goal = MIN_GOAL
+            search_space.goal = constant.MIN_GOAL
         for p in experiment.spec.parameter_specs.parameters:
             search_space.params.append(
                 HyperParameterSearchSpace.convertParameter(p))
@@ -72,7 +72,7 @@ class HyperParameter(object):
         self.step = step
 
     def __str__(self):
-        if self.type == INTEGER or self.type == DOUBLE:
+        if self.type == constant.INTEGER or self.type == constant.DOUBLE:
             return "HyperParameter(name: {}, type: {}, min: {}, max: {}, step: {})".format(
                 self.name, self.type, self.min, self.max, self.step)
         else:
@@ -81,16 +81,16 @@ class HyperParameter(object):
 
     @staticmethod
     def int(name, min_, max_, step):
-        return HyperParameter(name, INTEGER, min_, max_, [], step)
+        return HyperParameter(name, constant.INTEGER, min_, max_, [], step)
 
     @staticmethod
     def double(name, min_, max_, step):
-        return HyperParameter(name, DOUBLE, min_, max_, [], step)
+        return HyperParameter(name, constant.DOUBLE, min_, max_, [], step)
 
     @staticmethod
     def categorical(name, lst):
-        return HyperParameter(name, CATEGORICAL, 0, 0, [str(e) for e in lst], 0)
+        return HyperParameter(name, constant.CATEGORICAL, 0, 0, [str(e) for e in lst], 0)
 
     @staticmethod
     def discrete(name, lst):
-        return HyperParameter(name, DISCRETE, 0, 0, [str(e) for e in lst], 0)
+        return HyperParameter(name, constant.DISCRETE, 0, 0, [str(e) for e in lst], 0)


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1636.

In Chocolate Suggestion [`quantized_uniform`](https://chocolate.readthedocs.io/en/latest/api/space.html#chocolate.quantized_uniform) distribution uses half-open interval.

/assign @tenzen-y @gaocegege @johnugeorge 