### PR TITLE
[SDK] Fix namespace parameter in tune API

### DIFF
--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -295,7 +295,7 @@ class KatibClient(object):
         experiment.spec.trial_template = trial_template
 
         # Create the Katib Experiment.
-        self.create_experiment(exp_object=experiment)
+        self.create_experiment(exp_object=experiment, namespace=namespace)
 
     # TODO (andreyvelich): Get Experiment should always return one Experiment.
     # Use list_experiments to return Experiment list.


### PR DESCRIPTION
We should send `namespace` parameter to `create_experiment` API, so user can set it using `tune` API.

cc @tenzen-y @johnugeorge @anencore94 