### PR TITLE
Support for arm64 in enas-cnn-cifar10 image

### DIFF
--- a/examples/v1beta1/trial-images/enas-cnn-cifar10/Dockerfile.cpu
+++ b/examples/v1beta1/trial-images/enas-cnn-cifar10/Dockerfile.cpu
@@ -8,7 +8,7 @@ ADD examples/v1beta1/trial-images/enas-cnn-cifar10 ${TARGET_DIR}
 
 WORKDIR  ${TARGET_DIR}
 
-RUN if [ "${TARGETARCH}" = "aarch64" ]; then \
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
     apt-get -y update && \
     apt-get -y install gfortran libpcre3 libpcre3-dev && \
     apt-get clean && \

--- a/examples/v1beta1/trial-images/enas-cnn-cifar10/Dockerfile.gpu
+++ b/examples/v1beta1/trial-images/enas-cnn-cifar10/Dockerfile.gpu
@@ -1,4 +1,6 @@
-FROM tensorflow/tensorflow:2.9.1-gpu
+# tensorflow-gpu=2.9.1, cuda=11.7.1
+# Ref: https://docs.nvidia.com/deeplearning/frameworks/tensorflow-release-notes/rel_22-08.html#rel_22-08
+FROM nvcr.io/nvidia/tensorflow:22.08-tf2-py3
 
 ENV TARGET_DIR /opt/enas-cnn-cifar10
 ENV PYTHONPATH ${TARGET_DIR}

--- a/examples/v1beta1/trial-images/tf-mnist-with-summaries/Dockerfile
+++ b/examples/v1beta1/trial-images/tf-mnist-with-summaries/Dockerfile
@@ -6,7 +6,7 @@ ADD examples/v1beta1/trial-images/tf-mnist-with-summaries /opt/tf-mnist-with-sum
 
 WORKDIR /opt/tf-mnist-with-summaries
 
-RUN if [ "${TARGETARCH}" = "aarch64" ]; then \
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
     apt-get -y update && \
     apt-get -y install gfortran libpcre3 libpcre3-dev && \
     apt-get clean && \

--- a/scripts/v1beta1/build.sh
+++ b/scripts/v1beta1/build.sh
@@ -120,9 +120,6 @@ echo -e "\nBuilding training container images..."
 if [ ! "$ARCH" = "amd64" ]; then
   echo -e "\nSome training container images are supported only amd64."
 else
-  echo -e "\nBuilding Keras CIFAR-10 CNN training container example for ENAS with GPU support...\n"
-  docker buildx build --platform linux/amd64 -t "${REGISTRY}/enas-cnn-cifar10-gpu:${TAG}" -f examples/${VERSION}/trial-images/enas-cnn-cifar10/Dockerfile.gpu .
-
   echo -e "\nBuilding PyTorch CIFAR-10 CNN training container example for DARTS with CPU support...\n"
   docker buildx build --platform linux/amd64 -t "${REGISTRY}/darts-cnn-cifar10-cpu:${TAG}" -f examples/${VERSION}/trial-images/darts-cnn-cifar10/Dockerfile.cpu .
 
@@ -147,5 +144,8 @@ docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/tf-mnist-with-summa
 
 echo -e "\nBuilding Keras CIFAR-10 CNN training container example for ENAS with CPU support...\n"
 docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/enas-cnn-cifar10-cpu:${TAG}" -f examples/${VERSION}/trial-images/enas-cnn-cifar10/Dockerfile.cpu .
+
+echo -e "\nBuilding Keras CIFAR-10 CNN training container example for ENAS with GPU support...\n"
+docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/enas-cnn-cifar10-gpu:${TAG}" -f examples/${VERSION}/trial-images/enas-cnn-cifar10/Dockerfile.gpu .
 
 echo -e "\nAll Katib images with ${TAG} tag have been built successfully!\n"


### PR DESCRIPTION
Signed-off-by: tenzen-y <yuki.iwai.tz@gmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I modified Dockerfile for enas-cnn-cifar10 image to support arm64 and I tested operations  in the below commands:

```shell
$ # For arm64
$ docker run -it --platform linux/arm64 ytenzen/multiplatform-enas-cnn-cifar10-gpu:latest  --num_gpus=0 --num_epochs=1 --architecture="[[49]]" --nn_config="{'num_layers': 1, 'input_sizes': [32, 32, 3], 'output_sizes': [10], 'embedding': {'49': {'opt_id': 49, 'opt_type': 'separable_convolution', 'opt_params': {'filter_size': '3', 'num_filter': '128', 'stride': '2', 'depth_multiplier': '2'}}}}"
$ # For amd64
$ docker run -it --platform linux/amd64 ytenzen/multiplatform-enas-cnn-cifar10-gpu:latest  --num_gpus=0 --num_epochs=1 --architecture="[[49]]" --nn_config="{'num_layers': 1, 'input_sizes': [32, 32, 3], 'output_sizes': [10], 'embedding': {'49': {'opt_id': 49, 'opt_type': 'separable_convolution', 'opt_params': {'filter_size': '3', 'num_filter': '128', 'stride': '2', 'depth_multiplier': '2'}}}}"
```

Also, I fixed a bug in `TARGETARCH` for enas-cnn-cifar10 and tf-mnist-with-summaries images.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Part-of #1900 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
