### PR TITLE
Allow running examples on Apple Silicon M1 and fix image build errors for arm64

### DIFF
--- a/cmd/metricscollector/v1beta1/tfevent-metricscollector/Dockerfile
+++ b/cmd/metricscollector/v1beta1/tfevent-metricscollector/Dockerfile
@@ -7,6 +7,13 @@ ADD ./pkg/ ${TARGET_DIR}/pkg/
 ADD ./${METRICS_COLLECTOR_DIR}/ ${TARGET_DIR}/${METRICS_COLLECTOR_DIR}/
 WORKDIR  ${TARGET_DIR}/${METRICS_COLLECTOR_DIR}
 
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+    apt-get -y update && \
+    apt-get -y install gfortran libpcre3 libpcre3-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*; \
+    fi
+
 RUN pip install --no-cache-dir -r requirements.txt
 
 RUN chgrp -R 0 ${TARGET_DIR} \

--- a/cmd/suggestion/chocolate/v1beta1/Dockerfile
+++ b/cmd/suggestion/chocolate/v1beta1/Dockerfile
@@ -16,7 +16,7 @@ ENV SUGGESTION_DIR cmd/suggestion/chocolate/v1beta1
 RUN apt-get -y update && \
     apt-get -y install git && \
     if [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "aarch64" ]; then \
-    apt-get -y install gfortran libopenblas-dev liblapack-dev; \
+    apt-get -y install gfortran libopenblas-dev liblapack-dev g++; \
     fi && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/examples/v1beta1/kind-cluster/deploy.sh
+++ b/examples/v1beta1/kind-cluster/deploy.sh
@@ -36,8 +36,8 @@ if [ -z "$(command -v kubectl)" ]; then
   exit 1
 fi
 
-# Step 1. Create Kind cluster with Kubernetes v1.22.9
-kind create cluster --image kindest/node:v1.22.9
+# Step 1. Create Kind cluster with Kubernetes v1.23.6
+kind create cluster --image kindest/node:v1.23.6
 echo -e "\nKind cluster has been created\n"
 
 # Step 2. Set context for kubectl
@@ -52,6 +52,12 @@ kubectl get nodes
 # Step 4. Deploy Katib components.
 echo -e "\nDeploying Katib components\n"
 kubectl apply -k "github.com/kubeflow/katib.git/manifests/v1beta1/installs/katib-standalone?ref=master"
+
+# If the local machine's CPU architecture is arm64, rewrite mysql image.
+if [ "$(uname -m)" = "arm64" ]; then
+  kubectl patch deployments -n kubeflow katib-mysql --type json -p \
+    '[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "arm64v8/mysql:8.0.29-oracle"}]'
+fi
 
 # Wait until all Katib pods are running.
 kubectl wait --for=condition=ready --timeout=${TIMEOUT} -l "katib.kubeflow.org/component in (controller,db-manager,mysql,ui)" -n kubeflow pod

--- a/examples/v1beta1/trial-images/enas-cnn-cifar10/Dockerfile.cpu
+++ b/examples/v1beta1/trial-images/enas-cnn-cifar10/Dockerfile.cpu
@@ -7,8 +7,14 @@ WORKDIR  ${TARGET_DIR}
 
 ENV PYTHONPATH ${TARGET_DIR}
 
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+    apt-get -y update && \
+    apt-get -y install gfortran libpcre3 libpcre3-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*; \
+    fi
+
 RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install --no-cache-dir tensorflow==2.9.1
 RUN chgrp -R 0 ${TARGET_DIR} \
   && chmod -R g+rwX ${TARGET_DIR}
 

--- a/examples/v1beta1/trial-images/enas-cnn-cifar10/Dockerfile.gpu
+++ b/examples/v1beta1/trial-images/enas-cnn-cifar10/Dockerfile.gpu
@@ -7,7 +7,7 @@ WORKDIR  ${TARGET_DIR}
 
 ENV PYTHONPATH ${TARGET_DIR}
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir scipy==1.8.1
 RUN chgrp -R 0 ${TARGET_DIR} \
   && chmod -R g+rwX ${TARGET_DIR}
 

--- a/examples/v1beta1/trial-images/tf-mnist-with-summaries/Dockerfile
+++ b/examples/v1beta1/trial-images/tf-mnist-with-summaries/Dockerfile
@@ -3,7 +3,14 @@ FROM python:3.9-slim
 ADD examples/v1beta1/trial-images/tf-mnist-with-summaries /opt/tf-mnist-with-summaries
 WORKDIR /opt/tf-mnist-with-summaries
 
-RUN pip install --no-cache-dir tensorflow==2.9.1
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+    apt-get -y update && \
+    apt-get -y install gfortran libpcre3 libpcre3-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*; \
+    fi
+
+RUN pip install --no-cache-dir -r requirements.txt
 RUN chgrp -R 0 /opt/tf-mnist-with-summaries \
   && chmod -R g+rwX /opt/tf-mnist-with-summaries
 

--- a/examples/v1beta1/trial-images/tf-mnist-with-summaries/requirements.txt
+++ b/examples/v1beta1/trial-images/tf-mnist-with-summaries/requirements.txt
@@ -1,3 +1,2 @@
-scipy>=1.7.2
 tensorflow==2.9.1; platform_machine=="x86_64"
 tensorflow-aarch64==2.9.1; platform_machine=="aarch64"

--- a/scripts/v1beta1/build.sh
+++ b/scripts/v1beta1/build.sh
@@ -112,17 +112,14 @@ echo -e "\nBuilding median stopping rule...\n"
 docker build --platform "linux/$ARCH" -t "${REGISTRY}/earlystopping-medianstop:${TAG}" -f ${CMD_PREFIX}/earlystopping/medianstop/${VERSION}/Dockerfile .
 
 # Training container images
-if [ ! "$ARCH" = "amd64" ]; then
-  echo -e "\nTraining container images are supported only amd64."
-else
+echo -e "\nBuilding training container images..."
 
-  echo -e "\nBuilding training container images..."
+if [ ! "$ARCH" = "amd64" ]; then
+  echo -e "\nSome training container images are supported only amd64."
+else
 
   echo -e "\nBuilding mxnet mnist training container example...\n"
   docker build --platform linux/amd64 -t "${REGISTRY}/mxnet-mnist:${TAG}" -f examples/${VERSION}/trial-images/mxnet-mnist/Dockerfile .
-
-  echo -e "\nBuilding Tensorflow with summaries mnist training container example...\n"
-  docker build --platform linux/amd64 -t "${REGISTRY}/tf-mnist-with-summaries:${TAG}" -f examples/${VERSION}/trial-images/tf-mnist-with-summaries/Dockerfile .
 
   echo -e "\nBuilding PyTorch mnist training container example...\n"
   docker build --platform linux/amd64 -t "${REGISTRY}/pytorch-mnist:${TAG}" -f examples/${VERSION}/trial-images/pytorch-mnist/Dockerfile .
@@ -130,14 +127,18 @@ else
   echo -e "\nBuilding Keras CIFAR-10 CNN training container example for ENAS with GPU support...\n"
   docker build --platform linux/amd64 -t "${REGISTRY}/enas-cnn-cifar10-gpu:${TAG}" -f examples/${VERSION}/trial-images/enas-cnn-cifar10/Dockerfile.gpu .
 
-  echo -e "\nBuilding Keras CIFAR-10 CNN training container example for ENAS with CPU support...\n"
-  docker build --platform linux/amd64 -t "${REGISTRY}/enas-cnn-cifar10-cpu:${TAG}" -f examples/${VERSION}/trial-images/enas-cnn-cifar10/Dockerfile.cpu .
-
   echo -e "\nBuilding PyTorch CIFAR-10 CNN training container example for DARTS with CPU support...\n"
   docker build --platform linux/amd64 -t "${REGISTRY}/darts-cnn-cifar10-cpu:${TAG}" -f examples/${VERSION}/trial-images/darts-cnn-cifar10/Dockerfile.cpu .
 
   echo -e "\nBuilding PyTorch CIFAR-10 CNN training container example for DARTS with GPU support...\n"
   docker build --platform linux/amd64 -t "${REGISTRY}/darts-cnn-cifar10-gpu:${TAG}" -f examples/${VERSION}/trial-images/darts-cnn-cifar10/Dockerfile.gpu .
+
 fi
+
+echo -e "\nBuilding Tensorflow with summaries mnist training container example...\n"
+docker build --platform "linux/$ARCH" -t "${REGISTRY}/tf-mnist-with-summaries:${TAG}" -f examples/${VERSION}/trial-images/tf-mnist-with-summaries/Dockerfile .
+
+echo -e "\nBuilding Keras CIFAR-10 CNN training container example for ENAS with CPU support...\n"
+docker build --platform "linux/$ARCH" -t "${REGISTRY}/enas-cnn-cifar10-cpu:${TAG}" -f examples/${VERSION}/trial-images/enas-cnn-cifar10/Dockerfile.cpu .
 
 echo -e "\nAll Katib images with ${TAG} tag have been built successfully!\n"


### PR DESCRIPTION
**What this PR does / why we need it**:

 I added codes to change the katib-mysql image to `arm64v8/mysql:8.0.29-oracle` to `examples/v1beta1/kind-cluster/deploy.sh` since we get the following errors when we run KinD Cluster examples on Apple Silicon M1 Mac. 

Also I modified Dockerfile to fix [this TensorFlow issue](https://github.com/tensorflow/tensorflow/issues/52972) in `tf-mnist-with-summaries` and `enas-cnn-cifar10`.

```shell
Events:
  Type     Reason     Age   From               Message
  ----     ------     ----  ----               -------
  Normal   Scheduled  26s   default-scheduler  Successfully assigned kubeflow/katib-mysql-6975d6c6c4-4h2cn to kind-control-plane
  Normal   Pulling    25s   kubelet            Pulling image "mysql:8.0.29"
  Warning  Failed     1s    kubelet            Failed to pull image "mysql:8.0.29": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/library/mysql:8.0.29": no match for platform in manifest: not found
  Warning  Failed     1s    kubelet            Error: ErrImagePull
  Normal   BackOff    1s    kubelet            Back-off pulling image "mysql:8.0.29"
  Warning  Failed     1s    kubelet            Error: ImagePullBackOff
```

In addition, I fixed some following errors when we build some images for arm64.

<details>
<summary> error logs for tfevent-metricscollector 1 </summary>

```shell
 => ERROR [5/6] RUN pip install --no-cache-dir -r requirements.txt                                                                                                                                                                37.5s
------                                                                                                                                                                                                                                  
 > [5/6] RUN pip install --no-cache-dir -r requirements.txt:                                                                                                                                                                            
#9 1.115 Ignoring tensorflow: markers 'platform_machine == "x86_64"' don't match your environment                                                                                                                                       
#9 1.301 Collecting psutil==5.8.0                                                                                                                                                                                                       
#9 34.89 Collecting oauthlib>=3.0.0
#9 34.90   Downloading oauthlib-3.2.0-py3-none-any.whl (151 kB)
#9 34.92      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 151.5/151.5 KB 12.5 MB/s eta 0:00:00
#9 34.99 Building wheels for collected packages: psutil, googleapis-common-protos, termcolor
#9 34.99   Building wheel for psutil (setup.py): started
#9 35.13   Building wheel for psutil (setup.py): finished with status 'error'
#9 35.14   error: subprocess-exited-with-error
#9 35.14   
#9 35.14   × python setup.py bdist_wheel did not run successfully.
#9 35.14   │ exit code: 1
#9 35.14   ╰─> [43 lines of output]
#9 35.14       running bdist_wheel
#9 35.14       running build
#9 35.14       running build_py
#9 35.14       creating build
#9 35.14       creating build/lib.linux-aarch64-3.9
#9 35.14       creating build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_psosx.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_psaix.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_pswindows.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_pssunos.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_psposix.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_common.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_compat.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_pslinux.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_psbsd.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/__init__.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       creating build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_sunos.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_bsd.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_testutils.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_linux.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_system.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_osx.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_aix.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_memleaks.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_misc.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_windows.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/runner.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_unicode.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_process.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/__main__.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_connections.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_posix.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_contracts.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/__init__.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       running build_ext
#9 35.14       building 'psutil._psutil_linux' extension
#9 35.14       creating build/temp.linux-aarch64-3.9
#9 35.14       creating build/temp.linux-aarch64-3.9/psutil
#9 35.14       gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_SIZEOF_PID_T=4 -DPSUTIL_VERSION=580 -DPSUTIL_LINUX=1 -DPSUTIL_ETHTOOL_MISSING_TYPES=1 -I/usr/local/include/python3.9 -c psutil/_psutil_common.c -o build/temp.linux-aarch64-3.9/psutil/_psutil_common.o
#9 35.14       C compiler or Python headers are not installed on this system. Try to run:
#9 35.14       sudo apt-get install gcc python3-dev
#9 35.14       error: command 'gcc' failed: No such file or directory
#9 35.14       [end of output]
#9 35.14   
#9 35.14   note: This error originates from a subprocess, and is likely not a problem with pip.
#9 35.14   ERROR: Failed building wheel for psutil
#9 35.14   Running setup.py clean for psutil
#9 35.26   Building wheel for googleapis-common-protos (setup.py): started
#9 35.42   Building wheel for googleapis-common-protos (setup.py): finished with status 'done'
#9 35.42   Created wheel for googleapis-common-protos: filename=googleapis_common_protos-1.6.0-py3-none-any.whl size=77593 sha256=549ac859f2d3a2c1015f9b8a93c18924865ba392c2bcb4d960e53ceded35d93c
#9 35.42   Stored in directory: /tmp/pip-ephem-wheel-cache-mdsgn90y/wheels/e8/1f/11/8233e1627c658357f6be4ea4e353e54034485fc9496afc333f
#9 35.42   Building wheel for termcolor (setup.py): started
#9 35.54   Building wheel for termcolor (setup.py): finished with status 'done'
#9 35.54   Created wheel for termcolor: filename=termcolor-1.1.0-py3-none-any.whl size=4848 sha256=de51087fa392b8c1c5659173cad37c613c36461341bdc8fcaa9b65354db58038
#9 35.54   Stored in directory: /tmp/pip-ephem-wheel-cache-mdsgn90y/wheels/b6/0d/90/0d1bbd99855f99cb2f6c2e5ff96f8023fad8ec367695f7d72d
#9 35.54 Successfully built googleapis-common-protos termcolor
#9 35.54 Failed to build psutil
#9 35.66 Installing collected packages: termcolor, tensorboard-plugin-wit, rfc3339, pyasn1, libclang, keras, flatbuffers, zipp, wrapt, werkzeug, urllib3, typing-extensions, tensorflow-io-gcs-filesystem, tensorflow-estimator, tensorboard-data-server, six, rsa, pyparsing, pyasn1-modules, psutil, protobuf, oauthlib, numpy, idna, gast, charset-normalizer, certifi, cachetools, absl-py, requests, packaging, opt-einsum, keras-preprocessing, importlib-metadata, h5py, grpcio, googleapis-common-protos, google-pasta, google-auth, astunparse, requests-oauthlib, markdown, google-auth-oauthlib, tensorboard, tensorflow-aarch64
#9 37.03   Running setup.py install for psutil: started
#9 37.15   Running setup.py install for psutil: finished with status 'error'
#9 37.16   error: subprocess-exited-with-error
#9 37.16   
#9 37.16   × Running setup.py install for psutil did not run successfully.
#9 37.16   │ exit code: 1
#9 37.16   ╰─> [43 lines of output]
#9 37.16       running install
#9 37.16       running build
#9 37.16       running build_py
#9 37.16       creating build
#9 37.16       creating build/lib.linux-aarch64-3.9
#9 37.16       creating build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_psosx.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_psaix.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_pswindows.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_pssunos.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_psposix.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_common.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_compat.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_pslinux.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_psbsd.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/__init__.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       creating build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_sunos.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_bsd.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_testutils.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_linux.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_system.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_osx.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_aix.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_memleaks.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_misc.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_windows.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/runner.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_unicode.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_process.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/__main__.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_connections.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_posix.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_contracts.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/__init__.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       running build_ext
#9 37.16       building 'psutil._psutil_linux' extension
#9 37.16       creating build/temp.linux-aarch64-3.9
#9 37.16       creating build/temp.linux-aarch64-3.9/psutil
#9 37.16       gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_SIZEOF_PID_T=4 -DPSUTIL_VERSION=580 -DPSUTIL_LINUX=1 -DPSUTIL_ETHTOOL_MISSING_TYPES=1 -I/usr/local/include/python3.9 -c psutil/_psutil_common.c -o build/temp.linux-aarch64-3.9/psutil/_psutil_common.o
#9 37.16       C compiler or Python headers are not installed on this system. Try to run:
#9 37.16       sudo apt-get install gcc python3-dev
#9 37.16       error: command 'gcc' failed: No such file or directory
#9 37.16       [end of output]
#9 37.16   
#9 37.16   note: This error originates from a subprocess, and is likely not a problem with pip.
#9 37.16 error: legacy-install-failure
#9 37.16 
#9 37.16 × Encountered error while trying to install package.
#9 37.16 ╰─> psutil
#9 37.16 
#9 37.16 note: This is an issue with the package mentioned above, not pip.
#9 37.16 hint: See above for output from the failure.
#9 37.23 WARNING: You are using pip version 22.0.4; however, version 22.1.2 is available.
#9 37.23 You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
------
executor failed running [/bin/sh -c pip install --no-cache-dir -r requirements.txt]: exit code: 1
```

</details>

<details>
<summary> error logs for tfevent-metricscollector 2 </summary>

```shell
 => ERROR [5/6] RUN pip install --no-cache-dir -r requirements.txt                                                                                                                                                                37.5s
------                                                                                                                                                                                                                                  
 > [5/6] RUN pip install --no-cache-dir -r requirements.txt:                                                                                                                                                                            
#9 1.115 Ignoring tensorflow: markers 'platform_machine == "x86_64"' don't match your environment                                                                                                                                       
#9 1.301 Collecting psutil==5.8.0                                                                                                                                                                                                       
#9 34.89 Collecting oauthlib>=3.0.0
#9 34.90   Downloading oauthlib-3.2.0-py3-none-any.whl (151 kB)
#9 34.92      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 151.5/151.5 KB 12.5 MB/s eta 0:00:00
#9 34.99 Building wheels for collected packages: psutil, googleapis-common-protos, termcolor
#9 34.99   Building wheel for psutil (setup.py): started
#9 35.13   Building wheel for psutil (setup.py): finished with status 'error'
#9 35.14   error: subprocess-exited-with-error
#9 35.14   
#9 35.14   × python setup.py bdist_wheel did not run successfully.
#9 35.14   │ exit code: 1
#9 35.14   ╰─> [43 lines of output]
#9 35.14       running bdist_wheel
#9 35.14       running build
#9 35.14       running build_py
#9 35.14       creating build
#9 35.14       creating build/lib.linux-aarch64-3.9
#9 35.14       creating build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_psosx.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_psaix.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_pswindows.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_pssunos.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_psposix.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_common.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_compat.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_pslinux.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/_psbsd.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       copying psutil/__init__.py -> build/lib.linux-aarch64-3.9/psutil
#9 35.14       creating build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_sunos.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_bsd.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_testutils.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_linux.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_system.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_osx.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_aix.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_memleaks.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_misc.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_windows.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/runner.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_unicode.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_process.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/__main__.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_connections.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_posix.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/test_contracts.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       copying psutil/tests/__init__.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 35.14       running build_ext
#9 35.14       building 'psutil._psutil_linux' extension
#9 35.14       creating build/temp.linux-aarch64-3.9
#9 35.14       creating build/temp.linux-aarch64-3.9/psutil
#9 35.14       gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_SIZEOF_PID_T=4 -DPSUTIL_VERSION=580 -DPSUTIL_LINUX=1 -DPSUTIL_ETHTOOL_MISSING_TYPES=1 -I/usr/local/include/python3.9 -c psutil/_psutil_common.c -o build/temp.linux-aarch64-3.9/psutil/_psutil_common.o
#9 35.14       C compiler or Python headers are not installed on this system. Try to run:
#9 35.14       sudo apt-get install gcc python3-dev
#9 35.14       error: command 'gcc' failed: No such file or directory
#9 35.14       [end of output]
#9 35.14   
#9 35.14   note: This error originates from a subprocess, and is likely not a problem with pip.
#9 35.14   ERROR: Failed building wheel for psutil
#9 35.14   Running setup.py clean for psutil
#9 35.26   Building wheel for googleapis-common-protos (setup.py): started
#9 35.42   Building wheel for googleapis-common-protos (setup.py): finished with status 'done'
#9 35.42   Created wheel for googleapis-common-protos: filename=googleapis_common_protos-1.6.0-py3-none-any.whl size=77593 sha256=549ac859f2d3a2c1015f9b8a93c18924865ba392c2bcb4d960e53ceded35d93c
#9 35.42   Stored in directory: /tmp/pip-ephem-wheel-cache-mdsgn90y/wheels/e8/1f/11/8233e1627c658357f6be4ea4e353e54034485fc9496afc333f
#9 35.42   Building wheel for termcolor (setup.py): started
#9 35.54   Building wheel for termcolor (setup.py): finished with status 'done'
#9 35.54   Created wheel for termcolor: filename=termcolor-1.1.0-py3-none-any.whl size=4848 sha256=de51087fa392b8c1c5659173cad37c613c36461341bdc8fcaa9b65354db58038
#9 35.54   Stored in directory: /tmp/pip-ephem-wheel-cache-mdsgn90y/wheels/b6/0d/90/0d1bbd99855f99cb2f6c2e5ff96f8023fad8ec367695f7d72d
#9 35.54 Successfully built googleapis-common-protos termcolor
#9 35.54 Failed to build psutil
#9 35.66 Installing collected packages: termcolor, tensorboard-plugin-wit, rfc3339, pyasn1, libclang, keras, flatbuffers, zipp, wrapt, werkzeug, urllib3, typing-extensions, tensorflow-io-gcs-filesystem, tensorflow-estimator, tensorboard-data-server, six, rsa, pyparsing, pyasn1-modules, psutil, protobuf, oauthlib, numpy, idna, gast, charset-normalizer, certifi, cachetools, absl-py, requests, packaging, opt-einsum, keras-preprocessing, importlib-metadata, h5py, grpcio, googleapis-common-protos, google-pasta, google-auth, astunparse, requests-oauthlib, markdown, google-auth-oauthlib, tensorboard, tensorflow-aarch64
#9 37.03   Running setup.py install for psutil: started
#9 37.15   Running setup.py install for psutil: finished with status 'error'
#9 37.16   error: subprocess-exited-with-error
#9 37.16   
#9 37.16   × Running setup.py install for psutil did not run successfully.
#9 37.16   │ exit code: 1
#9 37.16   ╰─> [43 lines of output]
#9 37.16       running install
#9 37.16       running build
#9 37.16       running build_py
#9 37.16       creating build
#9 37.16       creating build/lib.linux-aarch64-3.9
#9 37.16       creating build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_psosx.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_psaix.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_pswindows.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_pssunos.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_psposix.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_common.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_compat.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_pslinux.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/_psbsd.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       copying psutil/__init__.py -> build/lib.linux-aarch64-3.9/psutil
#9 37.16       creating build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_sunos.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_bsd.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_testutils.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_linux.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_system.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_osx.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_aix.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_memleaks.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_misc.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_windows.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/runner.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_unicode.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_process.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/__main__.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_connections.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_posix.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/test_contracts.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       copying psutil/tests/__init__.py -> build/lib.linux-aarch64-3.9/psutil/tests
#9 37.16       running build_ext
#9 37.16       building 'psutil._psutil_linux' extension
#9 37.16       creating build/temp.linux-aarch64-3.9
#9 37.16       creating build/temp.linux-aarch64-3.9/psutil
#9 37.16       gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_SIZEOF_PID_T=4 -DPSUTIL_VERSION=580 -DPSUTIL_LINUX=1 -DPSUTIL_ETHTOOL_MISSING_TYPES=1 -I/usr/local/include/python3.9 -c psutil/_psutil_common.c -o build/temp.linux-aarch64-3.9/psutil/_psutil_common.o
#9 37.16       C compiler or Python headers are not installed on this system. Try to run:
#9 37.16       sudo apt-get install gcc python3-dev
#9 37.16       error: command 'gcc' failed: No such file or directory
#9 37.16       [end of output]
#9 37.16   
#9 37.16   note: This error originates from a subprocess, and is likely not a problem with pip.
#9 37.16 error: legacy-install-failure
#9 37.16 
#9 37.16 × Encountered error while trying to install package.
#9 37.16 ╰─> psutil
#9 37.16 
#9 37.16 note: This is an issue with the package mentioned above, not pip.
#9 37.16 hint: See above for output from the failure.
#9 37.23 WARNING: You are using pip version 22.0.4; however, version 22.1.2 is available.
#9 37.23 You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
------
executor failed running [/bin/sh -c pip install --no-cache-dir -r requirements.txt]: exit code: 1
```

</details>

<details>
<summary> error logs for suggestion-chocolate 1 </summary>

```shell
=> ERROR [stage-1 7/8] RUN pip install --no-cache-dir -r requirements.txt                                                                                                                                                        22.0s
------
 > [stage-1 7/8] RUN pip install --no-cache-dir -r requirements.txt:
#14 1.132 Collecting git+https://github.com/AIworx-Labs/chocolate@master (from -r requirements.txt (line 10))
#14 20.51 Collecting MarkupSafe>=0.9.2
#14 20.52   Downloading MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (26 kB)
#14 20.52 Building wheels for collected packages: googleapis-common-protos, chocolate, ghalton
#14 20.52   Building wheel for googleapis-common-protos (setup.py): started
#14 20.71   Building wheel for googleapis-common-protos (setup.py): finished with status 'done'
#14 20.71   Created wheel for googleapis-common-protos: filename=googleapis_common_protos-1.6.0-py3-none-any.whl size=77593 sha256=6fdb27eedcd49934c77a66aaa50c71e2123e633f2feff2c3aeed969bdaf1c926
#14 20.71   Stored in directory: /tmp/pip-ephem-wheel-cache-pyd5c_jf/wheels/e8/1f/11/8233e1627c658357f6be4ea4e353e54034485fc9496afc333f
#14 20.71   Building wheel for chocolate (setup.py): started
#14 21.05   Building wheel for chocolate (setup.py): finished with status 'done'
#14 21.05   Created wheel for chocolate: filename=chocolate-0.6-cp39-cp39-linux_aarch64.whl size=43127 sha256=00873b40dd1c883af4a739b1b19e491d160949bce16008d373e581518619696f
#14 21.05   Stored in directory: /tmp/pip-ephem-wheel-cache-pyd5c_jf/wheels/68/33/a2/82eeb15c0669e449fb81d64e03ebb1f04a97338857164087d1
#14 21.05   Building wheel for ghalton (setup.py): started
#14 21.16   Building wheel for ghalton (setup.py): finished with status 'error'
#14 21.17   error: subprocess-exited-with-error
#14 21.17   
#14 21.17   × python setup.py bdist_wheel did not run successfully.
#14 21.17   │ exit code: 1
#14 21.17   ╰─> [17 lines of output]
#14 21.17       running bdist_wheel
#14 21.17       running build
#14 21.17       running build_py
#14 21.17       creating build
#14 21.17       creating build/lib.linux-aarch64-3.9
#14 21.17       creating build/lib.linux-aarch64-3.9/ghalton
#14 21.17       copying ghalton/constants.py -> build/lib.linux-aarch64-3.9/ghalton
#14 21.17       copying ghalton/ghalton_wrapper.py -> build/lib.linux-aarch64-3.9/ghalton
#14 21.17       copying ghalton/__init__.py -> build/lib.linux-aarch64-3.9/ghalton
#14 21.17       running build_ext
#14 21.17       building 'ghalton._ghalton_wrapper' extension
#14 21.17       creating build/temp.linux-aarch64-3.9
#14 21.17       creating build/temp.linux-aarch64-3.9/src
#14 21.17       gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/local/include/python3.9 -c src/Halton.cpp -o build/temp.linux-aarch64-3.9/src/Halton.o
#14 21.17       gcc: fatal error: cannot execute ‘cc1plus’: execvp: No such file or directory
#14 21.17       compilation terminated.
#14 21.17       error: command '/usr/bin/gcc' failed with exit code 1
#14 21.17       [end of output]
#14 21.17   
#14 21.17   note: This error originates from a subprocess, and is likely not a problem with pip.
#14 21.17   ERROR: Failed building wheel for ghalton
#14 21.17   Running setup.py clean for ghalton
#14 21.27 Successfully built googleapis-common-protos chocolate
#14 21.27 Failed to build ghalton
#14 21.38 Installing collected packages: pytz, nose, ghalton, cloudpickle, banal, threadpoolctl, six, protobuf, numpy, MarkupSafe, joblib, greenlet, filelock, cython, SQLAlchemy, scipy, python-dateutil, Mako, grpcio, googleapis-common-protos, scikit-learn, pandas, alembic, forestci, dataset, chocolate
#14 21.50   Running setup.py install for ghalton: started
#14 21.60   Running setup.py install for ghalton: finished with status 'error'
#14 21.60   error: subprocess-exited-with-error
#14 21.60   
#14 21.60   × Running setup.py install for ghalton did not run successfully.
#14 21.60   │ exit code: 1
#14 21.60   ╰─> [17 lines of output]
#14 21.60       running install
#14 21.60       running build
#14 21.60       running build_py
#14 21.60       creating build
#14 21.60       creating build/lib.linux-aarch64-3.9
#14 21.60       creating build/lib.linux-aarch64-3.9/ghalton
#14 21.60       copying ghalton/constants.py -> build/lib.linux-aarch64-3.9/ghalton
#14 21.60       copying ghalton/ghalton_wrapper.py -> build/lib.linux-aarch64-3.9/ghalton
#14 21.60       copying ghalton/__init__.py -> build/lib.linux-aarch64-3.9/ghalton
#14 21.60       running build_ext
#14 21.60       building 'ghalton._ghalton_wrapper' extension
#14 21.60       creating build/temp.linux-aarch64-3.9
#14 21.60       creating build/temp.linux-aarch64-3.9/src
#14 21.60       gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/local/include/python3.9 -c src/Halton.cpp -o build/temp.linux-aarch64-3.9/src/Halton.o
#14 21.60       gcc: fatal error: cannot execute ‘cc1plus’: execvp: No such file or directory
#14 21.60       compilation terminated.
#14 21.60       error: command '/usr/bin/gcc' failed with exit code 1
#14 21.60       [end of output]
#14 21.60   
#14 21.60   note: This error originates from a subprocess, and is likely not a problem with pip.
#14 21.60 error: legacy-install-failure
#14 21.60 
#14 21.60 × Encountered error while trying to install package.
#14 21.60 ╰─> ghalton
#14 21.60 
#14 21.60 note: This is an issue with the package mentioned above, not pip.
#14 21.60 hint: See above for output from the failure.
#14 21.75 WARNING: You are using pip version 22.0.4; however, version 22.1.2 is available.
#14 21.75 You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
------
executor failed running [/bin/sh -c pip install --no-cache-dir -r requirements.txt]: exit code: 1
```

</details>

<details>
<summary> error logs for suggestion-chocolate 2 </summary>

```shell
=> ERROR [stage-1 7/8] RUN pip install --no-cache-dir -r requirements.txt                                                                                                                                                        22.6s
------
 > [stage-1 7/8] RUN pip install --no-cache-dir -r requirements.txt:
#14 1.149 Collecting git+https://github.com/AIworx-Labs/chocolate@master (from -r requirements.txt (line 10))
#14 21.21 Collecting MarkupSafe>=0.9.2
#14 21.22   Downloading MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl (26 kB)
#14 21.23 Building wheels for collected packages: googleapis-common-protos, chocolate, ghalton
#14 21.23   Building wheel for googleapis-common-protos (setup.py): started
#14 21.42   Building wheel for googleapis-common-protos (setup.py): finished with status 'done'
#14 21.42   Created wheel for googleapis-common-protos: filename=googleapis_common_protos-1.6.0-py3-none-any.whl size=77593 sha256=6a6b2f066bd8797cef36124bb0cb2586470ac28b1a5384aa49c2a7db75986dbc
#14 21.42   Stored in directory: /tmp/pip-ephem-wheel-cache-w9_d5wnc/wheels/e8/1f/11/8233e1627c658357f6be4ea4e353e54034485fc9496afc333f
#14 21.42   Building wheel for chocolate (setup.py): started
#14 21.76   Building wheel for chocolate (setup.py): finished with status 'done'
#14 21.76   Created wheel for chocolate: filename=chocolate-0.6-cp39-cp39-linux_aarch64.whl size=43127 sha256=88c568c252a686725638e364ca5667036564fdb9bf47b9e2cdd2d6f6f213c5a1
#14 21.76   Stored in directory: /tmp/pip-ephem-wheel-cache-w9_d5wnc/wheels/68/33/a2/82eeb15c0669e449fb81d64e03ebb1f04a97338857164087d1
#14 21.76   Building wheel for ghalton (setup.py): started
#14 21.87   Building wheel for ghalton (setup.py): finished with status 'error'
#14 21.88   error: subprocess-exited-with-error
#14 21.88   
#14 21.88   × python setup.py bdist_wheel did not run successfully.
#14 21.88   │ exit code: 1
#14 21.88   ╰─> [17 lines of output]
#14 21.88       running bdist_wheel
#14 21.88       running build
#14 21.88       running build_py
#14 21.88       creating build
#14 21.88       creating build/lib.linux-aarch64-3.9
#14 21.88       creating build/lib.linux-aarch64-3.9/ghalton
#14 21.88       copying ghalton/constants.py -> build/lib.linux-aarch64-3.9/ghalton
#14 21.88       copying ghalton/ghalton_wrapper.py -> build/lib.linux-aarch64-3.9/ghalton
#14 21.88       copying ghalton/__init__.py -> build/lib.linux-aarch64-3.9/ghalton
#14 21.88       running build_ext
#14 21.88       building 'ghalton._ghalton_wrapper' extension
#14 21.88       creating build/temp.linux-aarch64-3.9
#14 21.88       creating build/temp.linux-aarch64-3.9/src
#14 21.88       gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/local/include/python3.9 -c src/Halton.cpp -o build/temp.linux-aarch64-3.9/src/Halton.o
#14 21.88       gcc: fatal error: cannot execute ‘cc1plus’: execvp: No such file or directory
#14 21.88       compilation terminated.
#14 21.88       error: command '/usr/bin/gcc' failed with exit code 1
#14 21.88       [end of output]
#14 21.88   
#14 21.88   note: This error originates from a subprocess, and is likely not a problem with pip.
#14 21.88   ERROR: Failed building wheel for ghalton
#14 21.88   Running setup.py clean for ghalton
#14 21.98 Successfully built googleapis-common-protos chocolate
#14 21.98 Failed to build ghalton
#14 22.09 Installing collected packages: pytz, nose, ghalton, cloudpickle, banal, threadpoolctl, six, protobuf, numpy, MarkupSafe, joblib, greenlet, filelock, cython, SQLAlchemy, scipy, python-dateutil, Mako, grpcio, googleapis-common-protos, scikit-learn, pandas, alembic, forestci, dataset, chocolate
#14 22.21   Running setup.py install for ghalton: started
#14 22.31   Running setup.py install for ghalton: finished with status 'error'
#14 22.31   error: subprocess-exited-with-error
#14 22.31   
#14 22.31   × Running setup.py install for ghalton did not run successfully.
#14 22.31   │ exit code: 1
#14 22.31   ╰─> [17 lines of output]
#14 22.31       running install
#14 22.31       running build
#14 22.31       running build_py
#14 22.31       creating build
#14 22.31       creating build/lib.linux-aarch64-3.9
#14 22.31       creating build/lib.linux-aarch64-3.9/ghalton
#14 22.31       copying ghalton/constants.py -> build/lib.linux-aarch64-3.9/ghalton
#14 22.31       copying ghalton/ghalton_wrapper.py -> build/lib.linux-aarch64-3.9/ghalton
#14 22.31       copying ghalton/__init__.py -> build/lib.linux-aarch64-3.9/ghalton
#14 22.31       running build_ext
#14 22.31       building 'ghalton._ghalton_wrapper' extension
#14 22.31       creating build/temp.linux-aarch64-3.9
#14 22.31       creating build/temp.linux-aarch64-3.9/src
#14 22.31       gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/local/include/python3.9 -c src/Halton.cpp -o build/temp.linux-aarch64-3.9/src/Halton.o
#14 22.31       gcc: fatal error: cannot execute ‘cc1plus’: execvp: No such file or directory
#14 22.31       compilation terminated.
#14 22.31       error: command '/usr/bin/gcc' failed with exit code 1
#14 22.31       [end of output]
#14 22.31   
#14 22.31   note: This error originates from a subprocess, and is likely not a problem with pip.
#14 22.31 error: legacy-install-failure
#14 22.31 
#14 22.31 × Encountered error while trying to install package.
#14 22.31 ╰─> ghalton
#14 22.31 
#14 22.31 note: This is an issue with the package mentioned above, not pip.
#14 22.31 hint: See above for output from the failure.
#14 22.38 WARNING: You are using pip version 22.0.4; however, version 22.1.2 is available.
#14 22.38 You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
------
executor failed running [/bin/sh -c pip install --no-cache-dir -r requirements.txt]: exit code: 1
```

</details>

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
