### PR TITLE
Add Kubernetes version to AWS CI

### DIFF
--- a/test/e2e/v1beta1/argo_workflow.py
+++ b/test/e2e/v1beta1/argo_workflow.py
@@ -145,7 +145,7 @@ class WorkflowBuilder(object):
             },
             {
                 "name": "EKS_CLUSTER_VERSION",
-                "value": "1.22"
+                "value": "1.21"
             },
             {
                 "name": "ECR_REGISTRY",

--- a/test/e2e/v1beta1/argo_workflow.py
+++ b/test/e2e/v1beta1/argo_workflow.py
@@ -145,7 +145,7 @@ class WorkflowBuilder(object):
             },
             {
                 "name": "EKS_CLUSTER_VERSION",
-                "value": "1.21"
+                "value": "1.19"
             },
             {
                 "name": "ECR_REGISTRY",

--- a/test/e2e/v1beta1/argo_workflow.py
+++ b/test/e2e/v1beta1/argo_workflow.py
@@ -144,6 +144,10 @@ class WorkflowBuilder(object):
                 "value": self.workflow_name
             },
             {
+                "name": "EKS_CLUSTER_VERSION",
+                "value": "1.22"
+            },
+            {
                 "name": "ECR_REGISTRY",
                 "value": self.ecr_registry
             },


### PR DESCRIPTION
I added Kubernetes version to our AWS CI.
We should be able to use this env: https://github.com/kubeflow/testing/blob/master/images/aws-scripts/create-eks-cluster.sh#L29
