### PR TITLE
Upgrade tensorflow-aarch64 version to v2.9.1

### DIFF
--- a/cmd/metricscollector/v1beta1/tfevent-metricscollector/requirements.txt
+++ b/cmd/metricscollector/v1beta1/tfevent-metricscollector/requirements.txt
@@ -2,9 +2,5 @@ psutil==5.8.0
 rfc3339>=6.2
 grpcio==1.41.1
 googleapis-common-protos==1.6.0
-# TODO (tenzen-y): We need to delete the line to install protobuf after tensorflow-aarch64 v2.9.1, or higher has been released.
-# To avoid the `If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.` error,
-# we must restrict the protobuf version.
-protobuf >= 3.9.2, < 3.20; platform_machine=="aarch64"
 tensorflow==2.9.1; platform_machine=="x86_64"
-tensorflow-aarch64==2.9.0; platform_machine=="aarch64"
+tensorflow-aarch64==2.9.1; platform_machine=="aarch64"

--- a/cmd/suggestion/nas/enas/v1beta1/requirements.txt
+++ b/cmd/suggestion/nas/enas/v1beta1/requirements.txt
@@ -1,9 +1,5 @@
 grpcio==1.41.1
 googleapis-common-protos==1.6.0
 cython>=0.29.24
-# TODO (tenzen-y): We need to delete the line to install protobuf after tensorflow-aarch64 v2.9.1, or higher has been released.
-# To avoid the `If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.` error,
-# we must restrict the protobuf version.
-protobuf >= 3.9.2, < 3.20; platform_machine=="aarch64"
 tensorflow==2.9.1; platform_machine=="x86_64"
-tensorflow-aarch64==2.9.0; platform_machine=="aarch64"
+tensorflow-aarch64==2.9.1; platform_machine=="aarch64"


### PR DESCRIPTION
**What this PR does / why we need it**:
I upgraded the tensorflow-aarch64 version to v2.9.1.

Ref: https://pypi.org/project/tensorflow-aarch64/2.9.1/

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
