### PR TITLE
Automated cherry pick of #1808: Fix default label for Training Operators on release-0.13

### DIFF
--- a/docs/proposals/metrics-collector.md
+++ b/docs/proposals/metrics-collector.md
@@ -123,7 +123,7 @@ In the namespace with `katib.kubeflow.org/metrics-collector-injection=enabled` l
 
 In **Pod Level Injecting**,
 
-1. Job operators (_e.x. TFjob/PyTorchjob_) tag the `job-role: master` ([#1064](https://github.com/kubeflow/tf-operator/pull/1064)) label on the master pod.
+1. Job operators (_e.x. TFjob/PyTorchjob_) tag the `training.kubeflow.org/job-role: master` ([#1064](https://github.com/kubeflow/tf-operator/pull/1064)) label on the master pod.
 2. The webhook inject the metric collector only if the webhook recognizes this label.
 3. The webhook uses [ObjectSelector](https://github.com/kubernetes/kubernetes/pull/78505) to skip on irrelevant objects in order to optimize the performance.
 4. ObjectSelector is only supported above _Kubernetes v1.15_. Without this new feature, there may be a [performance issue](https://github.com/kubeflow/katib/issues/685#issuecomment-516226070) in webhook. In this situation, the following **Job Level Injecting** mode may be a better option.

--- a/docs/proposals/trial-custom-crd.md
+++ b/docs/proposals/trial-custom-crd.md
@@ -124,7 +124,7 @@ For example, for TFJob:
 ```yaml
 . . .
 PrimaryPodLabel:
-  "job-role": "master"
+  "training.kubeflow.org/job-role": "master"
 . . .
 ```
 

--- a/examples/v1beta1/kubeflow-training-operator/mxjob-byteps.yaml
+++ b/examples/v1beta1/kubeflow-training-operator/mxjob-byteps.yaml
@@ -23,7 +23,7 @@ spec:
     primaryContainerName: mxnet
     # In this example we can collect metrics only from the Worker pods.
     primaryPodLabels:
-      replica-type: worker
+      training.kubeflow.org/replica-type: worker
     trialParameters:
       - name: learningRate
         description: Learning rate for the training model

--- a/pkg/apis/controller/experiments/v1beta1/constants.go
+++ b/pkg/apis/controller/experiments/v1beta1/constants.go
@@ -38,7 +38,7 @@ const (
 
 var (
 	// DefaultKubeflowJobPrimaryPodLabels is the default value of spec.trialTemplate.primaryPodLabels for Kubeflow Training Job.
-	DefaultKubeflowJobPrimaryPodLabels = map[string]string{"job-role": "master"}
+	DefaultKubeflowJobPrimaryPodLabels = map[string]string{"training.kubeflow.org/job-role": "master"}
 
 	// KubeflowJobKinds is the list of Kubeflow Training Job kinds.
 	KubeflowJobKinds = map[string]bool{
@@ -46,5 +46,6 @@ var (
 		"PyTorchJob": true,
 		"XGBoostJob": true,
 		"MXJob":      true,
+		"MPIJob":     true,
 	}
 )

--- a/pkg/ui/v1beta1/frontend/src/reducers/general.js
+++ b/pkg/ui/v1beta1/frontend/src/reducers/general.js
@@ -50,14 +50,14 @@ const initialState = {
       value: 'status.conditions.#(type=="Complete")#|#(status=="True")#',
       description: `Condition when Trial custom resource is succeeded.
       Default value for k8s BatchJob: status.conditions.#(type=="Complete")#|#(status=="True")#.
-      Default value for Kubeflow Job (TFJob, PyTorchJob, XGBoostJob, MXJob): status.conditions.#(type=="Succeeded")#|#(status=="True")#.`,
+      Default value for Kubeflow Job (TFJob, PyTorchJob, XGBoostJob, MXJob, MPIJob): status.conditions.#(type=="Succeeded")#|#(status=="True")#.`,
     },
     {
       name: 'FailureCondition',
       value: 'status.conditions.#(type=="Failed")#|#(status=="True")#',
       description: `Condition when Trial custom resource is failed.
       Default value for k8s BatchJob: status.conditions.#(type=="Failed")#|#(status=="True")#.
-      Default value for Kubeflow Job (TFJob, PyTorchJob, XGBoostJob, MXJob): status.conditions.#(type=="Failed")#|#(status=="True")#.`,
+      Default value for Kubeflow Job (TFJob, PyTorchJob, XGBoostJob, MXJob, MPIJob): status.conditions.#(type=="Failed")#|#(status=="True")#.`,
     },
     {
       name: 'Retain',

--- a/test/e2e/v1beta1/argo_workflow.py
+++ b/test/e2e/v1beta1/argo_workflow.py
@@ -163,7 +163,7 @@ class WorkflowBuilder(object):
             },
             {
                 "name": "EXTRA_REPOS",
-                "value": "kubeflow/testing@HEAD;kubeflow/manifests@v1.4-branch"
+                "value": "kubeflow/testing@HEAD;kubeflow/manifests@v1.5-branch"
             },
             # Set GOPATH to test_dir because Katib repo is located under /src/github.com/kubeflow/katib
             {

--- a/test/e2e/v1beta1/scripts/setup-katib.sh
+++ b/test/e2e/v1beta1/scripts/setup-katib.sh
@@ -42,7 +42,7 @@ echo "Creating Kubeflow namespace"
 kubectl create namespace kubeflow
 
 cd "${MANIFESTS_DIR}/apps/training-operator/upstream/overlays/kubeflow"
-echo "Deploying Training Operator from kubeflow/manifests $(git branch --show-current)"
+echo "Deploying Training Operator from kubeflow/manifests $(git rev-parse --abbrev-ref HEAD)"
 kustomize build . | kubectl apply -f -
 
 echo "Deploying Katib"

--- a/test/e2e/v1beta1/scripts/setup-katib.sh
+++ b/test/e2e/v1beta1/scripts/setup-katib.sh
@@ -41,8 +41,8 @@ cat "manifests/v1beta1/components/controller/katib-config.yaml"
 echo "Creating Kubeflow namespace"
 kubectl create namespace kubeflow
 
-echo "Deploying training-operator from kubeflow/manifests v1.4 branch"
 cd "${MANIFESTS_DIR}/apps/training-operator/upstream/overlays/kubeflow"
+echo "Deploying Training Operator from kubeflow/manifests $(git branch --show-current)"
 kustomize build . | kubectl apply -f -
 
 echo "Deploying Katib"


### PR DESCRIPTION
This is cherry pick for https://github.com/kubeflow/katib/pull/1808 on `release-0.13` branch.
/cc @johnugeorge @tenzen-y 