### PR TITLE
Fix kubeflowkatib/mxnet-mnist image

### DIFF
--- a/examples/v1beta1/trial-images/mxnet-mnist/Dockerfile
+++ b/examples/v1beta1/trial-images/mxnet-mnist/Dockerfile
@@ -1,8 +1,9 @@
-FROM mxnet/python:latest_cpu_native_py3
+FROM python:3.9
 
 ADD examples/v1beta1/trial-images/mxnet-mnist /opt/mxnet-mnist
 WORKDIR /opt/mxnet-mnist
 
+RUN pip install mxnet==1.9.0
 RUN chgrp -R 0 /opt/mxnet-mnist \
   && chmod -R g+rwX /opt/mxnet-mnist
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It seems that `mxnet/python:latest_cpu_native_py3` image has been deleted from [upstream dockerhub](https://hub.docker.com/r/mxnet/python/tags). 
As a result, our suite test can no longer be run as shown below, so I changed the base image from `mxnet/python:latest_cpu_native_py3` to `python:3.9`.

> error building image: GET https://index.docker.io/v2/mxnet/python/manifests/latest_cpu_native_py3: MANIFEST_UNKNOWN: manifest unknown; unknown tag=latest_cpu_native_py3

[Argo Workflow Logs](https://argo.kubeflow-testing.com/workflows/kubeflow-test-infra/kubeflow-katib-presubmit-e2e-v1beta1-1833-c56b348-2224-eb75?tab=workflow&nodeId=kubeflow-katib-presubmit-e2e-v1beta1-1833-c56b348-2224-eb75-1092086686&sidePanel=logs%3Akubeflow-katib-presubmit-e2e-v1beta1-1833-c56b348-2224-eb75-1092086686%3Amain)

Also, I have used [`ytenzen/katib-mxnet-mnist:fix-mxnet-image`](https://hub.docker.com/layers/katib-mxnet-mnist/ytenzen/katib-mxnet-mnist/fix-mxnet-image/images/sha256-c7783a230a1b706d773030346350799ffc332ebcfbb40055e0aabc09d1c7019a?context=explore) to check the operation of the new image.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
