### PR TITLE
Limit the use of only one Kubernetes version to save GH Actions credit In E2E tests

### DIFF
--- a/.github/workflows/darts-cifar10-e2e-test.yaml
+++ b/.github/workflows/darts-cifar10-e2e-test.yaml
@@ -27,7 +27,8 @@ jobs:
       matrix:
         # Detail: https://hub.docker.com/r/kindest/node
         # TODO (tenzen-y): We need to consider running tests on more kubernetes versions.
+        # We need to limit the use of only one Kubernetes version to save GH Actions credit.
         # kubernetes-version: ["v1.20.15", "v1.21.12", "v1.22.9", "v1.23.6", "v1.24.1"]
-        kubernetes-version: ["v1.21.12", "v1.22.9", "v1.23.6"]
+        kubernetes-version: ["v1.22.9"]
         # Comma Delimited
         experiments: ["darts-cpu"]

--- a/.github/workflows/enas-cifar10-e2e-test.yaml
+++ b/.github/workflows/enas-cifar10-e2e-test.yaml
@@ -27,7 +27,8 @@ jobs:
       matrix:
         # Detail: https://hub.docker.com/r/kindest/node
         # TODO (tenzen-y): We need to consider running tests on more kubernetes versions.
+        # We need to limit the use of only one Kubernetes version to save GH Actions credit.
         # kubernetes-version: ["v1.20.15", "v1.21.12", "v1.22.9", "v1.23.6", "v1.24.1"]
-        kubernetes-version: ["v1.21.12", "v1.22.9", "v1.23.6"]
+        kubernetes-version: ["v1.22.9"]
         # Comma Delimited
         experiments: ["enas-cpu"]

--- a/.github/workflows/katib-ui-e2e-test.yaml
+++ b/.github/workflows/katib-ui-e2e-test.yaml
@@ -26,5 +26,6 @@ jobs:
       matrix:
         # Detail: https://hub.docker.com/r/kindest/node
         # TODO (tenzen-y): We need to consider running tests on more kubernetes versions.
+        # We need to limit the use of only one Kubernetes version to save GH Actions credit.
         # kubernetes-version: ["v1.20.15", "v1.21.12", "v1.22.9", "v1.23.6", "v1.24.1"]
-        kubernetes-version: ["v1.21.12", "v1.22.9", "v1.23.6"]
+        kubernetes-version: ["v1.22.9"]

--- a/.github/workflows/mxnet-mnist-e2e-test.yaml
+++ b/.github/workflows/mxnet-mnist-e2e-test.yaml
@@ -27,8 +27,9 @@ jobs:
       matrix:
         # Detail: https://hub.docker.com/r/kindest/node
         # TODO (tenzen-y): We need to consider running tests on more kubernetes versions.
+        # We need to limit the use of only one Kubernetes version to save GH Actions credit.
         # kubernetes-version: ["v1.20.15", "v1.21.12", "v1.22.9", "v1.23.6", "v1.24.1"]
-        kubernetes-version: ["v1.21.12", "v1.22.9", "v1.23.6"]
+        kubernetes-version: ["v1.22.9"]
         # Comma Delimited
         experiments:
           # suggestion-hyperopt

--- a/.github/workflows/pytorch-mnist-e2e-test.yaml
+++ b/.github/workflows/pytorch-mnist-e2e-test.yaml
@@ -28,8 +28,9 @@ jobs:
       matrix:
         # Detail: https://hub.docker.com/r/kindest/node
         # TODO (tenzen-y): We need to consider running tests on more kubernetes versions.
+        # We need to limit the use of only one Kubernetes version to save GH Actions credit.
         # kubernetes-version: ["v1.20.15", "v1.21.12", "v1.22.9", "v1.23.6", "v1.24.1"]
-        kubernetes-version: ["v1.21.12", "v1.22.9", "v1.23.6"]
+        kubernetes-version: ["v1.22.9"]
         # Comma Delimited
         experiments:
           - "file-metrics-collector,pytorchjob-mnist"

--- a/.github/workflows/tf-mnist-with-summaries-e2e-test.yaml
+++ b/.github/workflows/tf-mnist-with-summaries-e2e-test.yaml
@@ -28,7 +28,8 @@ jobs:
       matrix:
         # Detail: https://hub.docker.com/r/kindest/node
         # TODO (tenzen-y): We need to consider running tests on more kubernetes versions.
+        # We need to limit the use of only one Kubernetes version to save GH Actions credit.
         # kubernetes-version: ["v1.20.15", "v1.21.12", "v1.22.9", "v1.23.6", "v1.24.1"]
-        kubernetes-version: ["v1.21.12", "v1.22.9", "v1.23.6"]
+        kubernetes-version: ["v1.22.9"]
         # Comma Delimited
         experiments: ["tfjob-mnist-with-summaries"]


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to limit the use of only one Kubernetes version to save GH Actions credit in E2E tests.

/assign @johnugeorge 

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
