### PR TITLE
Change integration test sysytem from KinD Cluster to Minikube Cluster 

### DIFF
--- a/.github/workflows/darts-cifar10-e2e-test.yaml
+++ b/.github/workflows/darts-cifar10-e2e-test.yaml
@@ -2,6 +2,9 @@ name: E2E Test with darts-cnn-cifar10
 on:
   - pull_request
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   e2e:
     runs-on: ubuntu-20.04
@@ -25,9 +28,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Detail: https://hub.docker.com/r/kindest/node
         # TODO (tenzen-y): We need to consider running tests on more kubernetes versions.
-        # kubernetes-version: ["v1.20.15", "v1.21.12", "v1.22.9", "v1.23.6", "v1.24.1"]
-        kubernetes-version: ["v1.21.12", "v1.22.9", "v1.23.6"]
+        # kubernetes-version: ["v1.20.15", "v1.21.13", "v1.22.10", "v1.23.7", "v1.24.1"]
+        kubernetes-version: ["v1.21.13", "v1.22.10", "v1.23.7"]
         # Comma Delimited
         experiments: ["darts-cpu"]

--- a/.github/workflows/enas-cifar10-e2e-test.yaml
+++ b/.github/workflows/enas-cifar10-e2e-test.yaml
@@ -2,6 +2,9 @@ name: E2E Test with enas-cnn-cifar10
 on:
   - pull_request
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   e2e:
     runs-on: ubuntu-20.04
@@ -25,9 +28,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Detail: https://hub.docker.com/r/kindest/node
         # TODO (tenzen-y): We need to consider running tests on more kubernetes versions.
-        # kubernetes-version: ["v1.20.15", "v1.21.12", "v1.22.9", "v1.23.6", "v1.24.1"]
-        kubernetes-version: ["v1.21.12", "v1.22.9", "v1.23.6"]
+        # kubernetes-version: ["v1.20.15", "v1.21.13", "v1.22.10", "v1.23.7", "v1.24.1"]
+        kubernetes-version: ["v1.21.13", "v1.22.10", "v1.23.7"]
         # Comma Delimited
         experiments: ["enas-cpu"]

--- a/.github/workflows/katib-ui-e2e-test.yaml
+++ b/.github/workflows/katib-ui-e2e-test.yaml
@@ -2,6 +2,9 @@ name: E2E Test for katib-ui
 on:
   - pull_request
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   e2e:
     runs-on: ubuntu-20.04
@@ -15,8 +18,8 @@ jobs:
         with:
           kubernetes-version: ${{ matrix.kubernetes-version }}
 
-      - name: Set Up KinD Cluster
-        run: ./test/e2e/v1beta1/scripts/gh-actions/setup-kind.sh true
+      - name: Set Up Minikube Cluster
+        run: ./test/e2e/v1beta1/scripts/gh-actions/setup-minikube.sh true
 
       - name: Start Katib
         run: ./test/e2e/v1beta1/scripts/gh-actions/setup-katib.sh true false
@@ -24,7 +27,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Detail: https://hub.docker.com/r/kindest/node
         # TODO (tenzen-y): We need to consider running tests on more kubernetes versions.
-        # kubernetes-version: ["v1.20.15", "v1.21.12", "v1.22.9", "v1.23.6", "v1.24.1"]
-        kubernetes-version: ["v1.21.12", "v1.22.9", "v1.23.6"]
+        # kubernetes-version: ["v1.20.15", "v1.21.13", "v1.22.10", "v1.23.7", "v1.24.1"]
+        kubernetes-version: ["v1.21.13", "v1.22.10", "v1.23.7"]

--- a/.github/workflows/mxnet-mnist-e2e-test.yaml
+++ b/.github/workflows/mxnet-mnist-e2e-test.yaml
@@ -2,6 +2,9 @@ name: E2E Test with mxnet-mnist
 on:
   - pull_request
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   e2e:
     runs-on: ubuntu-20.04
@@ -25,10 +28,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Detail: https://hub.docker.com/r/kindest/node
         # TODO (tenzen-y): We need to consider running tests on more kubernetes versions.
-        # kubernetes-version: ["v1.20.15", "v1.21.12", "v1.22.9", "v1.23.6", "v1.24.1"]
-        kubernetes-version: ["v1.21.12", "v1.22.9", "v1.23.6"]
+        # kubernetes-version: ["v1.20.15", "v1.21.13", "v1.22.10", "v1.23.7", "v1.24.1"]
+        kubernetes-version: ["v1.21.13", "v1.22.10", "v1.23.7"]
         # Comma Delimited
         experiments:
           # suggestion-hyperopt

--- a/.github/workflows/pytorch-mnist-e2e-test.yaml
+++ b/.github/workflows/pytorch-mnist-e2e-test.yaml
@@ -2,6 +2,9 @@ name: E2E Test with pytorch-mnist
 on:
   - pull_request
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   e2e:
     runs-on: ubuntu-20.04
@@ -26,10 +29,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Detail: https://hub.docker.com/r/kindest/node
         # TODO (tenzen-y): We need to consider running tests on more kubernetes versions.
-        # kubernetes-version: ["v1.20.15", "v1.21.12", "v1.22.9", "v1.23.6", "v1.24.1"]
-        kubernetes-version: ["v1.21.12", "v1.22.9", "v1.23.6"]
+        # kubernetes-version: ["v1.20.15", "v1.21.13", "v1.22.10", "v1.23.7", "v1.24.1"]
+        kubernetes-version: ["v1.21.13", "v1.22.10", "v1.23.7"]
         # Comma Delimited
         experiments:
           - "file-metrics-collector,pytorchjob-mnist"

--- a/.github/workflows/template-e2e-test/action.yaml
+++ b/.github/workflows/template-e2e-test/action.yaml
@@ -1,10 +1,6 @@
 # Template for e2e tests.
 
 inputs:
-  cluster_name:
-    required: false
-    type: string
-    default: katib-e2e-cluster
   experiments:
     required: true
     type: string
@@ -22,9 +18,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set Up KinD Cluster
+    - name: Set Up Minikube Cluster
       shell: bash
-      run: ./test/e2e/v1beta1/scripts/gh-actions/setup-kind.sh ${{ inputs.katib-ui }} ${{ inputs.trial-images }} ${{ inputs.cluster_name }} ${{ inputs.experiments }}
+      run: ./test/e2e/v1beta1/scripts/gh-actions/setup-minikube.sh ${{ inputs.katib-ui }} ${{ inputs.trial-images }} ${{ inputs.experiments }}
 
     - name: Set Up Katib
       shell: bash

--- a/.github/workflows/template-setup-e2e-test/action.yaml
+++ b/.github/workflows/template-setup-e2e-test/action.yaml
@@ -4,21 +4,17 @@ inputs:
   kubernetes-version:
     required: true
     type: string
-  cluster_name:
-    required: false
-    type: string
-    default: katib-e2e-cluster
 
 runs:
   using: composite
   steps:
-    - name: Set Up KinD Cluster
-      uses: helm/kind-action@v1.2.0
+    - name: Set Up Minikube Cluster
+      uses: manusa/actions-setup-minikube@v2.6.0
       with:
-        version: v0.13.0
-        node_image: kindest/node:${{ inputs.kubernetes-version }}
-        cluster_name: ${{ inputs.cluster_name }}
-        wait: 120s
+        minikube version: "v1.25.2"
+        kubernetes version: ${{ inputs.kubernetes-version }}
+        start args: --driver none --wait-timeout=60s
+        github token: ${{ env.GITHUB_TOKEN }}
 
     - name: Set Up Docker Buildx
       uses: docker/setup-buildx-action@v1

--- a/.github/workflows/tf-mnist-with-summaries-e2e-test.yaml
+++ b/.github/workflows/tf-mnist-with-summaries-e2e-test.yaml
@@ -2,6 +2,9 @@ name: E2E Test with tf-mnist-with-summaries
 on:
   - pull_request
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   e2e:
     runs-on: ubuntu-20.04
@@ -26,9 +29,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Detail: https://hub.docker.com/r/kindest/node
         # TODO (tenzen-y): We need to consider running tests on more kubernetes versions.
-        # kubernetes-version: ["v1.20.15", "v1.21.12", "v1.22.9", "v1.23.6", "v1.24.1"]
-        kubernetes-version: ["v1.21.12", "v1.22.9", "v1.23.6"]
+        # kubernetes-version: ["v1.20.15", "v1.21.13", "v1.22.10", "v1.23.7", "v1.24.1"]
+        kubernetes-version: ["v1.21.13", "v1.22.10", "v1.23.7"]
         # Comma Delimited
         experiments: ["tfjob-mnist-with-summaries"]

--- a/test/e2e/v1beta1/scripts/gh-actions/build-load.sh
+++ b/test/e2e/v1beta1/scripts/gh-actions/build-load.sh
@@ -23,9 +23,8 @@ set -o nounset
 cd "$(dirname "$0")"
 
 TRIAL_IMAGES=${1:-""}
-CLUSTER_NAME=${2:-""}
-EXPERIMENTS=${3:-""}
-DEPLOY_KATIB_UI=${4:-false}
+EXPERIMENTS=${2:-""}
+DEPLOY_KATIB_UI=${3:-false}
 
 REGISTRY="docker.io/kubeflowkatib"
 TAG="e2e-test"
@@ -55,8 +54,8 @@ _build_containers() {
 _load_kind_cluster() {
   CONTAINER_NAME=${1:-"katib-controller"}
 
-  echo -e "\nLoading $CONTAINER_NAME image to $CLUSTER_NAME...\n"
-  kind load docker-image "$REGISTRY/$CONTAINER_NAME:$TAG" --name "$CLUSTER_NAME"
+  echo -e "\n\nLoading $CONTAINER_NAME image...\n\n"
+  minikube image load "$REGISTRY/$CONTAINER_NAME:$TAG"
 }
 
 _install_tools() {

--- a/test/e2e/v1beta1/scripts/gh-actions/setup-minikube.sh
+++ b/test/e2e/v1beta1/scripts/gh-actions/setup-minikube.sh
@@ -23,13 +23,12 @@ cd "$(dirname "$0")"
 
 DEPLOY_KATIB_UI=${1:-false}
 TRIAL_IMAGES=${2:-""}
-CLUSTER_NAME=${3:-"katib-e2e-cluster"}
-EXPERIMENTS=${4:-""}
+EXPERIMENTS=${3:-""}
 
-echo "Start to setup KinD Kubernetes Cluster"
-kubectl wait --for condition=ready --timeout=5m node "$CLUSTER_NAME-control-plane"
+echo "Start to setup Minikube Kubernetes Cluster"
 kubectl version
 kubectl cluster-info
 kubectl get nodes
+
 echo "Build and Load container images"
-./build-load.sh "$TRIAL_IMAGES" "$CLUSTER_NAME" "$EXPERIMENTS" "$DEPLOY_KATIB_UI"
+./build-load.sh "$TRIAL_IMAGES" "$EXPERIMENTS" "$DEPLOY_KATIB_UI"


### PR DESCRIPTION
**What this PR does / why we need it**:
As discussed in our community meeting, we need to change the integration test system from KinD Cluster to Minikube Cluster to be able to use RWX PVC. 

/assign @johnugeorge @andreyvelich 

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
