### PR TITLE
katib/operators: removes unrecognized keys from metadata.yaml

### DIFF
--- a/operators/katib-controller/metadata.yaml
+++ b/operators/katib-controller/metadata.yaml
@@ -1,5 +1,4 @@
 name: katib-controller
-display-name: Katib Controller
 summary: A Kubernetes-native project for automated machine learning (AutoML)
 description: |
   Katib supports Hyperparameter Tuning, Early Stopping and Neural Architecture Search
@@ -7,10 +6,6 @@ description: |
   Katib is the project which is agnostic to machine learning (ML) frameworks. It can tune
   hyperparameters of applications written in any language of the users’ choice and natively
   supports many ML frameworks, such as TensorFlow, MXNet, PyTorch, XGBoost, and others.
-tags: [ai, bigdata, katib, kubeflow, machine-learning, hyperparameter]
-maintainers:
-  - Dominik Fleischmann <dominik.fleischmann@canonical.com>
-  - Kenneth Koski <kenneth.koski@canonical.com>
 series: [kubernetes]
 resources:
   oci-image:
@@ -21,4 +16,3 @@ resources:
 provides:
   katib-controller:
     interface: http
-min-juju-version: 2.8.6

--- a/operators/katib-db-manager/metadata.yaml
+++ b/operators/katib-db-manager/metadata.yaml
@@ -1,5 +1,4 @@
 name: katib-db-manager
-display-name: Katib DB Manager
 summary: A Kubernetes-native project for automated machine learning (AutoML)
 description: |
   Katib supports Hyperparameter Tuning, Early Stopping and Neural Architecture Search
@@ -7,10 +6,6 @@ description: |
   Katib is the project which is agnostic to machine learning (ML) frameworks. It can tune
   hyperparameters of applications written in any language of the users’ choice and natively
   supports many ML frameworks, such as TensorFlow, MXNet, PyTorch, XGBoost, and others.
-tags: [ai, bigdata, katib, kubeflow, machine-learning, hyperparameter]
-maintainers:
-  - Dominik Fleischmann <dominik.fleischmann@canonical.com>
-  - Kenneth Koski <kenneth.koski@canonical.com>
 series: [kubernetes]
 resources:
   oci-image:
@@ -24,4 +19,3 @@ requires:
 provides:
   katib-db-manager:
     interface: http
-min-juju-version: 2.8.6

--- a/operators/katib-ui/metadata.yaml
+++ b/operators/katib-ui/metadata.yaml
@@ -1,5 +1,4 @@
 name: katib-ui
-display-name: Katib UI
 summary: A Kubernetes-native project for automated machine learning (AutoML)
 description: |
   Katib supports Hyperparameter Tuning, Early Stopping and Neural Architecture Search
@@ -7,10 +6,6 @@ description: |
   Katib is the project which is agnostic to machine learning (ML) frameworks. It can tune
   hyperparameters of applications written in any language of the users’ choice and natively
   supports many ML frameworks, such as TensorFlow, MXNet, PyTorch, XGBoost, and others.
-tags: [ai, bigdata, katib, kubeflow, machine-learning, hyperparameter]
-maintainers:
-  - Dominik Fleischmann <dominik.fleischmann@canonical.com>
-  - Kenneth Koski <kenneth.koski@canonical.com>
 series: [kubernetes]
 resources:
   oci-image:
@@ -26,4 +21,3 @@ requires:
 provides:
   katib-ui:
     interface: http
-min-juju-version: 2.8.6


### PR DESCRIPTION
Charmed Katib CI is [failing](https://github.com/kubeflow/katib/runs/4447581111?check_suite_focus=true) due to recent changes in `juju bundle` as it no longer recognizes certain keys in `metadata.yaml`. This PR should prevent the following:

```
Error: YAML Error: unknown field `display-name`, expected one of `name`, `summary`, `description`, `maintainers`, `terms`, `subordinate`, `containers`, `resources`, `provides`, `requires`, `peer`, `storage`, `devices`, `extra-bindings`, `series` at line 2 column 1
```