### PR TITLE
Update links for issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,6 @@
 ---
 name: Bug report
 about: Tell us about a problem you are experiencing
-
 ---
 
 /kind bug
@@ -9,17 +8,19 @@ about: Tell us about a problem you are experiencing
 **What steps did you take and what happened:**
 [A clear and concise description of what the bug is.]
 
-
 **What did you expect to happen:**
-
 
 **Anything else you would like to add:**
 [Miscellaneous information that will assist in solving the issue.]
 
-
 **Environment:**
 
-- Kubeflow version (`kfctl version`):
-- Minikube version (`minikube version`):
-- Kubernetes version: (use `kubectl version`):
-- OS (e.g. from `/etc/os-release`):
+- Katib version (check the Katib controller image version):
+- Kubernetes version: (`kubectl version`):
+- OS (`uname -a`):
+
+---
+
+<!-- Don't delete this message to encourage users to support your issue! -->
+
+Impacted by this bug? Give it a 👍 We prioritize the issues with the most 👍

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Katib Documentation
+    url: https://www.kubeflow.org/docs/components/katib/
+    about: Much help can be found in the docs
+  - name: AutoML Slack Channel
+    url: https://kubeflow.slack.com/archives/C018PMV53NW
+    about: Ask the Katib community on Slack

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,6 @@
 ---
 name: Feature enhancement request
 about: Suggest an idea for this project
-
 ---
 
 /kind feature
@@ -9,6 +8,11 @@ about: Suggest an idea for this project
 **Describe the solution you'd like**
 [A clear and concise description of what you want to happen.]
 
-
 **Anything else you would like to add:**
 [Miscellaneous information that will assist in solving the issue.]
+
+---
+
+<!-- Don't delete this message to encourage users to support your issue! -->
+
+Love this feature? Give it a 👍 We prioritize the features with the most 👍


### PR DESCRIPTION
Users don't need to check Kubeflow version by using `kfctl`.
I think Katib version should be enough for us.

Also, I added links to our docs and Slack channel to the issue config.

/assign @tenzen-y @gaocegege @johnugeorge 