### PR TITLE
manifests: Increate the probes seconds

### DIFF
--- a/manifests/v1beta1/components/mysql/mysql.yaml
+++ b/manifests/v1beta1/components/mysql/mysql.yaml
@@ -44,7 +44,8 @@ spec:
                 - "/bin/bash"
                 - "-c"
                 - "mysql -D ${MYSQL_DATABASE} -u root -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1'"
-            periodSeconds: 2
+            initialDelaySeconds: 10
+            periodSeconds: 5
             failureThreshold: 10
           livenessProbe:
             exec:
@@ -52,7 +53,8 @@ spec:
                 - "/bin/bash"
                 - "-c"
                 - "mysqladmin ping -u root -p${MYSQL_ROOT_PASSWORD}"
-            periodSeconds: 2
+            initialDelaySeconds: 10
+            periodSeconds: 5
             failureThreshold: 10
           startupProbe:
             exec:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

The current probe delay seconds are not suitable for the most environments.
We should increase these values.