### PR TITLE
Support for arm64 in simple-pbt image

### DIFF
--- a/scripts/v1beta1/build.sh
+++ b/scripts/v1beta1/build.sh
@@ -23,7 +23,7 @@ REGISTRY=$1
 TAG=$2
 ARCH=$3
 
-if [[ -z "$REGISTRY" || -z "$TAG" || -z "$ARCH" ]]; then
+if [[ -z "${REGISTRY}" || -z "${TAG}" || -z "${ARCH}" ]]; then
   echo "Image registry, tag and cpu-architecture must be set"
   echo "Usage: $0 <image-registry> <image-tag> <cpu-architecture>" 1>&2
   exit 1
@@ -32,11 +32,11 @@ fi
 SUPPORTED_CPU_ARCHS=(amd64 arm64 ppc64le)
 function check_specified_cpu_arch() {
   for SUPPORTED_ARCH in "${SUPPORTED_CPU_ARCHS[@]}"; do
-    if [ "$ARCH" = "$SUPPORTED_ARCH" ]; then
+    if [ "${ARCH}" = "${SUPPORTED_ARCH}" ]; then
       return 0
     fi
   done
-  echo "CPU architecture '$ARCH' is not supported"
+  echo "CPU architecture '${ARCH}' is not supported"
   echo "You can use '${SUPPORTED_CPU_ARCHS[*]}'"
   echo "To get machine architecture run: uname -m"
   return 1
@@ -56,96 +56,92 @@ cd "${SCRIPT_ROOT}"
 
 # Katib core images
 echo -e "\nBuilding Katib controller image...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/katib-controller:${TAG}" -f ${CMD_PREFIX}/katib-controller/${VERSION}/Dockerfile .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/katib-controller:${TAG}" -f ${CMD_PREFIX}/katib-controller/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding Katib DB manager image...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/katib-db-manager:${TAG}" -f ${CMD_PREFIX}/db-manager/${VERSION}/Dockerfile .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/katib-db-manager:${TAG}" -f ${CMD_PREFIX}/db-manager/${VERSION}/Dockerfile .
 
 # TODO (andreyvelich): Switch to ${CMD_PREFIX}/ui/${VERSION}/Dockerfile once old UI is deprecated.
 echo -e "\nBuilding Katib UI image...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/katib-ui:${TAG}" -f ${CMD_PREFIX}/new-ui/${VERSION}/Dockerfile .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/katib-ui:${TAG}" -f ${CMD_PREFIX}/new-ui/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding Katib cert generator image...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/cert-generator:${TAG}" -f ${CMD_PREFIX}/cert-generator/${VERSION}/Dockerfile .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/cert-generator:${TAG}" -f ${CMD_PREFIX}/cert-generator/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding file metrics collector image...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/file-metrics-collector:${TAG}" -f ${CMD_PREFIX}/metricscollector/${VERSION}/file-metricscollector/Dockerfile .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/file-metrics-collector:${TAG}" -f ${CMD_PREFIX}/metricscollector/${VERSION}/file-metricscollector/Dockerfile .
 
 echo -e "\nBuilding TF Event metrics collector image...\n"
-if [ "$ARCH" == "ppc64le" ]; then
-  docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/tfevent-metrics-collector:${TAG}" -f ${CMD_PREFIX}/metricscollector/${VERSION}/tfevent-metricscollector/Dockerfile.ppc64le .
+if [ "${ARCH}" == "ppc64le" ]; then
+  docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/tfevent-metrics-collector:${TAG}" -f ${CMD_PREFIX}/metricscollector/${VERSION}/tfevent-metricscollector/Dockerfile.ppc64le .
 else
-  docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/tfevent-metrics-collector:${TAG}" -f ${CMD_PREFIX}/metricscollector/${VERSION}/tfevent-metricscollector/Dockerfile .
+  docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/tfevent-metrics-collector:${TAG}" -f ${CMD_PREFIX}/metricscollector/${VERSION}/tfevent-metricscollector/Dockerfile .
 fi
 
 # Suggestion images
 echo -e "\nBuilding suggestion images..."
 
 echo -e "\nBuilding hyperopt suggestion...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/suggestion-hyperopt:${TAG}" -f ${CMD_PREFIX}/suggestion/hyperopt/${VERSION}/Dockerfile .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/suggestion-hyperopt:${TAG}" -f ${CMD_PREFIX}/suggestion/hyperopt/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding chocolate suggestion...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/suggestion-chocolate:${TAG}" -f ${CMD_PREFIX}/suggestion/chocolate/${VERSION}/Dockerfile .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/suggestion-chocolate:${TAG}" -f ${CMD_PREFIX}/suggestion/chocolate/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding hyperband suggestion...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/suggestion-hyperband:${TAG}" -f ${CMD_PREFIX}/suggestion/hyperband/${VERSION}/Dockerfile .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/suggestion-hyperband:${TAG}" -f ${CMD_PREFIX}/suggestion/hyperband/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding skopt suggestion...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/suggestion-skopt:${TAG}" -f ${CMD_PREFIX}/suggestion/skopt/${VERSION}/Dockerfile .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/suggestion-skopt:${TAG}" -f ${CMD_PREFIX}/suggestion/skopt/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding goptuna suggestion...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/suggestion-goptuna:${TAG}" -f ${CMD_PREFIX}/suggestion/goptuna/${VERSION}/Dockerfile .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/suggestion-goptuna:${TAG}" -f ${CMD_PREFIX}/suggestion/goptuna/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding optuna suggestion...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/suggestion-optuna:${TAG}" -f ${CMD_PREFIX}/suggestion/optuna/${VERSION}/Dockerfile .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/suggestion-optuna:${TAG}" -f ${CMD_PREFIX}/suggestion/optuna/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding ENAS suggestion...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/suggestion-enas:${TAG}" -f ${CMD_PREFIX}/suggestion/nas/enas/${VERSION}/Dockerfile .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/suggestion-enas:${TAG}" -f ${CMD_PREFIX}/suggestion/nas/enas/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding DARTS suggestion...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/suggestion-darts:${TAG}" -f ${CMD_PREFIX}/suggestion/nas/darts/${VERSION}/Dockerfile .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/suggestion-darts:${TAG}" -f ${CMD_PREFIX}/suggestion/nas/darts/${VERSION}/Dockerfile .
 
 echo -e "\nBuilding PBT suggestion...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/suggestion-pbt:${TAG}" -f ${CMD_PREFIX}/suggestion/pbt/${VERSION}/Dockerfile .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/suggestion-pbt:${TAG}" -f ${CMD_PREFIX}/suggestion/pbt/${VERSION}/Dockerfile .
 
 # Early stopping images
 echo -e "\nBuilding early stopping images...\n"
 
 echo -e "\nBuilding median stopping rule...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/earlystopping-medianstop:${TAG}" -f ${CMD_PREFIX}/earlystopping/medianstop/${VERSION}/Dockerfile .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/earlystopping-medianstop:${TAG}" -f ${CMD_PREFIX}/earlystopping/medianstop/${VERSION}/Dockerfile .
 
 # Training container images
 echo -e "\nBuilding training container images..."
 
-if [ ! "$ARCH" = "amd64" ]; then
-  echo -e "\nSome training container images are supported only amd64."
-else
-  echo -e "\nBuilding dynamic learning rate training container example for PBT...\n"
-  docker buildx build --platform linux/amd64 -t "${REGISTRY}/simple-pbt:${TAG}" -f examples/${VERSION}/trial-images/simple-pbt/Dockerfile .
-fi
+echo -e "\nBuilding dynamic learning rate training container example for PBT...\n"
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/simple-pbt:${TAG}" -f examples/${VERSION}/trial-images/simple-pbt/Dockerfile .
 
 echo -e "\nBuilding PyTorch CIFAR-10 CNN training container example for DARTS with CPU support...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/darts-cnn-cifar10-cpu:${TAG}" -f examples/${VERSION}/trial-images/darts-cnn-cifar10/Dockerfile.cpu .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/darts-cnn-cifar10-cpu:${TAG}" -f examples/${VERSION}/trial-images/darts-cnn-cifar10/Dockerfile.cpu .
 
 echo -e "\nBuilding PyTorch CIFAR-10 CNN training container example for DARTS with GPU support...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/darts-cnn-cifar10-gpu:${TAG}" -f examples/${VERSION}/trial-images/darts-cnn-cifar10/Dockerfile.gpu .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/darts-cnn-cifar10-gpu:${TAG}" -f examples/${VERSION}/trial-images/darts-cnn-cifar10/Dockerfile.gpu .
 
 echo -e "\nBuilding mxnet mnist training container example...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/mxnet-mnist:${TAG}" -f examples/${VERSION}/trial-images/mxnet-mnist/Dockerfile .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/mxnet-mnist:${TAG}" -f examples/${VERSION}/trial-images/mxnet-mnist/Dockerfile .
 
 echo -e "\nBuilding PyTorch mnist training container example with CPU support...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/pytorch-mnist-cpu:${TAG}" -f examples/${VERSION}/trial-images/pytorch-mnist/Dockerfile.cpu .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/pytorch-mnist-cpu:${TAG}" -f examples/${VERSION}/trial-images/pytorch-mnist/Dockerfile.cpu .
 
 echo -e "\nBuilding PyTorch mnist training container example with GPU support...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/pytorch-mnist-gpu:${TAG}" -f examples/${VERSION}/trial-images/pytorch-mnist/Dockerfile.gpu .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/pytorch-mnist-gpu:${TAG}" -f examples/${VERSION}/trial-images/pytorch-mnist/Dockerfile.gpu .
 
 echo -e "\nBuilding Tensorflow with summaries mnist training container example...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/tf-mnist-with-summaries:${TAG}" -f examples/${VERSION}/trial-images/tf-mnist-with-summaries/Dockerfile .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/tf-mnist-with-summaries:${TAG}" -f examples/${VERSION}/trial-images/tf-mnist-with-summaries/Dockerfile .
 
 echo -e "\nBuilding Keras CIFAR-10 CNN training container example for ENAS with CPU support...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/enas-cnn-cifar10-cpu:${TAG}" -f examples/${VERSION}/trial-images/enas-cnn-cifar10/Dockerfile.cpu .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/enas-cnn-cifar10-cpu:${TAG}" -f examples/${VERSION}/trial-images/enas-cnn-cifar10/Dockerfile.cpu .
 
 echo -e "\nBuilding Keras CIFAR-10 CNN training container example for ENAS with GPU support...\n"
-docker buildx build --platform "linux/$ARCH" -t "${REGISTRY}/enas-cnn-cifar10-gpu:${TAG}" -f examples/${VERSION}/trial-images/enas-cnn-cifar10/Dockerfile.gpu .
+docker buildx build --platform "linux/${ARCH}" -t "${REGISTRY}/enas-cnn-cifar10-gpu:${TAG}" -f examples/${VERSION}/trial-images/enas-cnn-cifar10/Dockerfile.gpu .
 
 echo -e "\nAll Katib images with ${TAG} tag have been built successfully!\n"


### PR DESCRIPTION
Signed-off-by: tenzen-y <yuki.iwai.tz@gmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I modified the Dockerfile for simple-pbt to support arm64 and I have tested on my local using the below commands:

- linux/arm64

```shell
docker run -it --platform linux/arm64 ytenzen/multiplatform-simple-pbt:latest --epochs=10
```

- linux/amd64

```shell
docker run -it --platform linux/amd64 ytenzen/multiplatform-simple-pbt:latest --epochs=10
```

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Part-of #1900 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
