### PR TITLE
Bump grpc_health_probe version to v0.4.6

### DIFF
--- a/cmd/db-manager/v1beta1/Dockerfile
+++ b/cmd/db-manager/v1beta1/Dockerfile
@@ -1,6 +1,8 @@
 # Build the Katib DB manager.
 FROM golang:alpine AS build-env
 
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.6
+
 WORKDIR /go/src/github.com/kubeflow/katib
 
 # Download packages.
@@ -22,8 +24,7 @@ RUN if [ "$(uname -m)" = "ppc64le" ]; then \
     fi
 
 # Add GRPC health probe.
-RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
-    if [ "$(uname -m)" = "ppc64le" ]; then \
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-ppc64le; \
     elif [ "$(uname -m)" = "aarch64" ]; then \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-arm64; \

--- a/cmd/suggestion/chocolate/v1beta1/Dockerfile
+++ b/cmd/suggestion/chocolate/v1beta1/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9
 
 ENV TARGET_DIR /opt/katib
 ENV SUGGESTION_DIR cmd/suggestion/chocolate/v1beta1
-ENV GRPC_HEALTH_PROBE_VERSION v0.3.1
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.6
 
 RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
     apt-get -y update && \

--- a/cmd/suggestion/goptuna/v1beta1/Dockerfile
+++ b/cmd/suggestion/goptuna/v1beta1/Dockerfile
@@ -1,7 +1,7 @@
 # Build the Goptuna Suggestion.
 FROM golang:alpine AS build-env
 
-ENV GRPC_HEALTH_PROBE_VERSION v0.3.1
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.6
 
 WORKDIR /go/src/github.com/kubeflow/katib
 

--- a/cmd/suggestion/hyperband/v1beta1/Dockerfile
+++ b/cmd/suggestion/hyperband/v1beta1/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9
 
 ENV TARGET_DIR /opt/katib
 ENV SUGGESTION_DIR cmd/suggestion/hyperband/v1beta1
-ENV GRPC_HEALTH_PROBE_VERSION v0.3.1
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.6
 
 RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
     apt-get -y update && \

--- a/cmd/suggestion/hyperopt/v1beta1/Dockerfile
+++ b/cmd/suggestion/hyperopt/v1beta1/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9
 
 ENV TARGET_DIR /opt/katib
 ENV SUGGESTION_DIR cmd/suggestion/hyperopt/v1beta1
-ENV GRPC_HEALTH_PROBE_VERSION v0.3.1
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.6
 
 RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
     apt-get -y update && \

--- a/cmd/suggestion/nas/darts/v1beta1/Dockerfile
+++ b/cmd/suggestion/nas/darts/v1beta1/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9
 
 ENV TARGET_DIR /opt/katib
 ENV SUGGESTION_DIR cmd/suggestion/nas/darts/v1beta1
-ENV GRPC_HEALTH_PROBE_VERSION v0.3.1
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.6
 
 RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
     apt-get -y update && \

--- a/cmd/suggestion/nas/enas/v1beta1/Dockerfile
+++ b/cmd/suggestion/nas/enas/v1beta1/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9
 
 ENV TARGET_DIR /opt/katib
 ENV SUGGESTION_DIR cmd/suggestion/nas/enas/v1beta1
-ENV GRPC_HEALTH_PROBE_VERSION v0.3.1
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.6
 # tensorflow community build for aarch64
 # https://github.com/tensorflow/build#tensorflow-builds
 ENV PIP_EXTRA_INDEX_URL https://snapshots.linaro.org/ldcg/python-cache/

--- a/cmd/suggestion/optuna/v1beta1/Dockerfile
+++ b/cmd/suggestion/optuna/v1beta1/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9
 
 ENV TARGET_DIR /opt/katib
 ENV SUGGESTION_DIR cmd/suggestion/optuna/v1beta1
-ENV GRPC_HEALTH_PROBE_VERSION v0.3.1
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.6
 
 RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
     apt-get -y update && \

--- a/cmd/suggestion/skopt/v1beta1/Dockerfile
+++ b/cmd/suggestion/skopt/v1beta1/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9
 
 ENV TARGET_DIR /opt/katib
 ENV SUGGESTION_DIR cmd/suggestion/skopt/v1beta1
-ENV GRPC_HEALTH_PROBE_VERSION v0.3.1
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.6
 
 RUN if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
     apt-get -y update && \


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump `grpc_health_probe` version to v0.4.6 since `golang.org/x/text` v0.3.2, on which `grpc_health_probe` v0.3.1 depends, has a vulnerability with a CVSS score of 7.5.

```shell
$ trivy image --severity HIGH,CRITICAL,MEDIUM,LOW kubeflowkatib/katib-db-manager:v1beta1-fa1babe
2022-01-16T21:29:40.788+0900    INFO    Detected OS: alpine
2022-01-16T21:29:40.788+0900    INFO    Detecting Alpine vulnerabilities...
2022-01-16T21:29:40.790+0900    INFO    Number of language-specific files: 2
2022-01-16T21:29:40.790+0900    INFO    Detecting gobinary vulnerabilities...

kubeflowkatib/katib-db-manager:v1beta1-fa1babe (alpine 3.15.0)
==============================================================
Total: 0 (LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


app/katib-db-manager (gobinary)
===============================
Total: 0 (LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


bin/grpc_health_probe (gobinary)
================================
Total: 1 (LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)

+-------------------+------------------+----------+-------------------+---------------+---------------------------------------+
|      LIBRARY      | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+-------------------+------------------+----------+-------------------+---------------+---------------------------------------+
| golang.org/x/text | CVE-2020-14040   | HIGH     | v0.3.2            | 0.3.3         | golang.org/x/text: possibility        |
|                   |                  |          |                   |               | to trigger an infinite loop in        |
|                   |                  |          |                   |               | encoding/unicode could lead to...     |
|                   |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2020-14040 |
+-------------------+------------------+----------+-------------------+---------------+---------------------------------------+
```

Ref:
- https://nvd.nist.gov/vuln/detail/CVE-2020-14040
- https://github.com/grpc-ecosystem/grpc-health-probe/releases/tag/v0.3.3

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
