### PR TITLE
Add semicolon when using `command` command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-HAS_LINT := $(shell command -v golangci-lint)
-HAS_SHELLCHECK := $(shell command -v shellcheck)
-HAS_SETUP_ENVTEST := $(shell command -v setup-envtest)
+HAS_LINT := $(shell command -v golangci-lint;)
+HAS_SHELLCHECK := $(shell command -v shellcheck;)
+HAS_SETUP_ENVTEST := $(shell command -v setup-envtest;)
 
 COMMIT := v1beta1-$(shell git rev-parse --short=7 HEAD)
 KATIB_REGISTRY := docker.io/kubeflowkatib

--- a/examples/v1beta1/kind-cluster/deploy.sh
+++ b/examples/v1beta1/kind-cluster/deploy.sh
@@ -18,19 +18,19 @@
 set -e
 
 # Verify that appropriate tools are installed.
-if [[ ! $(which docker) ]]; then
+if [ -z "$(command -v docker)" ]; then
   echo "Unable to find Docker"
   echo "To install Docker, please follow this guide: https://docs.docker.com/get-docker"
   exit 1
 fi
 
-if [[ ! $(which kind) ]]; then
+if [ -z "$(command -v kind)" ]; then
   echo "Unable to find Kind"
   echo "To install Kind, please follow this guide: https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
   exit 1
 fi
 
-if [[ ! $(which kubectl) ]]; then
+if [ -z "$(command -v kubectl)" ]; then
   echo "Unable to find kubectl"
   echo "To install kubectl, please follow this guide: https://kubernetes.io/docs/tasks/tools/#kubectl"
   exit 1

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if ! which gofmt >/dev/null; then
+if [ -z "$(command -v gofmt)" ]; then
   echo "Can not find gofmt"
   exit 1
 fi

--- a/hack/verify-golangci-lint.sh
+++ b/hack/verify-golangci-lint.sh
@@ -19,7 +19,7 @@ set -o pipefail
 
 cd "$(dirname "$0")/.."
 
-if ! which golangci-lint >/dev/null; then
+if [ -z "$(command -v golangci-lint)" ]; then
 	echo 'Can not find golangci-lint, install with: make lint'
 	exit 1
 fi

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -19,7 +19,7 @@ set -o pipefail
 
 cd "$(dirname "$0")/.."
 
-if ! which shellcheck >/dev/null; then
+if [ -z "$(command -v shellcheck)" ]; then
 	echo 'Can not find shellcheck, install with: make shellcheck'
 	exit 1
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
To avoid the `make: command: Command not found` error, I have added `-v` option when using the `command` command in https://github.com/kubeflow/katib/pull/1884, although we received the same error message again.

> Run go mod download
make: command: Command not found
make: command: Command not found
make: command: Command not found
go generate ./pkg/... ./cmd/...
Generate deepcopy, clientset, listers, informers for the APIs

https://github.com/kubeflow/katib/runs/6736557128?check_suite_focus=true#step:5:10

According to this StackOverflow comment, we need to add a semicolon when using the `command` command on the Ubuntu machine.

> you must have a version of GNU make pre 4.3, that doesn't realize command is a shell built-in. You can force it by adding a semicolon like: $(shell command -v python3;)

https://stackoverflow.com/questions/63286462/gnu-make-check-whether-a-python-module-needs-to-be-installed

After applying this patch, I confirmed that we don't receive the error message in [this](https://github.com/tenzen-y/katib/runs/6737111804?check_suite_focus=true#step:5:10) job.

> Run go mod download
go generate ./pkg/... ./cmd/...
Generate deepcopy, clientset, listers, informers for the APIs

/assign @johnugeorge 

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
