### PR TITLE
Fix the default Metrics Collector regex

### DIFF
--- a/pkg/metricscollector/v1beta1/common/const.go
+++ b/pkg/metricscollector/v1beta1/common/const.go
@@ -39,12 +39,12 @@ const (
 	// DefaultFilter is the default metrics collector filter to parse the metrics.
 	// Metrics must be printed this way
 	// loss=0.3
-	// accuracy=0.98
+	// accuracy=.98
 	// Score=-7.53e-05
 	// Score=-7.53e+05
 	// Score=1E0
 	// Score=1.23E10
-	DefaultFilter = `([\w|-]+)\s*=\s*([+-]?\d(\.\d+)?([Ee][+-]?\d+)?)`
+	DefaultFilter = `([\w|-]+)\s*=\s*([+-]?\d*(\.\d+)?([Ee][+-]?\d+)?)`
 
 	// TODO (andreyvelich): Do we need to maintain 2 names? Should we leave only 1?
 	MetricCollectorContainerName       = "metrics-collector"


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/1754.
I fixed the default regex format.
I will create separate PR to update the website doc.

/assign @kubeflow/wg-automl-leads 
/cc @RDarrylR @anencore94 

