### PR TITLE
UI: Make KWA's main table responsive and add toolbar

### DIFF
--- a/cmd/new-ui/v1beta1/Dockerfile
+++ b/cmd/new-ui/v1beta1/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install git -y
 WORKDIR /kf
 RUN git clone https://github.com/kubeflow/kubeflow.git && \
     cd kubeflow && \
-    git checkout ecb72c2
+    git checkout c4ca7a9
 
 # --- Build the frontend kubeflow library ---
 FROM node:12 AS frontend-kubeflow-lib

--- a/pkg/new-ui/v1beta1/README.md
+++ b/pkg/new-ui/v1beta1/README.md
@@ -42,7 +42,7 @@ You can build the common library with:
 ```bash
 cd /tmp && git clone https://github.com/kubeflow/kubeflow.git \
   && cd kubeflow \
-  && git checkout ecb72c2 \
+  && git checkout c4ca7a9 \
   && cd components/crud-web-apps/common/frontend/kubeflow-common-lib
 
 # build the common library module

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/config.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/config.ts
@@ -19,8 +19,6 @@ import {
 import { ExperimentOptimalTrialComponent } from './optimal-trial/experiment-optimal-trial.component';
 
 export const experimentsTableConfig: TableConfig = {
-  title: 'Experiments',
-  newButtonText: 'NEW EXPERIMENT',
   columns: [
     {
       matHeaderCellDef: 'Status',

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/experiments.component.html
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/experiments.component.html
@@ -1,11 +1,18 @@
-<lib-namespace-select
-  *ngIf="(ns.dashboardConnected$ | async) === dashboardDisconnectedState"
-  namespacesUrl="/katib/fetch_namespaces"
-></lib-namespace-select>
+<div class="lib-content-wrapper">
+  <lib-title-actions-toolbar title="Experiments" [buttons]="buttons" i18n-title>
+    <lib-namespace-select
+      *ngIf="(ns.dashboardConnected$ | async) === dashboardDisconnectedState"
+      namespacesUrl="/katib/fetch_namespaces"
+    ></lib-namespace-select>
+  </lib-title-actions-toolbar>
 
-<lib-resource-table
-  [config]="config"
-  [data]="experiments"
-  [trackByFn]="trackByFn"
-  (actionsEmitter)="reactToAction($event)"
-></lib-resource-table>
+  <div class="page-padding lib-flex-grow lib-overflow-auto">
+    <lib-table
+      [config]="config"
+      [data]="experiments"
+      [trackByFn]="trackByFn"
+      (actionsEmitter)="reactToAction($event)"
+    >
+    </lib-table>
+  </div>
+</div>

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/experiments.component.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/experiments.component.ts
@@ -18,6 +18,7 @@ import {
   TemplateValue,
   ActionEvent,
   DashboardState,
+  ToolbarButton,
 } from 'kubeflow';
 
 import { KWABackendService } from 'src/app/services/backend.service';
@@ -41,6 +42,17 @@ export class ExperimentsComponent implements OnInit, OnDestroy {
 
   private subs = new Subscription();
   private poller: ExponentialBackoff;
+
+  buttons: ToolbarButton[] = [
+    new ToolbarButton({
+      text: `New Experiment`,
+      icon: 'add',
+      stroked: true,
+      fn: () => {
+        this.router.navigate(['/new']);
+      },
+    }),
+  ];
 
   constructor(
     private backend: KWABackendService,
@@ -73,9 +85,6 @@ export class ExperimentsComponent implements OnInit, OnDestroy {
   reactToAction(a: ActionEvent) {
     const exp = a.data as Experiment;
     switch (a.action) {
-      case 'newResourceButton': // TODO: could also use enums here
-        this.router.navigate(['/new']);
-        break;
       case 'name:link':
         this.router.navigate([`/experiment/${exp.name}`]);
         break;

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/experiments.module.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/experiments.module.ts
@@ -1,28 +1,12 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MatCardModule } from '@angular/material/card';
-import {
-  NamespaceSelectModule,
-  ResourceTableModule,
-  ConfirmDialogModule,
-} from 'kubeflow';
-
+import { KubeflowModule } from 'kubeflow';
 import { ExperimentsComponent } from './experiments.component';
 import { ExperimentOptimalTrialModule } from './optimal-trial/experiment-optimal-trial.module';
 
 @NgModule({
   declarations: [ExperimentsComponent],
-  imports: [
-    CommonModule,
-    NamespaceSelectModule,
-    ResourceTableModule,
-
-    ConfirmDialogModule,
-    ExperimentOptimalTrialModule,
-    MatCardModule,
-    ConfirmDialogModule,
-    MatCardModule,
-  ],
+  imports: [CommonModule, ExperimentOptimalTrialModule, KubeflowModule],
   exports: [ExperimentsComponent],
 })
 export class ExperimentsModule {}


### PR DESCRIPTION
In this PR:

* Add a top row toolbar with the title of the app and the button to create a new Experiment.
* Replace the card with a responsive table that shows the items. The component also has a paginator.
* Update `Dockerfile` and `README` file to check out to the commit in master branch from the Kubeflow repository that includes the corresponding changes.

Here the new look of the app:
![image](https://user-images.githubusercontent.com/87971102/197756139-5e87ff05-2d83-44bb-b62e-f8ea2a94c29d.png)

Related PR: https://github.com/kubeflow/kubeflow/pull/6316

Signed-off-by: Elena Zioga <elena@arrikto.com>
