### PR TITLE
Fix `HAS_SHELLCHECK` and `HAS_SETUP_ENVTEST` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-HAS_LINT := $(shell command -v golangci-lint;)
-HAS_SHELLCHECK := $(shell command shellcheck --version)
-HAS_SETUP_ENVTEST := $(shell command setup-envtest list)
+HAS_LINT := $(shell command -v golangci-lint)
+HAS_SHELLCHECK := $(shell command -v shellcheck)
+HAS_SETUP_ENVTEST := $(shell command -v setup-envtest)
 
 COMMIT := v1beta1-$(shell git rev-parse --short=7 HEAD)
 KATIB_REGISTRY := docker.io/kubeflowkatib


### PR DESCRIPTION
**What this PR does / why we need it**:
I fixed `HAS_SHELLCHECK` and `HAS_SETUP_ENVTEST` in Makefile to resolve `"make: command: Command not found"` errors reported in https://github.com/kubeflow/katib/pull/1882#discussion_r889232351.

/assign @johnugeorge 

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
