### PR TITLE
Fix the Dockerfile for API documentation generation

### DIFF
--- a/pkg/apis/manager/v1beta1/gen-doc/Dockerfile
+++ b/pkg/apis/manager/v1beta1/gen-doc/Dockerfile
@@ -1,17 +1,15 @@
 FROM pseudomuto/protoc-gen-doc
-RUN apt-get -q -y update && apt-get -q -y install curl && \
-        mkdir -p /protobuf/google/protobuf && \
-        for f in any duration descriptor empty struct timestamp wrappers; do \
-        curl -L -o /protobuf/google/protobuf/${f}.proto https://raw.githubusercontent.com/google/protobuf/master/src/google/protobuf/${f}.proto; \
-        done && \
-        mkdir -p /protobuf/google/api && \
-        for f in annotations http; do \
-        curl -L -o /protobuf/google/api/${f}.proto https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/master/third_party/googleapis/google/api/${f}.proto; \
-        done && \
-        mkdir -p /protobuf/github.com/gogo/protobuf/gogoproto && \
-        curl -L -o /protobuf/github.com/gogo/protobuf/gogoproto/gogo.proto https://raw.githubusercontent.com/gogo/protobuf/master/gogoproto/gogo.proto && \
-        mkdir -p /protobuf/github.com/mwitkow/go-proto-validators && \
-        curl -L -o /protobuf/github.com/mwitkow/go-proto-validators/validator.proto https://raw.githubusercontent.com/mwitkow/go-proto-validators/master/validator.proto && \
-        apt-get remove --purge -y curl && \
-        apt-get -y autoremove && \
-        rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache curl && \
+    mkdir -p /protobuf/google/protobuf && \
+    for f in any duration descriptor empty struct timestamp wrappers; do \
+      curl -L -o /protobuf/google/protobuf/${f}.proto https://raw.githubusercontent.com/google/protobuf/master/src/google/protobuf/${f}.proto; \
+    done && \
+    mkdir -p /protobuf/google/api && \
+    for f in annotations http; do \
+      curl -L -o /protobuf/google/api/${f}.proto https://raw.githubusercontent.com/grpc-ecosystem/grpc-gateway/master/third_party/googleapis/google/api/${f}.proto; \
+    done && \
+    mkdir -p /protobuf/github.com/gogo/protobuf/gogoproto && \
+    curl -L -o /protobuf/github.com/gogo/protobuf/gogoproto/gogo.proto https://raw.githubusercontent.com/gogo/protobuf/master/gogoproto/gogo.proto && \
+    mkdir -p /protobuf/github.com/mwitkow/go-proto-validators && \
+    curl -L -o /protobuf/github.com/mwitkow/go-proto-validators/validator.proto https://raw.githubusercontent.com/mwitkow/go-proto-validators/master/validator.proto && \
+    apk del --purge curl

--- a/pkg/apis/manager/v1beta1/gen-doc/api.md
+++ b/pkg/apis/manager/v1beta1/gen-doc/api.md
@@ -3,71 +3,71 @@
 
 ## Table of Contents
 
-- [api.proto](#api.proto)
-    - [AlgorithmSetting](#api.v1.beta1.AlgorithmSetting)
-    - [AlgorithmSpec](#api.v1.beta1.AlgorithmSpec)
-    - [DeleteObservationLogReply](#api.v1.beta1.DeleteObservationLogReply)
-    - [DeleteObservationLogRequest](#api.v1.beta1.DeleteObservationLogRequest)
-    - [EarlyStoppingRule](#api.v1.beta1.EarlyStoppingRule)
-    - [EarlyStoppingSetting](#api.v1.beta1.EarlyStoppingSetting)
-    - [EarlyStoppingSpec](#api.v1.beta1.EarlyStoppingSpec)
-    - [Experiment](#api.v1.beta1.Experiment)
-    - [ExperimentSpec](#api.v1.beta1.ExperimentSpec)
-    - [ExperimentSpec.ParameterSpecs](#api.v1.beta1.ExperimentSpec.ParameterSpecs)
-    - [FeasibleSpace](#api.v1.beta1.FeasibleSpace)
-    - [GetEarlyStoppingRulesReply](#api.v1.beta1.GetEarlyStoppingRulesReply)
-    - [GetEarlyStoppingRulesRequest](#api.v1.beta1.GetEarlyStoppingRulesRequest)
-    - [GetObservationLogReply](#api.v1.beta1.GetObservationLogReply)
-    - [GetObservationLogRequest](#api.v1.beta1.GetObservationLogRequest)
-    - [GetSuggestionsReply](#api.v1.beta1.GetSuggestionsReply)
-    - [GetSuggestionsReply.ParameterAssignments](#api.v1.beta1.GetSuggestionsReply.ParameterAssignments)
-    - [GetSuggestionsRequest](#api.v1.beta1.GetSuggestionsRequest)
-    - [GraphConfig](#api.v1.beta1.GraphConfig)
-    - [Metric](#api.v1.beta1.Metric)
-    - [MetricLog](#api.v1.beta1.MetricLog)
-    - [NasConfig](#api.v1.beta1.NasConfig)
-    - [NasConfig.Operations](#api.v1.beta1.NasConfig.Operations)
-    - [ObjectiveSpec](#api.v1.beta1.ObjectiveSpec)
-    - [Observation](#api.v1.beta1.Observation)
-    - [ObservationLog](#api.v1.beta1.ObservationLog)
-    - [Operation](#api.v1.beta1.Operation)
-    - [Operation.ParameterSpecs](#api.v1.beta1.Operation.ParameterSpecs)
-    - [ParameterAssignment](#api.v1.beta1.ParameterAssignment)
-    - [ParameterSpec](#api.v1.beta1.ParameterSpec)
-    - [ReportObservationLogReply](#api.v1.beta1.ReportObservationLogReply)
-    - [ReportObservationLogRequest](#api.v1.beta1.ReportObservationLogRequest)
-    - [SetTrialStatusReply](#api.v1.beta1.SetTrialStatusReply)
-    - [SetTrialStatusRequest](#api.v1.beta1.SetTrialStatusRequest)
-    - [Trial](#api.v1.beta1.Trial)
-    - [TrialSpec](#api.v1.beta1.TrialSpec)
-    - [TrialSpec.ParameterAssignments](#api.v1.beta1.TrialSpec.ParameterAssignments)
-    - [TrialStatus](#api.v1.beta1.TrialStatus)
-    - [ValidateAlgorithmSettingsReply](#api.v1.beta1.ValidateAlgorithmSettingsReply)
-    - [ValidateAlgorithmSettingsRequest](#api.v1.beta1.ValidateAlgorithmSettingsRequest)
-    - [ValidateEarlyStoppingSettingsReply](#api.v1.beta1.ValidateEarlyStoppingSettingsReply)
-    - [ValidateEarlyStoppingSettingsRequest](#api.v1.beta1.ValidateEarlyStoppingSettingsRequest)
+- [api.proto](#api-proto)
+    - [AlgorithmSetting](#api-v1-beta1-AlgorithmSetting)
+    - [AlgorithmSpec](#api-v1-beta1-AlgorithmSpec)
+    - [DeleteObservationLogReply](#api-v1-beta1-DeleteObservationLogReply)
+    - [DeleteObservationLogRequest](#api-v1-beta1-DeleteObservationLogRequest)
+    - [EarlyStoppingRule](#api-v1-beta1-EarlyStoppingRule)
+    - [EarlyStoppingSetting](#api-v1-beta1-EarlyStoppingSetting)
+    - [EarlyStoppingSpec](#api-v1-beta1-EarlyStoppingSpec)
+    - [Experiment](#api-v1-beta1-Experiment)
+    - [ExperimentSpec](#api-v1-beta1-ExperimentSpec)
+    - [ExperimentSpec.ParameterSpecs](#api-v1-beta1-ExperimentSpec-ParameterSpecs)
+    - [FeasibleSpace](#api-v1-beta1-FeasibleSpace)
+    - [GetEarlyStoppingRulesReply](#api-v1-beta1-GetEarlyStoppingRulesReply)
+    - [GetEarlyStoppingRulesRequest](#api-v1-beta1-GetEarlyStoppingRulesRequest)
+    - [GetObservationLogReply](#api-v1-beta1-GetObservationLogReply)
+    - [GetObservationLogRequest](#api-v1-beta1-GetObservationLogRequest)
+    - [GetSuggestionsReply](#api-v1-beta1-GetSuggestionsReply)
+    - [GetSuggestionsReply.ParameterAssignments](#api-v1-beta1-GetSuggestionsReply-ParameterAssignments)
+    - [GetSuggestionsRequest](#api-v1-beta1-GetSuggestionsRequest)
+    - [GraphConfig](#api-v1-beta1-GraphConfig)
+    - [Metric](#api-v1-beta1-Metric)
+    - [MetricLog](#api-v1-beta1-MetricLog)
+    - [NasConfig](#api-v1-beta1-NasConfig)
+    - [NasConfig.Operations](#api-v1-beta1-NasConfig-Operations)
+    - [ObjectiveSpec](#api-v1-beta1-ObjectiveSpec)
+    - [Observation](#api-v1-beta1-Observation)
+    - [ObservationLog](#api-v1-beta1-ObservationLog)
+    - [Operation](#api-v1-beta1-Operation)
+    - [Operation.ParameterSpecs](#api-v1-beta1-Operation-ParameterSpecs)
+    - [ParameterAssignment](#api-v1-beta1-ParameterAssignment)
+    - [ParameterSpec](#api-v1-beta1-ParameterSpec)
+    - [ReportObservationLogReply](#api-v1-beta1-ReportObservationLogReply)
+    - [ReportObservationLogRequest](#api-v1-beta1-ReportObservationLogRequest)
+    - [SetTrialStatusReply](#api-v1-beta1-SetTrialStatusReply)
+    - [SetTrialStatusRequest](#api-v1-beta1-SetTrialStatusRequest)
+    - [Trial](#api-v1-beta1-Trial)
+    - [TrialSpec](#api-v1-beta1-TrialSpec)
+    - [TrialSpec.ParameterAssignments](#api-v1-beta1-TrialSpec-ParameterAssignments)
+    - [TrialStatus](#api-v1-beta1-TrialStatus)
+    - [ValidateAlgorithmSettingsReply](#api-v1-beta1-ValidateAlgorithmSettingsReply)
+    - [ValidateAlgorithmSettingsRequest](#api-v1-beta1-ValidateAlgorithmSettingsRequest)
+    - [ValidateEarlyStoppingSettingsReply](#api-v1-beta1-ValidateEarlyStoppingSettingsReply)
+    - [ValidateEarlyStoppingSettingsRequest](#api-v1-beta1-ValidateEarlyStoppingSettingsRequest)
   
-    - [ComparisonType](#api.v1.beta1.ComparisonType)
-    - [ObjectiveType](#api.v1.beta1.ObjectiveType)
-    - [ParameterType](#api.v1.beta1.ParameterType)
-    - [TrialStatus.TrialConditionType](#api.v1.beta1.TrialStatus.TrialConditionType)
+    - [ComparisonType](#api-v1-beta1-ComparisonType)
+    - [ObjectiveType](#api-v1-beta1-ObjectiveType)
+    - [ParameterType](#api-v1-beta1-ParameterType)
+    - [TrialStatus.TrialConditionType](#api-v1-beta1-TrialStatus-TrialConditionType)
   
-    - [DBManager](#api.v1.beta1.DBManager)
-    - [EarlyStopping](#api.v1.beta1.EarlyStopping)
-    - [Suggestion](#api.v1.beta1.Suggestion)
+    - [DBManager](#api-v1-beta1-DBManager)
+    - [EarlyStopping](#api-v1-beta1-EarlyStopping)
+    - [Suggestion](#api-v1-beta1-Suggestion)
   
 - [Scalar Value Types](#scalar-value-types)
 
 
 
-<a name="api.proto"></a>
+<a name="api-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## api.proto
 Katib GRPC API v1beta1
 
 
-<a name="api.v1.beta1.AlgorithmSetting"></a>
+<a name="api-v1-beta1-AlgorithmSetting"></a>
 
 ### AlgorithmSetting
 HP or NAS algorithm settings.
@@ -83,7 +83,7 @@ HP or NAS algorithm settings.
 
 
 
-<a name="api.v1.beta1.AlgorithmSpec"></a>
+<a name="api-v1-beta1-AlgorithmSpec"></a>
 
 ### AlgorithmSpec
 HP or NAS algorithm specification.
@@ -92,14 +92,14 @@ HP or NAS algorithm specification.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | algorithm_name | [string](#string) |  |  |
-| algorithm_settings | [AlgorithmSetting](#api.v1.beta1.AlgorithmSetting) | repeated |  |
+| algorithm_settings | [AlgorithmSetting](#api-v1-beta1-AlgorithmSetting) | repeated |  |
 
 
 
 
 
 
-<a name="api.v1.beta1.DeleteObservationLogReply"></a>
+<a name="api-v1-beta1-DeleteObservationLogReply"></a>
 
 ### DeleteObservationLogReply
 
@@ -109,7 +109,7 @@ HP or NAS algorithm specification.
 
 
 
-<a name="api.v1.beta1.DeleteObservationLogRequest"></a>
+<a name="api-v1-beta1-DeleteObservationLogRequest"></a>
 
 ### DeleteObservationLogRequest
 
@@ -124,7 +124,7 @@ HP or NAS algorithm specification.
 
 
 
-<a name="api.v1.beta1.EarlyStoppingRule"></a>
+<a name="api-v1-beta1-EarlyStoppingRule"></a>
 
 ### EarlyStoppingRule
 EarlyStoppingRule represents single early stopping rule.
@@ -134,7 +134,7 @@ EarlyStoppingRule represents single early stopping rule.
 | ----- | ---- | ----- | ----------- |
 | name | [string](#string) |  | Name of the rule. Usually, metric name. |
 | value | [string](#string) |  | Value of the metric. |
-| comparison | [ComparisonType](#api.v1.beta1.ComparisonType) |  | Correlation between name and value, one of equal, less or greater |
+| comparison | [ComparisonType](#api-v1-beta1-ComparisonType) |  | Correlation between name and value, one of equal, less or greater |
 | start_step | [int32](#int32) |  | Defines quantity of intermediate results that should be received before applying the rule. If start step is empty, rule is applied from the first recorded metric. |
 
 
@@ -142,7 +142,7 @@ EarlyStoppingRule represents single early stopping rule.
 
 
 
-<a name="api.v1.beta1.EarlyStoppingSetting"></a>
+<a name="api-v1-beta1-EarlyStoppingSetting"></a>
 
 ### EarlyStoppingSetting
 Early stopping algorithm settings.
@@ -158,7 +158,7 @@ Early stopping algorithm settings.
 
 
 
-<a name="api.v1.beta1.EarlyStoppingSpec"></a>
+<a name="api-v1-beta1-EarlyStoppingSpec"></a>
 
 ### EarlyStoppingSpec
 Early stopping algorithm specification.
@@ -167,14 +167,14 @@ Early stopping algorithm specification.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | algorithm_name | [string](#string) |  |  |
-| algorithm_settings | [EarlyStoppingSetting](#api.v1.beta1.EarlyStoppingSetting) | repeated |  |
+| algorithm_settings | [EarlyStoppingSetting](#api-v1-beta1-EarlyStoppingSetting) | repeated |  |
 
 
 
 
 
 
-<a name="api.v1.beta1.Experiment"></a>
+<a name="api-v1-beta1-Experiment"></a>
 
 ### Experiment
 Structure for a single Experiment.
@@ -183,14 +183,14 @@ Structure for a single Experiment.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | name | [string](#string) |  | Name for the Experiment. |
-| spec | [ExperimentSpec](#api.v1.beta1.ExperimentSpec) |  | Experiment specification. |
+| spec | [ExperimentSpec](#api-v1-beta1-ExperimentSpec) |  | Experiment specification. |
 
 
 
 
 
 
-<a name="api.v1.beta1.ExperimentSpec"></a>
+<a name="api-v1-beta1-ExperimentSpec"></a>
 
 ### ExperimentSpec
 Specification of an Experiment. Experiment represents a single optimization run over a feasible space. 
@@ -200,20 +200,20 @@ It is assumed that objective function f(x) does not change in the course of an E
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| parameter_specs | [ExperimentSpec.ParameterSpecs](#api.v1.beta1.ExperimentSpec.ParameterSpecs) |  |  |
-| objective | [ObjectiveSpec](#api.v1.beta1.ObjectiveSpec) |  | Objective specification for the Experiment. |
-| algorithm | [AlgorithmSpec](#api.v1.beta1.AlgorithmSpec) |  | HP or NAS algorithm specification for the Experiment. |
-| early_stopping | [EarlyStoppingSpec](#api.v1.beta1.EarlyStoppingSpec) |  | Early stopping specification for the Experiment. |
+| parameter_specs | [ExperimentSpec.ParameterSpecs](#api-v1-beta1-ExperimentSpec-ParameterSpecs) |  |  |
+| objective | [ObjectiveSpec](#api-v1-beta1-ObjectiveSpec) |  | Objective specification for the Experiment. |
+| algorithm | [AlgorithmSpec](#api-v1-beta1-AlgorithmSpec) |  | HP or NAS algorithm specification for the Experiment. |
+| early_stopping | [EarlyStoppingSpec](#api-v1-beta1-EarlyStoppingSpec) |  | Early stopping specification for the Experiment. |
 | parallel_trial_count | [int32](#int32) |  | How many Trials can be processed in parallel. |
 | max_trial_count | [int32](#int32) |  | Max completed Trials to mark Experiment as succeeded. |
-| nas_config | [NasConfig](#api.v1.beta1.NasConfig) |  | NAS configuration for the Experiment. |
+| nas_config | [NasConfig](#api-v1-beta1-NasConfig) |  | NAS configuration for the Experiment. |
 
 
 
 
 
 
-<a name="api.v1.beta1.ExperimentSpec.ParameterSpecs"></a>
+<a name="api-v1-beta1-ExperimentSpec-ParameterSpecs"></a>
 
 ### ExperimentSpec.ParameterSpecs
 List of ParameterSpec.
@@ -221,14 +221,14 @@ List of ParameterSpec.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| parameters | [ParameterSpec](#api.v1.beta1.ParameterSpec) | repeated |  |
+| parameters | [ParameterSpec](#api-v1-beta1-ParameterSpec) | repeated |  |
 
 
 
 
 
 
-<a name="api.v1.beta1.FeasibleSpace"></a>
+<a name="api-v1-beta1-FeasibleSpace"></a>
 
 ### FeasibleSpace
 Feasible space for optimization.
@@ -248,7 +248,7 @@ Discrete and Categorical type use List.
 
 
 
-<a name="api.v1.beta1.GetEarlyStoppingRulesReply"></a>
+<a name="api-v1-beta1-GetEarlyStoppingRulesReply"></a>
 
 ### GetEarlyStoppingRulesReply
 
@@ -256,14 +256,14 @@ Discrete and Categorical type use List.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| early_stopping_rules | [EarlyStoppingRule](#api.v1.beta1.EarlyStoppingRule) | repeated |  |
+| early_stopping_rules | [EarlyStoppingRule](#api-v1-beta1-EarlyStoppingRule) | repeated |  |
 
 
 
 
 
 
-<a name="api.v1.beta1.GetEarlyStoppingRulesRequest"></a>
+<a name="api-v1-beta1-GetEarlyStoppingRulesRequest"></a>
 
 ### GetEarlyStoppingRulesRequest
 
@@ -271,8 +271,8 @@ Discrete and Categorical type use List.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| experiment | [Experiment](#api.v1.beta1.Experiment) |  |  |
-| trials | [Trial](#api.v1.beta1.Trial) | repeated |  |
+| experiment | [Experiment](#api-v1-beta1-Experiment) |  |  |
+| trials | [Trial](#api-v1-beta1-Trial) | repeated |  |
 | db_manager_address | [string](#string) |  |  |
 
 
@@ -280,7 +280,7 @@ Discrete and Categorical type use List.
 
 
 
-<a name="api.v1.beta1.GetObservationLogReply"></a>
+<a name="api-v1-beta1-GetObservationLogReply"></a>
 
 ### GetObservationLogReply
 
@@ -288,14 +288,14 @@ Discrete and Categorical type use List.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| observation_log | [ObservationLog](#api.v1.beta1.ObservationLog) |  |  |
+| observation_log | [ObservationLog](#api-v1-beta1-ObservationLog) |  |  |
 
 
 
 
 
 
-<a name="api.v1.beta1.GetObservationLogRequest"></a>
+<a name="api-v1-beta1-GetObservationLogRequest"></a>
 
 ### GetObservationLogRequest
 
@@ -313,7 +313,7 @@ Discrete and Categorical type use List.
 
 
 
-<a name="api.v1.beta1.GetSuggestionsReply"></a>
+<a name="api-v1-beta1-GetSuggestionsReply"></a>
 
 ### GetSuggestionsReply
 
@@ -321,16 +321,16 @@ Discrete and Categorical type use List.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| parameter_assignments | [GetSuggestionsReply.ParameterAssignments](#api.v1.beta1.GetSuggestionsReply.ParameterAssignments) | repeated |  |
-| algorithm | [AlgorithmSpec](#api.v1.beta1.AlgorithmSpec) |  |  |
-| early_stopping_rules | [EarlyStoppingRule](#api.v1.beta1.EarlyStoppingRule) | repeated |  |
+| parameter_assignments | [GetSuggestionsReply.ParameterAssignments](#api-v1-beta1-GetSuggestionsReply-ParameterAssignments) | repeated |  |
+| algorithm | [AlgorithmSpec](#api-v1-beta1-AlgorithmSpec) |  |  |
+| early_stopping_rules | [EarlyStoppingRule](#api-v1-beta1-EarlyStoppingRule) | repeated |  |
 
 
 
 
 
 
-<a name="api.v1.beta1.GetSuggestionsReply.ParameterAssignments"></a>
+<a name="api-v1-beta1-GetSuggestionsReply-ParameterAssignments"></a>
 
 ### GetSuggestionsReply.ParameterAssignments
 
@@ -338,14 +338,14 @@ Discrete and Categorical type use List.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| assignments | [ParameterAssignment](#api.v1.beta1.ParameterAssignment) | repeated |  |
+| assignments | [ParameterAssignment](#api-v1-beta1-ParameterAssignment) | repeated |  |
 
 
 
 
 
 
-<a name="api.v1.beta1.GetSuggestionsRequest"></a>
+<a name="api-v1-beta1-GetSuggestionsRequest"></a>
 
 ### GetSuggestionsRequest
 
@@ -353,8 +353,8 @@ Discrete and Categorical type use List.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| experiment | [Experiment](#api.v1.beta1.Experiment) |  |  |
-| trials | [Trial](#api.v1.beta1.Trial) | repeated | All completed trials owned by the experiment. |
+| experiment | [Experiment](#api-v1-beta1-Experiment) |  |  |
+| trials | [Trial](#api-v1-beta1-Trial) | repeated | All completed trials owned by the experiment. |
 | request_number | [int32](#int32) |  | **Deprecated.** Use current_request_number instead. This API will be removed in Katib 0.14. The number of Suggestions requested at one time. |
 | current_request_number | [int32](#int32) |  | The number of Suggestions requested at one time. When you set 3 to current_request_number, you get three Suggestions at one time. |
 | total_request_number | [int32](#int32) |  | The number of Suggestions requested till now. |
@@ -364,7 +364,7 @@ Discrete and Categorical type use List.
 
 
 
-<a name="api.v1.beta1.GraphConfig"></a>
+<a name="api-v1-beta1-GraphConfig"></a>
 
 ### GraphConfig
 GraphConfig contains a config of DAG
@@ -381,7 +381,7 @@ GraphConfig contains a config of DAG
 
 
 
-<a name="api.v1.beta1.Metric"></a>
+<a name="api-v1-beta1-Metric"></a>
 
 ### Metric
 
@@ -397,7 +397,7 @@ GraphConfig contains a config of DAG
 
 
 
-<a name="api.v1.beta1.MetricLog"></a>
+<a name="api-v1-beta1-MetricLog"></a>
 
 ### MetricLog
 
@@ -406,14 +406,14 @@ GraphConfig contains a config of DAG
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | time_stamp | [string](#string) |  | RFC3339 format |
-| metric | [Metric](#api.v1.beta1.Metric) |  |  |
+| metric | [Metric](#api-v1-beta1-Metric) |  |  |
 
 
 
 
 
 
-<a name="api.v1.beta1.NasConfig"></a>
+<a name="api-v1-beta1-NasConfig"></a>
 
 ### NasConfig
 NasConfig contains a config of NAS job
@@ -421,15 +421,15 @@ NasConfig contains a config of NAS job
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| graph_config | [GraphConfig](#api.v1.beta1.GraphConfig) |  | Config of DAG |
-| operations | [NasConfig.Operations](#api.v1.beta1.NasConfig.Operations) |  | List of Operation |
+| graph_config | [GraphConfig](#api-v1-beta1-GraphConfig) |  | Config of DAG |
+| operations | [NasConfig.Operations](#api-v1-beta1-NasConfig-Operations) |  | List of Operation |
 
 
 
 
 
 
-<a name="api.v1.beta1.NasConfig.Operations"></a>
+<a name="api-v1-beta1-NasConfig-Operations"></a>
 
 ### NasConfig.Operations
 
@@ -437,14 +437,14 @@ NasConfig contains a config of NAS job
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| operation | [Operation](#api.v1.beta1.Operation) | repeated |  |
+| operation | [Operation](#api-v1-beta1-Operation) | repeated |  |
 
 
 
 
 
 
-<a name="api.v1.beta1.ObjectiveSpec"></a>
+<a name="api-v1-beta1-ObjectiveSpec"></a>
 
 ### ObjectiveSpec
 Objective specification.
@@ -452,7 +452,7 @@ Objective specification.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| type | [ObjectiveType](#api.v1.beta1.ObjectiveType) |  | Type of optimization. |
+| type | [ObjectiveType](#api-v1-beta1-ObjectiveType) |  | Type of optimization. |
 | goal | [double](#double) |  | Goal of optimization, can be empty. |
 | objective_metric_name | [string](#string) |  | Primary metric name for the optimization. |
 | additional_metric_names | [string](#string) | repeated | List of additional metrics to record from Trial. This can be empty if we only care about the objective metric. |
@@ -462,7 +462,7 @@ Objective specification.
 
 
 
-<a name="api.v1.beta1.Observation"></a>
+<a name="api-v1-beta1-Observation"></a>
 
 ### Observation
 
@@ -470,14 +470,14 @@ Objective specification.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| metrics | [Metric](#api.v1.beta1.Metric) | repeated |  |
+| metrics | [Metric](#api-v1-beta1-Metric) | repeated |  |
 
 
 
 
 
 
-<a name="api.v1.beta1.ObservationLog"></a>
+<a name="api-v1-beta1-ObservationLog"></a>
 
 ### ObservationLog
 
@@ -485,14 +485,14 @@ Objective specification.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| metric_logs | [MetricLog](#api.v1.beta1.MetricLog) | repeated |  |
+| metric_logs | [MetricLog](#api-v1-beta1-MetricLog) | repeated |  |
 
 
 
 
 
 
-<a name="api.v1.beta1.Operation"></a>
+<a name="api-v1-beta1-Operation"></a>
 
 ### Operation
 Config for operations in DAG
@@ -501,14 +501,14 @@ Config for operations in DAG
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | operation_type | [string](#string) |  | Type of operation in DAG |
-| parameter_specs | [Operation.ParameterSpecs](#api.v1.beta1.Operation.ParameterSpecs) |  |  |
+| parameter_specs | [Operation.ParameterSpecs](#api-v1-beta1-Operation-ParameterSpecs) |  |  |
 
 
 
 
 
 
-<a name="api.v1.beta1.Operation.ParameterSpecs"></a>
+<a name="api-v1-beta1-Operation-ParameterSpecs"></a>
 
 ### Operation.ParameterSpecs
 List of ParameterSpec
@@ -516,14 +516,14 @@ List of ParameterSpec
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| parameters | [ParameterSpec](#api.v1.beta1.ParameterSpec) | repeated |  |
+| parameters | [ParameterSpec](#api-v1-beta1-ParameterSpec) | repeated |  |
 
 
 
 
 
 
-<a name="api.v1.beta1.ParameterAssignment"></a>
+<a name="api-v1-beta1-ParameterAssignment"></a>
 
 ### ParameterAssignment
 
@@ -539,7 +539,7 @@ List of ParameterSpec
 
 
 
-<a name="api.v1.beta1.ParameterSpec"></a>
+<a name="api-v1-beta1-ParameterSpec"></a>
 
 ### ParameterSpec
 Config for a hyperparameter.
@@ -549,15 +549,15 @@ Katib will create each Hyper parameter from this config.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | name | [string](#string) |  | Name of the parameter. |
-| parameter_type | [ParameterType](#api.v1.beta1.ParameterType) |  | Type of the parameter. |
-| feasible_space | [FeasibleSpace](#api.v1.beta1.FeasibleSpace) |  | FeasibleSpace for the parameter. |
+| parameter_type | [ParameterType](#api-v1-beta1-ParameterType) |  | Type of the parameter. |
+| feasible_space | [FeasibleSpace](#api-v1-beta1-FeasibleSpace) |  | FeasibleSpace for the parameter. |
 
 
 
 
 
 
-<a name="api.v1.beta1.ReportObservationLogReply"></a>
+<a name="api-v1-beta1-ReportObservationLogReply"></a>
 
 ### ReportObservationLogReply
 
@@ -567,7 +567,7 @@ Katib will create each Hyper parameter from this config.
 
 
 
-<a name="api.v1.beta1.ReportObservationLogRequest"></a>
+<a name="api-v1-beta1-ReportObservationLogRequest"></a>
 
 ### ReportObservationLogRequest
 
@@ -576,14 +576,14 @@ Katib will create each Hyper parameter from this config.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | trial_name | [string](#string) |  |  |
-| observation_log | [ObservationLog](#api.v1.beta1.ObservationLog) |  |  |
+| observation_log | [ObservationLog](#api-v1-beta1-ObservationLog) |  |  |
 
 
 
 
 
 
-<a name="api.v1.beta1.SetTrialStatusReply"></a>
+<a name="api-v1-beta1-SetTrialStatusReply"></a>
 
 ### SetTrialStatusReply
 
@@ -593,7 +593,7 @@ Katib will create each Hyper parameter from this config.
 
 
 
-<a name="api.v1.beta1.SetTrialStatusRequest"></a>
+<a name="api-v1-beta1-SetTrialStatusRequest"></a>
 
 ### SetTrialStatusRequest
 
@@ -608,7 +608,7 @@ Katib will create each Hyper parameter from this config.
 
 
 
-<a name="api.v1.beta1.Trial"></a>
+<a name="api-v1-beta1-Trial"></a>
 
 ### Trial
 Structure for a single Trial.
@@ -617,15 +617,15 @@ Structure for a single Trial.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | name | [string](#string) |  | Name for the Trial. |
-| spec | [TrialSpec](#api.v1.beta1.TrialSpec) |  | Trial specification. |
-| status | [TrialStatus](#api.v1.beta1.TrialStatus) |  | Trial status. |
+| spec | [TrialSpec](#api-v1-beta1-TrialSpec) |  | Trial specification. |
+| status | [TrialStatus](#api-v1-beta1-TrialStatus) |  | Trial status. |
 
 
 
 
 
 
-<a name="api.v1.beta1.TrialSpec"></a>
+<a name="api-v1-beta1-TrialSpec"></a>
 
 ### TrialSpec
 Specification of a Trial. It represents Trial&#39;s parameter assignments and objective.
@@ -633,15 +633,15 @@ Specification of a Trial. It represents Trial&#39;s parameter assignments and ob
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| objective | [ObjectiveSpec](#api.v1.beta1.ObjectiveSpec) |  | Objective specification for the Trial. |
-| parameter_assignments | [TrialSpec.ParameterAssignments](#api.v1.beta1.TrialSpec.ParameterAssignments) |  | List of assignments generated for the Trial. |
+| objective | [ObjectiveSpec](#api-v1-beta1-ObjectiveSpec) |  | Objective specification for the Trial. |
+| parameter_assignments | [TrialSpec.ParameterAssignments](#api-v1-beta1-TrialSpec-ParameterAssignments) |  | List of assignments generated for the Trial. |
 
 
 
 
 
 
-<a name="api.v1.beta1.TrialSpec.ParameterAssignments"></a>
+<a name="api-v1-beta1-TrialSpec-ParameterAssignments"></a>
 
 ### TrialSpec.ParameterAssignments
 List of ParameterAssignment
@@ -649,14 +649,14 @@ List of ParameterAssignment
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| assignments | [ParameterAssignment](#api.v1.beta1.ParameterAssignment) | repeated |  |
+| assignments | [ParameterAssignment](#api-v1-beta1-ParameterAssignment) | repeated |  |
 
 
 
 
 
 
-<a name="api.v1.beta1.TrialStatus"></a>
+<a name="api-v1-beta1-TrialStatus"></a>
 
 ### TrialStatus
 Current Trial status. It contains Trial&#39;s latest condition, start time, completion time, observation.
@@ -666,15 +666,15 @@ Current Trial status. It contains Trial&#39;s latest condition, start time, comp
 | ----- | ---- | ----- | ----------- |
 | start_time | [string](#string) |  | Trial start time in RFC3339 format |
 | completion_time | [string](#string) |  | Trial completion time in RFC3339 format |
-| condition | [TrialStatus.TrialConditionType](#api.v1.beta1.TrialStatus.TrialConditionType) |  | Trial current condition. It is equal to the latest Trial CR condition. |
-| observation | [Observation](#api.v1.beta1.Observation) |  | The best Trial observation in logs. |
+| condition | [TrialStatus.TrialConditionType](#api-v1-beta1-TrialStatus-TrialConditionType) |  | Trial current condition. It is equal to the latest Trial CR condition. |
+| observation | [Observation](#api-v1-beta1-Observation) |  | The best Trial observation in logs. |
 
 
 
 
 
 
-<a name="api.v1.beta1.ValidateAlgorithmSettingsReply"></a>
+<a name="api-v1-beta1-ValidateAlgorithmSettingsReply"></a>
 
 ### ValidateAlgorithmSettingsReply
 Return INVALID_ARGUMENT Error if Algorithm Settings are not Valid
@@ -684,7 +684,7 @@ Return INVALID_ARGUMENT Error if Algorithm Settings are not Valid
 
 
 
-<a name="api.v1.beta1.ValidateAlgorithmSettingsRequest"></a>
+<a name="api-v1-beta1-ValidateAlgorithmSettingsRequest"></a>
 
 ### ValidateAlgorithmSettingsRequest
 
@@ -692,14 +692,14 @@ Return INVALID_ARGUMENT Error if Algorithm Settings are not Valid
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| experiment | [Experiment](#api.v1.beta1.Experiment) |  |  |
+| experiment | [Experiment](#api-v1-beta1-Experiment) |  |  |
 
 
 
 
 
 
-<a name="api.v1.beta1.ValidateEarlyStoppingSettingsReply"></a>
+<a name="api-v1-beta1-ValidateEarlyStoppingSettingsReply"></a>
 
 ### ValidateEarlyStoppingSettingsReply
 Return INVALID_ARGUMENT Error if Early Stopping Settings are not Valid
@@ -709,7 +709,7 @@ Return INVALID_ARGUMENT Error if Early Stopping Settings are not Valid
 
 
 
-<a name="api.v1.beta1.ValidateEarlyStoppingSettingsRequest"></a>
+<a name="api-v1-beta1-ValidateEarlyStoppingSettingsRequest"></a>
 
 ### ValidateEarlyStoppingSettingsRequest
 
@@ -717,7 +717,7 @@ Return INVALID_ARGUMENT Error if Early Stopping Settings are not Valid
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| early_stopping | [EarlyStoppingSpec](#api.v1.beta1.EarlyStoppingSpec) |  |  |
+| early_stopping | [EarlyStoppingSpec](#api-v1-beta1-EarlyStoppingSpec) |  |  |
 
 
 
@@ -726,7 +726,7 @@ Return INVALID_ARGUMENT Error if Early Stopping Settings are not Valid
  
 
 
-<a name="api.v1.beta1.ComparisonType"></a>
+<a name="api-v1-beta1-ComparisonType"></a>
 
 ### ComparisonType
 
@@ -740,7 +740,7 @@ Return INVALID_ARGUMENT Error if Early Stopping Settings are not Valid
 
 
 
-<a name="api.v1.beta1.ObjectiveType"></a>
+<a name="api-v1-beta1-ObjectiveType"></a>
 
 ### ObjectiveType
 Direction of optimization. Minimize or Maximize.
@@ -753,7 +753,7 @@ Direction of optimization. Minimize or Maximize.
 
 
 
-<a name="api.v1.beta1.ParameterType"></a>
+<a name="api-v1-beta1-ParameterType"></a>
 
 ### ParameterType
 Types of value for HyperParameter.
@@ -768,7 +768,7 @@ Types of value for HyperParameter.
 
 
 
-<a name="api.v1.beta1.TrialStatus.TrialConditionType"></a>
+<a name="api-v1-beta1-TrialStatus-TrialConditionType"></a>
 
 ### TrialStatus.TrialConditionType
 Trial can be in one of 6 conditions.
@@ -790,39 +790,39 @@ TODO (andreyvelich): Remove unused conditions.
  
 
 
-<a name="api.v1.beta1.DBManager"></a>
+<a name="api-v1-beta1-DBManager"></a>
 
 ### DBManager
 DBManager service defines APIs to manage Katib database.
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| ReportObservationLog | [ReportObservationLogRequest](#api.v1.beta1.ReportObservationLogRequest) | [ReportObservationLogReply](#api.v1.beta1.ReportObservationLogReply) | Report a log of Observations for a Trial. The log consists of timestamp and value of metric. Katib store every log of metrics. You can see accuracy curve or other metric logs on UI. |
-| GetObservationLog | [GetObservationLogRequest](#api.v1.beta1.GetObservationLogRequest) | [GetObservationLogReply](#api.v1.beta1.GetObservationLogReply) | Get all log of Observations for a Trial. |
-| DeleteObservationLog | [DeleteObservationLogRequest](#api.v1.beta1.DeleteObservationLogRequest) | [DeleteObservationLogReply](#api.v1.beta1.DeleteObservationLogReply) | Delete all log of Observations for a Trial. |
+| ReportObservationLog | [ReportObservationLogRequest](#api-v1-beta1-ReportObservationLogRequest) | [ReportObservationLogReply](#api-v1-beta1-ReportObservationLogReply) | Report a log of Observations for a Trial. The log consists of timestamp and value of metric. Katib store every log of metrics. You can see accuracy curve or other metric logs on UI. |
+| GetObservationLog | [GetObservationLogRequest](#api-v1-beta1-GetObservationLogRequest) | [GetObservationLogReply](#api-v1-beta1-GetObservationLogReply) | Get all log of Observations for a Trial. |
+| DeleteObservationLog | [DeleteObservationLogRequest](#api-v1-beta1-DeleteObservationLogRequest) | [DeleteObservationLogReply](#api-v1-beta1-DeleteObservationLogReply) | Delete all log of Observations for a Trial. |
 
 
-<a name="api.v1.beta1.EarlyStopping"></a>
+<a name="api-v1-beta1-EarlyStopping"></a>
 
 ### EarlyStopping
 EarlyStopping service defines APIs to manage Katib Early Stopping algorithms
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetEarlyStoppingRules | [GetEarlyStoppingRulesRequest](#api.v1.beta1.GetEarlyStoppingRulesRequest) | [GetEarlyStoppingRulesReply](#api.v1.beta1.GetEarlyStoppingRulesReply) |  |
-| SetTrialStatus | [SetTrialStatusRequest](#api.v1.beta1.SetTrialStatusRequest) | [SetTrialStatusReply](#api.v1.beta1.SetTrialStatusReply) |  |
-| ValidateEarlyStoppingSettings | [ValidateEarlyStoppingSettingsRequest](#api.v1.beta1.ValidateEarlyStoppingSettingsRequest) | [ValidateEarlyStoppingSettingsReply](#api.v1.beta1.ValidateEarlyStoppingSettingsReply) |  |
+| GetEarlyStoppingRules | [GetEarlyStoppingRulesRequest](#api-v1-beta1-GetEarlyStoppingRulesRequest) | [GetEarlyStoppingRulesReply](#api-v1-beta1-GetEarlyStoppingRulesReply) |  |
+| SetTrialStatus | [SetTrialStatusRequest](#api-v1-beta1-SetTrialStatusRequest) | [SetTrialStatusReply](#api-v1-beta1-SetTrialStatusReply) |  |
+| ValidateEarlyStoppingSettings | [ValidateEarlyStoppingSettingsRequest](#api-v1-beta1-ValidateEarlyStoppingSettingsRequest) | [ValidateEarlyStoppingSettingsReply](#api-v1-beta1-ValidateEarlyStoppingSettingsReply) |  |
 
 
-<a name="api.v1.beta1.Suggestion"></a>
+<a name="api-v1-beta1-Suggestion"></a>
 
 ### Suggestion
 Suggestion service defines APIs to manage Katib Suggestion from HP or NAS algorithms
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetSuggestions | [GetSuggestionsRequest](#api.v1.beta1.GetSuggestionsRequest) | [GetSuggestionsReply](#api.v1.beta1.GetSuggestionsReply) |  |
-| ValidateAlgorithmSettings | [ValidateAlgorithmSettingsRequest](#api.v1.beta1.ValidateAlgorithmSettingsRequest) | [ValidateAlgorithmSettingsReply](#api.v1.beta1.ValidateAlgorithmSettingsReply) |  |
+| GetSuggestions | [GetSuggestionsRequest](#api-v1-beta1-GetSuggestionsRequest) | [GetSuggestionsReply](#api-v1-beta1-GetSuggestionsReply) |  |
+| ValidateAlgorithmSettings | [ValidateAlgorithmSettingsRequest](#api-v1-beta1-ValidateAlgorithmSettingsRequest) | [ValidateAlgorithmSettingsReply](#api-v1-beta1-ValidateAlgorithmSettingsReply) |  |
 
  
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I fix the Dockerfile for API documentation generation since the base image of `pseudomuto/protoc-gen-doc` has been changed from `debian:jessie-slim` to `alpine:3.15.0` in v1.5.1.

Ref: https://github.com/pseudomuto/protoc-gen-doc/blob/v1.5.1/Dockerfile#L1

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
