### PR TITLE
Add min-juju-version element to operators prevent excess PVC creation

### DIFF
--- a/operators/katib-controller/metadata.yaml
+++ b/operators/katib-controller/metadata.yaml
@@ -6,6 +6,7 @@ description: |
   Katib is the project which is agnostic to machine learning (ML) frameworks. It can tune
   hyperparameters of applications written in any language of the users’ choice and natively
   supports many ML frameworks, such as TensorFlow, MXNet, PyTorch, XGBoost, and others.
+min-juju-version: "2.9.0"
 series: [kubernetes]
 resources:
   oci-image:

--- a/operators/katib-db-manager/metadata.yaml
+++ b/operators/katib-db-manager/metadata.yaml
@@ -6,6 +6,7 @@ description: |
   Katib is the project which is agnostic to machine learning (ML) frameworks. It can tune
   hyperparameters of applications written in any language of the users’ choice and natively
   supports many ML frameworks, such as TensorFlow, MXNet, PyTorch, XGBoost, and others.
+min-juju-version: "2.9.0"
 series: [kubernetes]
 resources:
   oci-image:

--- a/operators/katib-ui/metadata.yaml
+++ b/operators/katib-ui/metadata.yaml
@@ -6,6 +6,7 @@ description: |
   Katib is the project which is agnostic to machine learning (ML) frameworks. It can tune
   hyperparameters of applications written in any language of the users’ choice and natively
   supports many ML frameworks, such as TensorFlow, MXNet, PyTorch, XGBoost, and others.
+min-juju-version: "2.9.0"
 series: [kubernetes]
 resources:
   oci-image:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR addresses https://github.com/canonical/bundle-kubeflow/issues/425 where a PVC is created per operator, adding the `min-juju-version: 2.9.0` element to prevent that PVC creation.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #425
https://github.com/canonical/bundle-kubeflow/issues/425 

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
No user facing changes required
