### PR TITLE
Improve UI API/controller logging to ease troubleshooting

### DIFF
--- a/pkg/new-ui/v1beta1/hp.go
+++ b/pkg/new-ui/v1beta1/hp.go
@@ -80,7 +80,6 @@ func (k *KatibUIHandler) FetchHPJobInfo(w http.ResponseWriter, r *http.Request) 
 
 	foundPipelineUID := false
 	for _, t := range trialList.Items {
-		log.Printf("Processing trial: %s", t.Name)
 		runUid, ok := t.GetAnnotations()[kfpRunIDAnnotation]
 		if !ok {
 			log.Printf("Trial %s has no pipeline run.", t.Name)
@@ -99,7 +98,6 @@ func (k *KatibUIHandler) FetchHPJobInfo(w http.ResponseWriter, r *http.Request) 
 		trialResText := make([]string, len(metricsList)+len(paramList))
 
 		if t.IsSucceeded() || t.IsEarlyStopped() {
-			log.Printf("Trial: %s suceeded or stopped early", t.Name)
 			obsLogResp, err := c.GetObservationLog(
 				context.Background(),
 				&api_pb_v1beta1.GetObservationLogRequest{

--- a/pkg/new-ui/v1beta1/hp.go
+++ b/pkg/new-ui/v1beta1/hp.go
@@ -99,7 +99,7 @@ func (k *KatibUIHandler) FetchHPJobInfo(w http.ResponseWriter, r *http.Request) 
 		trialResText := make([]string, len(metricsList)+len(paramList))
 
 		if t.IsSucceeded() || t.IsEarlyStopped() {
-			log.Printf("Trial: %s Suceeded or Stopped Early", t.Name)
+			log.Printf("Trial: %s suceeded or stopped early", t.Name)
 			obsLogResp, err := c.GetObservationLog(
 				context.Background(),
 				&api_pb_v1beta1.GetObservationLogRequest{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Added some additional logging that was needed when troubleshooting a customer issue. It was possible to get into a state where the API was not responding and you couldn't tell if it was the underlying controller of the web API.

- Log start to command with experiment name and namespace (best practice - let's you know the call was make before possible errors)
- Log count of trials in case something goes wrong with processing.