### PR TITLE
Add CyberAgent to adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -4,14 +4,15 @@ Below are the adopters of project Katib. If you are using Katib
 please add yourself into the following list by a pull request.
 Please keep the list in alphabetical order.
 
-| Organization | Contact | Description of Use |
-| ------------ | ------- | ------------------ |
-| [Akuity](https://akuity.io/) | [@terrytangyuan](https://github.com/terrytangyuan) | |
-| [Ant Group](https://www.antgroup.com/) |[@ohmystack](https://github.com/ohmystack) | Automatic training in Ant Group internal AI Platform |
-| [babylon health](https://www.babylonhealth.com/) |[@jeremievallee](https://github.com/jeremievallee) | Hyperparameter tuning for AIR internal AI Platform |
-| [caicloud](https://caicloud.io/) |[@gaocegege](https://github.com/gaocegege) | Hyperparameter tuning in Caicloud Cloud-Native AI Platform |
-| [canonical](https://ubuntu.com/) |[@RFMVasconcelos](https://github.com/rfmvasconcelos) | Hyperparameter tuning for customer projects in Defense and Fintech |
-| [cisco](https://cisco.com/) |[@ramdootp](https://github.com/ramdootp) | Hyperparameter tuning for conversational AI interface using Rasa |
-| [cubonacci](https://www.cubonacci.com) |[@janvdvegt](https://github.com/janvdvegt) | Hyperparameter tuning within the Cubonacci machine learning platform |
-| [fuzhi](http://www.fuzhi.ai/) | [@planck0591](https://github.com/planck0591) | Experiment and Trial in autoML Platform |
-| [karrot](https://uk.karrotmarket.com/) |[@muik](https://github.com/muik) | Hyperparameter tuning in Karrot ML Platform |
+| Organization                                     | Contact                                              | Description of Use                                                   |
+|--------------------------------------------------|------------------------------------------------------|----------------------------------------------------------------------|
+| [Akuity](https://akuity.io/)                     | [@terrytangyuan](https://github.com/terrytangyuan)   |                                                                      |
+| [Ant Group](https://www.antgroup.com/)           | [@ohmystack](https://github.com/ohmystack)           | Automatic training in Ant Group internal AI Platform                 |
+| [babylon health](https://www.babylonhealth.com/) | [@jeremievallee](https://github.com/jeremievallee)   | Hyperparameter tuning for AIR internal AI Platform                   |
+| [caicloud](https://caicloud.io/)                 | [@gaocegege](https://github.com/gaocegege)           | Hyperparameter tuning in Caicloud Cloud-Native AI Platform           |
+| [canonical](https://ubuntu.com/)                 | [@RFMVasconcelos](https://github.com/rfmvasconcelos) | Hyperparameter tuning for customer projects in Defense and Fintech   |
+| [cisco](https://cisco.com/)                      | [@ramdootp](https://github.com/ramdootp)             | Hyperparameter tuning for conversational AI interface using Rasa     |
+| [cubonacci](https://www.cubonacci.com)           | [@janvdvegt](https://github.com/janvdvegt)           | Hyperparameter tuning within the Cubonacci machine learning platform |
+| [CyberAgent](https://www.cyberagent.co.jp/en/)   | [@tenzen-y](https://github.com/tenzen-y)             | Experiment in CyberAgent internal ML Platform on Private Cloud       |
+| [fuzhi](http://www.fuzhi.ai/)                    | [@planck0591](https://github.com/planck0591)         | Experiment and Trial in autoML Platform                              |
+| [karrot](https://uk.karrotmarket.com/)           | [@muik](https://github.com/muik)                     | Hyperparameter tuning in Karrot ML Platform                          |


### PR DESCRIPTION
**What this PR does / why we need it**:
I added CyberAgent to `ADOPTERS.md`.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
