### PR TITLE
Bump `alpine` version to 3.15

### DIFF
--- a/cmd/db-manager/v1beta1/Dockerfile
+++ b/cmd/db-manager/v1beta1/Dockerfile
@@ -33,7 +33,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
     chmod +x /bin/grpc_health_probe
 
 # Copy the db-manager into a thin image.
-FROM alpine:3.7
+FROM alpine:3.15
 WORKDIR /app
 COPY --from=build-env /bin/grpc_health_probe /bin/
 COPY --from=build-env /go/src/github.com/kubeflow/katib/katib-db-manager /app/

--- a/cmd/katib-controller/v1beta1/Dockerfile
+++ b/cmd/katib-controller/v1beta1/Dockerfile
@@ -22,7 +22,7 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
     fi
 
 # Copy the controller-manager into a thin image.
-FROM alpine:3.7
+FROM alpine:3.15
 WORKDIR /app
 COPY --from=build-env /go/src/github.com/kubeflow/katib/katib-controller .
 ENTRYPOINT ["./katib-controller"]

--- a/cmd/metricscollector/v1beta1/file-metricscollector/Dockerfile
+++ b/cmd/metricscollector/v1beta1/file-metricscollector/Dockerfile
@@ -22,7 +22,7 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
     fi
 
 # Copy the file metrics collector into a thin image.
-FROM alpine:3.7
+FROM alpine:3.15
 WORKDIR /app
 COPY --from=build-env /go/src/github.com/kubeflow/katib/file-metricscollector .
 ENTRYPOINT ["./file-metricscollector"]

--- a/cmd/new-ui/v1beta1/Dockerfile
+++ b/cmd/new-ui/v1beta1/Dockerfile
@@ -56,7 +56,7 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
     fi
 
 # --- Compose the web app ---
-FROM alpine:3.7
+FROM alpine:3.15
 WORKDIR /app
 COPY --from=go-build /go/src/github.com/kubeflow/katib/katib-ui /app/
 COPY --from=frontend /src/dist/static /app/build/static/

--- a/cmd/suggestion/goptuna/v1beta1/Dockerfile
+++ b/cmd/suggestion/goptuna/v1beta1/Dockerfile
@@ -34,7 +34,7 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
   chmod +x /bin/grpc_health_probe
 
 # Copy the Goptuna suggestion into a thin image.
-FROM alpine:3.7
+FROM alpine:3.15
 
 ENV TARGET_DIR /opt/katib
 

--- a/cmd/ui/v1beta1/Dockerfile
+++ b/cmd/ui/v1beta1/Dockerfile
@@ -31,7 +31,7 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
     fi
 
 # Copy the backend and frontend into a thin image.
-FROM alpine:3.7
+FROM alpine:3.15
 WORKDIR /app
 COPY --from=go-build /go/src/github.com/kubeflow/katib/katib-ui /app/
 COPY --from=npm-build /frontend/build /app/build


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump `alpine` version to 3.15 since `musl` and `musl-utils` in `alpine:3.7` have a vulnerability with a CVSS score of 9.8.

ref: https://nvd.nist.gov/vuln/detail/cve-2019-14697

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #1775 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
