### PR TITLE
[Bug Report] Validator failed to parse volume mounts if readOnly set to false

### DIFF
--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -404,7 +404,7 @@ func validatePatchJob(runSpec *unstructured.Unstructured, job interface{}, jobTy
 		// If operation != "remove" some values from trialTemplate were not converted
 		// We can't validate /resources/limits/ because CRDs can have custom k8s resources using defice plugin
 		// ref https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/
-		if operation.Operation != "remove" && !strings.Contains(operation.Path, "/resources/limits/") && !strings.Contains(operation.Path, "/resources/requests/") && !strings.Contains(operation.Path, "/volumeMounts/") {
+		if operation.Operation != "remove" && !strings.Contains(operation.Path, "/resources/limits/") && !strings.Contains(operation.Path, "/resources/requests/") {
 			return fmt.Errorf("unable to convert: %v - %v to %v, converted template: %v", operation.Path, operation.Value, jobType, string(runSpecAfter))
 		}
 	}

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -404,7 +404,7 @@ func validatePatchJob(runSpec *unstructured.Unstructured, job interface{}, jobTy
 		// If operation != "remove" some values from trialTemplate were not converted
 		// We can't validate /resources/limits/ because CRDs can have custom k8s resources using defice plugin
 		// ref https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/
-		if operation.Operation != "remove" && !strings.Contains(operation.Path, "/resources/limits/") && !strings.Contains(operation.Path, "/resources/requests/") {
+		if operation.Operation != "remove" && !strings.Contains(operation.Path, "/resources/limits/") && !strings.Contains(operation.Path, "/resources/requests/") && !strings.Contains(operation.Path, "/volumeMounts/") {
 			return fmt.Errorf("unable to convert: %v - %v to %v, converted template: %v", operation.Path, operation.Value, jobType, string(runSpecAfter))
 		}
 	}

--- a/pkg/webhook/v1beta1/experiment/validator/validator_test.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator_test.go
@@ -761,7 +761,26 @@ spec:
 		t.Errorf("ConvertStringToUnstructured failed: %v", err)
 	}
 
-	volumeMountBatchJob := `apiVersion: batch/v1
+	readonlyVolumeMountBatchJob := `apiVersion: batch/v1
+kind: Job
+spec:
+  template:
+    spec:
+      containers:
+        - name: job-with-volume-mounts
+          volumeMounts:
+            - mountPath: /tmp
+              readOnly: true
+              name: tmp
+      volumes:
+        - emptyDir: {}
+          name: tmp`
+	readonlyVolumeMountBatchJobUnstr, err := util.ConvertStringToUnstructured(readonlyVolumeMountBatchJob)
+	if err != nil {
+		t.Errorf("ConvertStringToUnstructured failed: %v", err)
+	}
+
+	nonReadonlyVolumeMountBatchJob := `apiVersion: batch/v1
 kind: Job
 spec:
   template:
@@ -775,7 +794,7 @@ spec:
       volumes:
         - emptyDir: {}
           name: tmp`
-	volumeMountBatchJobUnstr, err := util.ConvertStringToUnstructured(volumeMountBatchJob)
+	nonReadonlyVolumeMountBatchJobUnstr, err := util.ConvertStringToUnstructured(nonReadonlyVolumeMountBatchJob)
 	if err != nil {
 		t.Errorf("ConvertStringToUnstructured failed: %v", err)
 	}
@@ -808,9 +827,14 @@ spec:
 		},
 		// Valid case with not default Kubernetes resource (nvidia.com/gpu: 1)
 		{
-			RunSpec:         volumeMountBatchJobUnstr,
+			RunSpec:         readonlyVolumeMountBatchJobUnstr,
 			Err:             false,
-			testDescription: "Valid case with volume mount resource in Trial template",
+			testDescription: "Valid readonly volume mount resource in Trial template",
+		},
+		{
+			RunSpec:         nonReadonlyVolumeMountBatchJobUnstr,
+			Err:             true,
+			testDescription: "Invalid volume mount resource in Trial template",
 		},
 	}
 

--- a/pkg/webhook/v1beta1/experiment/validator/validator_test.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator_test.go
@@ -761,6 +761,25 @@ spec:
 		t.Errorf("ConvertStringToUnstructured failed: %v", err)
 	}
 
+	volumeMountBatchJob := `apiVersion: batch/v1
+kind: Job
+spec:
+  template:
+    spec:
+      containers:
+        - name: job-with-volume-mounts
+          volumeMounts:
+            - mountPath: /tmp
+              readOnly: false
+              name: tmp
+      volumes:
+        - emptyDir: {}
+          name: tmp`
+	volumeMountBatchJobUnstr, err := util.ConvertStringToUnstructured(volumeMountBatchJob)
+	if err != nil {
+		t.Errorf("ConvertStringToUnstructured failed: %v", err)
+	}
+
 	tcs := []struct {
 		RunSpec         *unstructured.Unstructured
 		Err             bool
@@ -786,6 +805,12 @@ spec:
 			RunSpec:         notDefaultResourceBatchUnstr,
 			Err:             false,
 			testDescription: "Valid case with nvidia.com/gpu resource in Trial template",
+		},
+		// Valid case with not default Kubernetes resource (nvidia.com/gpu: 1)
+		{
+			RunSpec:         volumeMountBatchJobUnstr,
+			Err:             false,
+			testDescription: "Valid case with volume mount resource in Trial template",
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Report bug when non readOnly volume mounts exists in the Trial Job template and add two unit tests to reproduce it.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #
We can either skip `volumeMounts` in the if conditions or skip the patch job validation: https://github.com/kubeflow/katib/blob/master/pkg/webhook/v1beta1/experiment/validator/validator.go#L380


**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
