### PR TITLE
Update job name and service name as configurable for cert generator

### DIFF
--- a/pkg/cert-generator/v1beta1/generate/generate.go
+++ b/pkg/cert-generator/v1beta1/generate/generate.go
@@ -39,6 +39,8 @@ import (
 // generateOptions contains values for all certificates.
 type generateOptions struct {
 	namespace         string
+	service           string
+	job               string
 	fullServiceDomain string
 }
 
@@ -59,12 +61,14 @@ func NewGenerateCmd(kubeClient client.Client) *cobra.Command {
 	}
 	f := cmd.Flags()
 	f.StringVarP(&o.namespace, "namespace", "n", "kubeflow", "set namespace")
+	f.StringVarP(&o.job, "job", "j", consts.JobName, "set job name")
+	f.StringVarP(&o.service, "service", "s", consts.Service, "set service name")
 	return cmd
 }
 
 // run is main function for `generate` subcommand.
 func (o *generateOptions) run(ctx context.Context, kubeClient client.Client) error {
-	o.fullServiceDomain = strings.Join([]string{consts.Service, o.namespace, "svc"}, ".")
+	o.fullServiceDomain = strings.Join([]string{o.service, o.namespace, "svc"}, ".")
 
 	caKeyPair, err := o.createCACert()
 	if err != nil {
@@ -127,8 +131,8 @@ func (o *generateOptions) createCert(caKeyPair *certificates) (*certificates, er
 			CommonName: o.fullServiceDomain,
 		},
 		DNSNames: []string{
-			consts.Service,
-			strings.Join([]string{consts.Service, o.namespace}, "."),
+			o.service,
+			strings.Join([]string{o.service, o.namespace}, "."),
 			o.fullServiceDomain,
 		},
 		NotBefore:             now,
@@ -156,7 +160,7 @@ func (o *generateOptions) createCert(caKeyPair *certificates) (*certificates, er
 func (o *generateOptions) createWebhookCertSecret(ctx context.Context, kubeClient client.Client, caKeyPair *certificates, keyPair *certificates) error {
 
 	certGeneratorJob := &batchv1.Job{}
-	if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: o.namespace, Name: consts.JobName}, certGeneratorJob); err != nil {
+	if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: o.namespace, Name: o.job}, certGeneratorJob); err != nil {
 		return err
 	}
 
@@ -177,7 +181,7 @@ func (o *generateOptions) createWebhookCertSecret(ctx context.Context, kubeClien
 					APIVersion: "batch/v1",
 					Kind:       "Job",
 					Controller: &isController,
-					Name:       consts.JobName,
+					Name:       o.job,
 					UID:        jobUID,
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR adds two additional command line input args `serviceName` `jobName` for the `cert-generator` job so that it's configurable in case Katib controller is deployed to multiple envs, e.g having `katib-controller-production` and `katib-controller-staging`.

By default, these two values will fall back to the hardcoded constants defined here: https://github.com/kubeflow/katib/blob/master/pkg/cert-generator/v1beta1/consts/const.go#L21 

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #
Allows `cert-generator` usage like:
```
./katib-cert-generator generate --namespace={{ Namespace }} --jobName={{ JobName }} --serviceName={{ ServiceName }}
```

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
