### PR TITLE
Fix a link for GRPC API documentation

### DIFF
--- a/pkg/apis/manager/README.md
+++ b/pkg/apis/manager/README.md
@@ -8,7 +8,7 @@ Katib offers the following APIs:
 
 ## GRPC API documentation
 
-See the [Katib v1beta1 API reference docs](https://www.kubeflow.org/docs/reference/katib/v1beta1/katib/).
+See the [Katib v1beta1 API reference docs](./v1beta1/gen-doc/api.md).
 
 ## Update API and generate documents
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a link for GRPC API documentation since we have removed outdated API Reference from the website in https://github.com/kubeflow/website/pull/3080

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
