### PR TITLE
Add PBT to experiment creation form

### DIFF
--- a/pkg/new-ui/v1beta1/frontend/src/app/constants/algorithms-settings.const.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/constants/algorithms-settings.const.ts
@@ -242,6 +242,29 @@ export const DartsSettings: AlgorithmSetting[] = [
   },
 ];
 
+export const PbtSettings: AlgorithmSetting[] = [
+  {
+    name: 'suggestion_trial_dir',
+    value: '/var/log/katib/checkpoints/',
+    type: AlgorithmSettingType.STRING,
+  },
+  {
+    name: 'n_population',
+    value: 40,
+    type: AlgorithmSettingType.INTEGER,
+  },
+  {
+    name: 'resample_probability',
+    value: null,
+    type: AlgorithmSettingType.FLOAT,
+  },
+  {
+    name: 'truncation_threshold',
+    value: 0.2,
+    type: AlgorithmSettingType.FLOAT,
+  },
+];
+
 export const EarlyStoppingSettings: AlgorithmSetting[] = [
   {
     name: 'min_trials_required',
@@ -271,4 +294,5 @@ export const AlgorithmSettingsMap: { [key: string]: AlgorithmSetting[] } = {
   [AlgorithmsEnum.SOBOL]: SOBOLSettings,
   [AlgorithmsEnum.ENAS]: ENASSettings,
   [AlgorithmsEnum.DARTS]: DartsSettings,
+  [AlgorithmsEnum.PBT]: PbtSettings,
 };

--- a/pkg/new-ui/v1beta1/frontend/src/app/constants/algorithms-types.const.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/constants/algorithms-types.const.ts
@@ -12,6 +12,7 @@ export const AlgorithmNames = {
   [AlgorithmsEnum.MULTIVARIATE_TPE]: 'Multivariate Tree of Parzen Estimators',
   [AlgorithmsEnum.CMAES]: 'Covariance Matrix Adaptation: Evolution Strategy',
   [AlgorithmsEnum.SOBOL]: 'Sobol Quasirandom Sequence',
+  [AlgorithmsEnum.PBT]: 'Population Based Training',
 };
 
 export const NasAlgorithmNames = {

--- a/pkg/new-ui/v1beta1/frontend/src/app/enumerations/algorithms.enum.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/enumerations/algorithms.enum.ts
@@ -9,6 +9,7 @@ export enum AlgorithmsEnum {
   SOBOL = 'sobol',
   ENAS = 'enas',
   DARTS = 'darts',
+  PBT = 'pbt',
 }
 
 export enum EarlyStoppingAlgorithmsEnum {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds PBT as an option to the search algorithms drop-down for creating a new experiment from the Katib UI.

Related to: https://github.com/kubeflow/katib/issues/1382, https://github.com/kubeflow/katib/pull/1862

**Checklist:**

- [-] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
