### PR TITLE
Generate controller RBAC from kubebuilder markers

### DIFF
--- a/manifests/v1beta1/components/controller/role.yaml
+++ b/manifests/v1beta1/components/controller/role.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: katib-controller
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - experiments.kubeflow.org
+  resources:
+  - experiments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - experiments.kubeflow.org
+  resources:
+  - experiments/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - katib.kubeflow.org
+  resources:
+  - suggestions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - katib.kubeflow.org
+  resources:
+  - suggestions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - trials.kubeflow.org
+  resources:
+  - trials
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - trials.kubeflow.org
+  resources:
+  - trials/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/pkg/controller.v1beta1/experiment/experiment_controller.go
+++ b/pkg/controller.v1beta1/experiment/experiment_controller.go
@@ -111,6 +111,10 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	return nil
 }
 
+// +kubebuilder:rbac:groups=experiments.kubeflow.org,resources=experiments,verbs=get;list;watch
+// +kubebuilder:rbac:groups=trials.kubeflow.org,resources=trials,verbs=get;list;watch
+// +kubebuilder:rbac:groups=suggestions.kubeflow.org,resources=suggestions,verbs=get;list;watch
+
 // addWatch adds a new Controller to mgr with r as the reconcile.Reconciler
 func addWatch(mgr manager.Manager, c controller.Controller) error {
 	// Watch for changes to Experiment
@@ -163,10 +167,11 @@ type ReconcileExperiment struct {
 	collector *util.ExperimentsCollector
 }
 
-// Reconcile reads that state of the cluster for a Experiment object and makes changes based on the state read
-// and what is in the Experiment.Spec
 // +kubebuilder:rbac:groups=experiments.kubeflow.org,resources=experiments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=experiments.kubeflow.org,resources=experiments/status,verbs=get;update;patch
+
+// Reconcile reads that state of the cluster for a Experiment object and makes changes based on the state read
+// and what is in the Experiment.Spec
 func (r *ReconcileExperiment) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the Experiment instance
 	logger := log.WithValues("Experiment", request.NamespacedName)

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller.go
@@ -120,15 +120,16 @@ type ReconcileSuggestion struct {
 	recorder record.EventRecorder
 }
 
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=katib.kubeflow.org,resources=suggestions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=katib.kubeflow.org,resources=suggestions/status,verbs=get;update;patch
+
 // Reconcile reads that state of the cluster for a Suggestion object and makes changes based on the state read
 // and what is in the Suggestion.Spec
 // TODO(user): Modify this Reconcile function to implement your Controller logic.  The scaffolding writes
 // a Deployment as an example
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=katib.kubeflow.org,resources=suggestions,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=katib.kubeflow.org,resources=suggestions/status,verbs=get;update;patch
 func (r *ReconcileSuggestion) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	logger := log.WithValues("Suggestion", request.NamespacedName)
 	// Fetch the Suggestion instance

--- a/pkg/controller.v1beta1/trial/trial_controller.go
+++ b/pkg/controller.v1beta1/trial/trial_controller.go
@@ -146,10 +146,11 @@ type ReconcileTrial struct {
 	collector *trialutil.TrialsCollector
 }
 
-// Reconcile reads that state of the cluster for a Trial object and makes changes based on the state read
-// and what is in the Trial.Spec
 // +kubebuilder:rbac:groups=trials.kubeflow.org,resources=trials,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=trials.kubeflow.org,resources=trials/status,verbs=get;update;patch
+
+// Reconcile reads that state of the cluster for a Trial object and makes changes based on the state read
+// and what is in the Trial.Spec
 func (r *ReconcileTrial) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the Trial instance
 	logger := log.WithValues("Trial", request.NamespacedName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR enables automatic generation of RBAC manifests based on in-code kubebuilder markers and updates those markers to represent current API access requirements.
Access requirements declaration for each method that calls API client will make RBAC rules much more transparent. 

**Which issue(s) this PR fixes**:
Fixes #1639

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
