### PR TITLE
Fix the FPGA examples documentation

### DIFF
--- a/examples/v1beta1/fpga/README.md
+++ b/examples/v1beta1/fpga/README.md
@@ -10,9 +10,9 @@ visit the [InAccel](https://docs.inaccel.com) documentation.
 ## Simplifying FPGA management in EKS\* (Elastic Kubernetes Service)
 
 \*_For development and testing purposes you can still [deploy Kubeflow Katib
-using Minikube](https://kubeflow.org/docs/started/workstation/minikube-linux) in
-a single AMI instance. In production environments, Amazon's managed Kubernetes
-service ([EKS](https://aws.amazon.com/eks)) is recommended._
+using MicroK8s](https://ubuntu.com/tutorials/accelerated-ml-experiments-on-microk8s-with-inaccel-fpga-operator-and-kubeflow-katib)
+in a single AMI instance. In production environments, Amazon's managed
+Kubernetes service ([EKS](https://aws.amazon.com/eks)) is recommended._
 
 The InAccel FPGA Operator allows administrators of Kubernetes clusters to manage
 FPGA nodes just like CPU nodes in the cluster. Instead of provisioning a special

--- a/examples/v1beta1/fpga/README.md
+++ b/examples/v1beta1/fpga/README.md
@@ -37,7 +37,7 @@ Kubernetes, as a Helm app on your cluster, with the following command.
 ```sh
 helm repo add inaccel https://setup.inaccel.com/helm
 
-helm install inaccel inaccel/fpga-operator
+helm install -n kube-system inaccel inaccel/fpga-operator
 ```
 
 You can verify that your nodes have available FPGAs with the following command:


### PR DESCRIPTION
**What this PR does**:

* Set `kube-system` as the suggested (InAccel FPGA Operator) namespace
* Replace broken link

The new link points to a MicroK8s + InAccel + Katib [tutorial](https://ubuntu.com/tutorials/accelerated-ml-experiments-on-microk8s-with-inaccel-fpga-operator-and-kubeflow-katib).