### PR TITLE
operators/katib-*: pins pip and setuptools versions to avoid installation issues

### DIFF
--- a/operators/katib-controller/charmcraft.yaml
+++ b/operators/katib-controller/charmcraft.yaml
@@ -8,4 +8,5 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    charm-python-packages: [setuptools, pip]
+    # Remove when pypa/setuptools_scm#713 gets fixed
+    charm-python-packages: [setuptools==62.1.0, pip==22.0.4]

--- a/operators/katib-db-manager/charmcraft.yaml
+++ b/operators/katib-db-manager/charmcraft.yaml
@@ -8,4 +8,5 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    charm-python-packages: [setuptools, pip]
+    # Remove when pypa/setuptools_scm#713 gets fixed
+    charm-python-packages: [setuptools==62.1.0, pip==22.0.4]

--- a/operators/katib-ui/charmcraft.yaml
+++ b/operators/katib-ui/charmcraft.yaml
@@ -8,4 +8,5 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    charm-python-packages: [setuptools, pip]
+    # Remove when pypa/setuptools_scm#713 gets fixed
+    charm-python-packages: [setuptools==62.1.0, pip==22.0.4]


### PR DESCRIPTION
Due to pypa/setuptools_scm#713, we are experiencing errors when building charms both locally and in the CI. This change will prevent the error from happening until the issue is fixed.

This PR fixes the CI errors reported in #1866