### PR TITLE
Chore: Uses Istio v1beta1 api

### DIFF
--- a/manifests/v1beta1/installs/katib-with-kubeflow/ui-virtual-service.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/ui-virtual-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: katib-ui


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

There is nothing different between `v1alpha3` and `v1beta1` currently IMO.
But it's better to use `v1beta1` for the Istio upgrade in the future.