### PR TITLE
Fixes lint warnings in YAML files

### DIFF
--- a/examples/v1beta1/argo/argo-workflow.yaml
+++ b/examples/v1beta1/argo/argo-workflow.yaml
@@ -1,3 +1,4 @@
+---
 # This example shows how you can use Argo Workflows in Katib, transfer parameters from one Step to another and run HP job.
 # It uses a simple random algorithm and tunes only learning rate.
 # Workflow contains 2 Steps, first is data-preprocessing second is model-training.

--- a/examples/v1beta1/early-stopping/median-stop-with-json-format.yaml
+++ b/examples/v1beta1/early-stopping/median-stop-with-json-format.yaml
@@ -1,3 +1,4 @@
+---
 # This is example with median stopping early stopping rule with logs in JSON format.
 # It has bad feasible space for learning rate to show more early stopped Trials.
 apiVersion: kubeflow.org/v1beta1

--- a/examples/v1beta1/early-stopping/median-stop.yaml
+++ b/examples/v1beta1/early-stopping/median-stop.yaml
@@ -1,3 +1,4 @@
+---
 # This is example with median stopping early stopping rule.
 # It has bad feasible space for learning rate to show more early stopped Trials.
 apiVersion: kubeflow.org/v1beta1

--- a/examples/v1beta1/hp-tuning/bayesian-optimization.yaml
+++ b/examples/v1beta1/hp-tuning/bayesian-optimization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/hp-tuning/cma-es.yaml
+++ b/examples/v1beta1/hp-tuning/cma-es.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/hp-tuning/grid.yaml
+++ b/examples/v1beta1/hp-tuning/grid.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/hp-tuning/hyperband.yaml
+++ b/examples/v1beta1/hp-tuning/hyperband.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/hp-tuning/multivariate-tpe.yaml
+++ b/examples/v1beta1/hp-tuning/multivariate-tpe.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/hp-tuning/random.yaml
+++ b/examples/v1beta1/hp-tuning/random.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/hp-tuning/simple-pbt.yaml
+++ b/examples/v1beta1/hp-tuning/simple-pbt.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/hp-tuning/sobol.yaml
+++ b/examples/v1beta1/hp-tuning/sobol.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/hp-tuning/tpe.yaml
+++ b/examples/v1beta1/hp-tuning/tpe.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/kubeflow-training-operator/mpijob-horovod.yaml
+++ b/examples/v1beta1/kubeflow-training-operator/mpijob-horovod.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/kubeflow-training-operator/mxjob-byteps.yaml
+++ b/examples/v1beta1/kubeflow-training-operator/mxjob-byteps.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/kubeflow-training-operator/pytorchjob-mnist.yaml
+++ b/examples/v1beta1/kubeflow-training-operator/pytorchjob-mnist.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/kubeflow-training-operator/tfjob-mnist-with-summaries.yaml
+++ b/examples/v1beta1/kubeflow-training-operator/tfjob-mnist-with-summaries.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/kubeflow-training-operator/xgboostjob-lightgbm.yaml
+++ b/examples/v1beta1/kubeflow-training-operator/xgboostjob-lightgbm.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/metrics-collector/custom-metrics-collector.yaml
+++ b/examples/v1beta1/metrics-collector/custom-metrics-collector.yaml
@@ -1,3 +1,4 @@
+---
 # TODO (andreyvelich) This metrics collector image (kubeflowkatib/custom-metrics-collector) doesn't work in v1beta1.
 # It is currently using api.v1.alpha3.Manager instead of api.v1.beta1.Manager to report metrics.
 apiVersion: kubeflow.org/v1beta1

--- a/examples/v1beta1/metrics-collector/file-metrics-collector-with-json-format.yaml
+++ b/examples/v1beta1/metrics-collector/file-metrics-collector-with-json-format.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/metrics-collector/file-metrics-collector.yaml
+++ b/examples/v1beta1/metrics-collector/file-metrics-collector.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/metrics-collector/metrics-collection-strategy.yaml
+++ b/examples/v1beta1/metrics-collector/metrics-collection-strategy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/nas/darts-cpu.yaml
+++ b/examples/v1beta1/nas/darts-cpu.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/nas/darts-gpu.yaml
+++ b/examples/v1beta1/nas/darts-gpu.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/nas/enas-cpu.yaml
+++ b/examples/v1beta1/nas/enas-cpu.yaml
@@ -1,3 +1,4 @@
+---
 # This CPU example aims to show all the possible operations
 # is not very likely to get good result due to the extensive search space
 

--- a/examples/v1beta1/nas/enas-gpu.yaml
+++ b/examples/v1beta1/nas/enas-gpu.yaml
@@ -1,3 +1,4 @@
+---
 # This GPU example aims to show all the possible operations
 # is not very likely to get good result due to the extensive search space
 

--- a/examples/v1beta1/resume-experiment/from-volume-resume.yaml
+++ b/examples/v1beta1/resume-experiment/from-volume-resume.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/resume-experiment/never-resume.yaml
+++ b/examples/v1beta1/resume-experiment/never-resume.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/tekton/pipeline-run.yaml
+++ b/examples/v1beta1/tekton/pipeline-run.yaml
@@ -1,3 +1,4 @@
+---
 # This example shows how you can use Tekton Pipelines in Katib, transfer parameters from one Task to another and run HP job.
 # It uses simple random algorithm and tunes only learning rate.
 # Pipelines contains 2 Tasks, first is data-preprocessing second is model-training.

--- a/examples/v1beta1/trial-template/trial-configmap-source.yaml
+++ b/examples/v1beta1/trial-template/trial-configmap-source.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:

--- a/examples/v1beta1/trial-template/trial-metadata-substitution.yaml
+++ b/examples/v1beta1/trial-template/trial-metadata-substitution.yaml
@@ -1,3 +1,4 @@
+---
 # This example shows how you can use trial metadata in template substitution
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment

--- a/manifests/v1beta1/components/cert-generator/cert-generator.yaml
+++ b/manifests/v1beta1/components/cert-generator/cert-generator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/manifests/v1beta1/components/cert-generator/kustomization.yaml
+++ b/manifests/v1beta1/components/cert-generator/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/manifests/v1beta1/components/cert-generator/rbac.yaml
+++ b/manifests/v1beta1/components/cert-generator/rbac.yaml
@@ -1,3 +1,4 @@
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/manifests/v1beta1/components/controller/controller.yaml
+++ b/manifests/v1beta1/components/controller/controller.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/manifests/v1beta1/components/controller/katib-config.yaml
+++ b/manifests/v1beta1/components/controller/katib-config.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/manifests/v1beta1/components/controller/kustomization.yaml
+++ b/manifests/v1beta1/components/controller/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/manifests/v1beta1/components/controller/rbac.yaml
+++ b/manifests/v1beta1/components/controller/rbac.yaml
@@ -1,3 +1,4 @@
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/manifests/v1beta1/components/controller/service.yaml
+++ b/manifests/v1beta1/components/controller/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/manifests/v1beta1/components/controller/trial-templates.yaml
+++ b/manifests/v1beta1/components/controller/trial-templates.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/manifests/v1beta1/components/crd/experiment.yaml
+++ b/manifests/v1beta1/components/crd/experiment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/manifests/v1beta1/components/crd/kustomization.yaml
+++ b/manifests/v1beta1/components/crd/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/manifests/v1beta1/components/crd/suggestion.yaml
+++ b/manifests/v1beta1/components/crd/suggestion.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/manifests/v1beta1/components/crd/trial.yaml
+++ b/manifests/v1beta1/components/crd/trial.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/manifests/v1beta1/components/db-manager/db-manager.yaml
+++ b/manifests/v1beta1/components/db-manager/db-manager.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/manifests/v1beta1/components/db-manager/kustomization.yaml
+++ b/manifests/v1beta1/components/db-manager/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/manifests/v1beta1/components/db-manager/service.yaml
+++ b/manifests/v1beta1/components/db-manager/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/manifests/v1beta1/components/mysql/kustomization.yaml
+++ b/manifests/v1beta1/components/mysql/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/manifests/v1beta1/components/mysql/mysql.yaml
+++ b/manifests/v1beta1/components/mysql/mysql.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/manifests/v1beta1/components/mysql/pvc.yaml
+++ b/manifests/v1beta1/components/mysql/pvc.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/manifests/v1beta1/components/mysql/secret.yaml
+++ b/manifests/v1beta1/components/mysql/secret.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/manifests/v1beta1/components/mysql/secret.yaml
+++ b/manifests/v1beta1/components/mysql/secret.yaml
@@ -5,4 +5,4 @@ type: Opaque
 metadata:
   name: katib-mysql-secrets
 data:
-  MYSQL_ROOT_PASSWORD: dGVzdA== # "test"
+  MYSQL_ROOT_PASSWORD: dGVzdA==  # "test"

--- a/manifests/v1beta1/components/mysql/service.yaml
+++ b/manifests/v1beta1/components/mysql/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/manifests/v1beta1/components/namespace/kustomization.yaml
+++ b/manifests/v1beta1/components/namespace/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow

--- a/manifests/v1beta1/components/namespace/namespace.yaml
+++ b/manifests/v1beta1/components/namespace/namespace.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/manifests/v1beta1/components/ui/kustomization.yaml
+++ b/manifests/v1beta1/components/ui/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/manifests/v1beta1/components/ui/rbac.yaml
+++ b/manifests/v1beta1/components/ui/rbac.yaml
@@ -1,3 +1,4 @@
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/manifests/v1beta1/components/ui/service.yaml
+++ b/manifests/v1beta1/components/ui/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/manifests/v1beta1/components/ui/ui.yaml
+++ b/manifests/v1beta1/components/ui/ui.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/manifests/v1beta1/components/webhook/kustomization.yaml
+++ b/manifests/v1beta1/components/webhook/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/manifests/v1beta1/components/webhook/webhooks.yaml
+++ b/manifests/v1beta1/components/webhook/webhooks.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/manifests/v1beta1/installs/katib-cert-manager/certificate.yaml
+++ b/manifests/v1beta1/installs/katib-cert-manager/certificate.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/manifests/v1beta1/installs/katib-cert-manager/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-cert-manager/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow

--- a/manifests/v1beta1/installs/katib-cert-manager/params.yaml
+++ b/manifests/v1beta1/installs/katib-cert-manager/params.yaml
@@ -1,3 +1,4 @@
+---
 varReference:
   - path: spec/commonName
     kind: Certificate

--- a/manifests/v1beta1/installs/katib-cert-manager/patches/katib-cert-injection.yaml
+++ b/manifests/v1beta1/installs/katib-cert-manager/patches/katib-cert-injection.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/manifests/v1beta1/installs/katib-external-db/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-external-db/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow

--- a/manifests/v1beta1/installs/katib-external-db/patches/db-manager.yaml
+++ b/manifests/v1beta1/installs/katib-external-db/patches/db-manager.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/manifests/v1beta1/installs/katib-leader-election/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-leader-election/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow

--- a/manifests/v1beta1/installs/katib-leader-election/leader-election-rbac.yaml
+++ b/manifests/v1beta1/installs/katib-leader-election/leader-election-rbac.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/manifests/v1beta1/installs/katib-leader-election/patches/controller.yaml
+++ b/manifests/v1beta1/installs/katib-leader-election/patches/controller.yaml
@@ -1,3 +1,4 @@
+---
 - op: add
   path: /spec/template/spec/containers/0/args/-
   value: "--enable-leader-election"

--- a/manifests/v1beta1/installs/katib-openshift/patches/service-serving-cert.yaml
+++ b/manifests/v1beta1/installs/katib-openshift/patches/service-serving-cert.yaml
@@ -1,3 +1,4 @@
+---
 - op: "add"
   path: "/metadata/annotations/service.beta.openshift.io~1serving-cert-secret-name"
   value: katib-webhook-cert

--- a/manifests/v1beta1/installs/katib-openshift/patches/webhook-inject-cabundle.yaml
+++ b/manifests/v1beta1/installs/katib-openshift/patches/webhook-inject-cabundle.yaml
@@ -1,3 +1,4 @@
+---
 - op: "add"
   path: "/metadata/annotations"
   value:

--- a/manifests/v1beta1/installs/katib-standalone/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-standalone/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow

--- a/manifests/v1beta1/installs/katib-with-kubeflow/kubeflow-katib-roles.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/kubeflow-katib-roles.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow

--- a/manifests/v1beta1/installs/katib-with-kubeflow/params.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/params.yaml
@@ -1,3 +1,4 @@
+---
 varReference:
   - path: spec/http/route/destination/host
     kind: VirtualService

--- a/manifests/v1beta1/installs/katib-with-kubeflow/patches/remove-namespace.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/patches/remove-namespace.yaml
@@ -1,3 +1,4 @@
+---
 $patch: delete
 apiVersion: v1
 kind: Namespace

--- a/manifests/v1beta1/installs/katib-with-kubeflow/ui-virtual-service.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/ui-virtual-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes lint warnings in all YAML files as suggested by @johnugeorge in https://github.com/kubeflow/katib/pull/1901#issuecomment-1162594122

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Should be merged before #1901 

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
