### PR TITLE
Add --connect-timeout flag to katib-db-manager

### DIFF
--- a/cmd/db-manager/v1beta1/Dockerfile
+++ b/cmd/db-manager/v1beta1/Dockerfile
@@ -28,4 +28,3 @@ WORKDIR /app
 COPY --from=build-env /bin/grpc_health_probe /bin/
 COPY --from=build-env /go/src/github.com/kubeflow/katib/katib-db-manager /app/
 ENTRYPOINT ["./katib-db-manager"]
-CMD ["-w", "kubernetes"]

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -58,7 +58,7 @@ make generate
 Below is a list of command-line flags accepted by Katib controller:
 
 | Name                            | Type                      | Default                       | Description                                                                                                            |
-| ------------------------------- | ------------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+|---------------------------------|---------------------------|-------------------------------|------------------------------------------------------------------------------------------------------------------------|
 | enable-grpc-probe-in-suggestion | bool                      | true                          | Enable grpc probe in suggestions                                                                                       |
 | experiment-suggestion-name      | string                    | "default"                     | The implementation of suggestion interface in experiment controller                                                    |
 | metrics-addr                    | string                    | ":8080"                       | The address the metric endpoint binds to                                                                               |
@@ -67,6 +67,14 @@ Below is a list of command-line flags accepted by Katib controller:
 | webhook-port                    | int                       | 8443                          | The port number to be used for admission webhook server                                                                |
 | enable-leader-election          | bool                      | false                         | Enable leader election for katib-controller. Enabling this will ensure there is only one active katib-controller.      |
 | leader-election-id              | string                    | "3fbc96e9.katib.kubeflow.org" | The ID for leader election.                                                                                            |
+
+## DB Manager Flags
+
+Below is a list of command-line flags accepted by Katib DB Manager:
+
+| Name            | Type          | Default | Description                                             |
+|-----------------|---------------|---------|---------------------------------------------------------|
+| connect-timeout | time.Duration | 60s     | Timeout before calling error during database connection |
 
 ## Workflow design
 

--- a/pkg/db/v1beta1/common/const.go
+++ b/pkg/db/v1beta1/common/const.go
@@ -20,7 +20,6 @@ import "time"
 
 const (
 	ConnectInterval = 5 * time.Second
-	ConnectTimeout  = 60 * time.Second
 
 	DBUserEnvName     = "DB_USER"
 	DBNameEnvName     = "DB_NAME"

--- a/pkg/db/v1beta1/db.go
+++ b/pkg/db/v1beta1/db.go
@@ -18,6 +18,7 @@ package db
 
 import (
 	"errors"
+	"time"
 
 	"github.com/kubeflow/katib/pkg/db/v1beta1/common"
 	"github.com/kubeflow/katib/pkg/db/v1beta1/mysql"
@@ -25,14 +26,14 @@ import (
 	"k8s.io/klog"
 )
 
-func NewKatibDBInterface(dbName string) (common.KatibDBInterface, error) {
+func NewKatibDBInterface(dbName string, connectTimeout time.Duration) (common.KatibDBInterface, error) {
 
 	if dbName == common.MySqlDBNameEnvValue {
 		klog.Info("Using MySQL")
-		return mysql.NewDBInterface()
+		return mysql.NewDBInterface(connectTimeout)
 	} else if dbName == common.PostgresSQLDBNameEnvValue {
 		klog.Info("Using Postgres")
-		return postgres.NewDBInterface()
+		return postgres.NewDBInterface(connectTimeout)
 	}
 	return nil, errors.New("Invalid DB Name")
 }

--- a/pkg/db/v1beta1/mysql/mysql.go
+++ b/pkg/db/v1beta1/mysql/mysql.go
@@ -73,8 +73,8 @@ func NewWithSQLConn(db *sql.DB) (common.KatibDBInterface, error) {
 	return d, nil
 }
 
-func NewDBInterface() (common.KatibDBInterface, error) {
-	db, err := common.OpenSQLConn(dbDriver, getDbName(), common.ConnectInterval, common.ConnectTimeout)
+func NewDBInterface(connectTimeout time.Duration) (common.KatibDBInterface, error) {
+	db, err := common.OpenSQLConn(dbDriver, getDbName(), common.ConnectInterval, connectTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("DB open failed: %v", err)
 	}

--- a/pkg/db/v1beta1/postgres/postgres.go
+++ b/pkg/db/v1beta1/postgres/postgres.go
@@ -49,7 +49,7 @@ func getDbName() string {
 		common.PostgreSQLDBHostEnvName, common.DefaultPostgreSQLHost)
 	dbPort := env.GetEnvOrDefault(
 		common.PostgreSQLDBPortEnvName, common.DefaultPostgreSQLPort)
-	dbName := env.GetEnvOrDefault(common.DefaultPostgreSQLDatabase,
+	dbName := env.GetEnvOrDefault(common.PostgreSQLDatabase,
 		common.DefaultPostgreSQLDatabase)
 
 	psqlInfo := fmt.Sprintf("host=%s port=%s user=%s "+
@@ -59,8 +59,8 @@ func getDbName() string {
 	return psqlInfo
 }
 
-func NewDBInterface() (common.KatibDBInterface, error) {
-	db, err := common.OpenSQLConn(dbDriver, getDbName(), common.ConnectInterval, common.ConnectTimeout)
+func NewDBInterface(connectTimeout time.Duration) (common.KatibDBInterface, error) {
+	db, err := common.OpenSQLConn(dbDriver, getDbName(), common.ConnectInterval, connectTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("DB open failed: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I added a flag, `--connect-timeout`, to katib-db-manager that sets the time before calling an error on database connection and remove the non-configurable flag, `-w kubernetes`, set in katib-db-manager Dockerfile.

Also, I fixed a process to set PostgreSQL Database.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #1928 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
