### PR TITLE
Add more reviewers to Katib OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,5 +4,7 @@ approvers:
   - hougangliu
   - johnugeorge
 reviewers:
+  - anencore94
   - c-bata
   - sperlingxx
+  - tenzen-y


### PR DESCRIPTION
I propose to add @anencore94 and @tenzen-y to Katib reviewers since they are very active with PRs and issues resolving.
That will automatically assign more reviewers to created PRs.

Thank you so much for your help with Katib project!

/assign @kubeflow/wg-automl-leads 