### PR TITLE
Add authorization mechanisms in new Katib UI backend

### DIFF
--- a/cmd/new-ui/v1beta1/main.go
+++ b/cmd/new-ui/v1beta1/main.go
@@ -48,7 +48,7 @@ func main() {
 	http.HandleFunc("/katib/", kuh.ServeIndex(*buildDir))
 	http.Handle("/katib/static/", http.StripPrefix("/katib/", frontend))
 
-	http.HandleFunc("/katib/fetch_experiments/", kuh.FetchAllExperiments)
+	http.HandleFunc("/katib/fetch_namespaced_experiments/", kuh.FetchNamespacedExperiments)
 
 	http.HandleFunc("/katib/create_experiment/", kuh.CreateExperiment)
 

--- a/cmd/new-ui/v1beta1/main.go
+++ b/cmd/new-ui/v1beta1/main.go
@@ -48,7 +48,7 @@ func main() {
 	http.HandleFunc("/katib/", kuh.ServeIndex(*buildDir))
 	http.Handle("/katib/static/", http.StripPrefix("/katib/", frontend))
 
-	http.HandleFunc("/katib/fetch_namespaced_experiments/", kuh.FetchNamespacedExperiments)
+	http.HandleFunc("/katib/fetch_experiments/", kuh.FetchExperiments)
 
 	http.HandleFunc("/katib/create_experiment/", kuh.CreateExperiment)
 

--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -26,8 +26,23 @@ import (
 
 const (
 
+	// ActionTypeCreate is the create CRUD action
+	ActionTypeCreate = "create"
+	// ActionTypeList is the list CRUD action
+	ActionTypeList = "list"
+	// ActionTypeGet is the get CRUD action
+	ActionTypeGet = "get"
+	// ActionTypeUpdate is the update CRUD action
+	ActionTypeUpdate = "update"
+	// ActionTypeDelete is the delete CRUD action
+	ActionTypeDelete = "delete"
+
 	// PluralTrial is the plural for Trial object
 	PluralTrial = "trials"
+	// PluralExperiment is the plural for Experiment object
+	PluralExperiment = "experiments"
+	// PluralSuggestion is the plural for Suggestion object
+	PluralSuggestion = "suggestions"
 
 	// ConfigExperimentSuggestionName is the config name of the
 	// suggestion client implementation in experiment controller.

--- a/pkg/new-ui/v1beta1/README.md
+++ b/pkg/new-ui/v1beta1/README.md
@@ -91,6 +91,7 @@ This is the recommended way to test the web app e2e. In order to build the UI an
    For example, if you use port-forwarding to expose `katib-db-manager`, run this command:
 
    ```
+   export APP_DISABLE_AUTH=true
    go run main.go --build-dir=../../../pkg/new-ui/v1beta1/frontend/dist --port=8080 --db-manager-address=localhost:6789
    ```
 

--- a/pkg/new-ui/v1beta1/authzn.go
+++ b/pkg/new-ui/v1beta1/authzn.go
@@ -2,13 +2,13 @@ package v1beta1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"strings"
 
 	"github.com/kubeflow/katib/pkg/util/v1beta1/env"
-	"github.com/pkg/errors"
 	v1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -30,7 +30,7 @@ func GetUsername(r *http.Request) (string, error) {
 	}
 
 	if r.Header.Get(USER_HEADER) == "" {
-		return "", errors.New("User header not present!")
+		return "", errors.New("user header not present")
 	}
 
 	user := r.Header.Get(USER_HEADER)

--- a/pkg/new-ui/v1beta1/authzn.go
+++ b/pkg/new-ui/v1beta1/authzn.go
@@ -18,14 +18,13 @@ import (
 var (
 	USER_HEADER  = env.GetEnvOrDefault("USERID_HEADER", "kubeflow-userid")
 	USER_PREFIX  = env.GetEnvOrDefault("USERID_PREFIX", ":")
-	DISABLE_AUTH = env.GetEnvOrDefault("APP_DISABLE_AUTH", "false") == "true"
-	BACKEND_MODE = env.GetEnvOrDefault("BACKEND_MODE", "prod")
+	DISABLE_AUTH = env.GetEnvOrDefault("APP_DISABLE_AUTH", "false")
 )
 
 func GetUsername(r *http.Request) (string, error) {
 	var username string
-	if DISABLE_AUTH {
-		log.Printf("APP_DISABLE_AUTH set to True. Skipping authorization check")
+	if DISABLE_AUTH == "true" {
+		log.Printf("APP_DISABLE_AUTH set to True. Skipping authentication check")
 		return "", nil
 	}
 
@@ -61,13 +60,8 @@ func CreateSAR(user, verb, namespace, resource, subresource, name string, schema
 
 func IsAuthorized(user, verb, namespace, resource, subresource, name string, schema schema.GroupVersion, client client.Client) error {
 
-	// Skip authz when in dev_mode
-	if BACKEND_MODE == "dev" || BACKEND_MODE == "development" {
-		log.Printf("Skipping authorization check in development mode")
-		return nil
-	}
 	// Skip authz when admin is explicity requested it
-	if DISABLE_AUTH {
+	if DISABLE_AUTH == "true" {
 		log.Printf("APP_DISABLE_AUTH set to True. Skipping authorization check")
 		return nil
 	}

--- a/pkg/new-ui/v1beta1/authzn.go
+++ b/pkg/new-ui/v1beta1/authzn.go
@@ -1,0 +1,116 @@
+package v1beta1
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/kubeflow/katib/pkg/util/v1beta1/env"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ENV variables
+var (
+	USER_HEADER  = env.GetEnvOrDefault("USERID_HEADER", "kubeflow-userid")
+	USER_PREFIX  = env.GetEnvOrDefault("USERID_PREFIX", ":")
+	DISABLE_AUTH = env.GetEnvOrDefault("APP_DISABLE_AUTH", "false") == "true"
+	BACKEND_MODE = env.GetEnvOrDefault("BACKEND_MODE", "prod")
+)
+
+func GetUsername(r *http.Request) (string, error) {
+	var username string
+	if DISABLE_AUTH {
+		log.Printf("APP_DISABLE_AUTH set to True. Skipping authorization check")
+		return "", nil
+	}
+
+	if r.Header.Get(USER_HEADER) == "" {
+		return "", errors.New("User header not present!")
+	}
+
+	user := r.Header.Get(USER_HEADER)
+	username = strings.Replace(user, USER_PREFIX, "", 1)
+
+	return username, nil
+}
+
+// Function for constructing SubjectAccessReviews (SAR) objects
+func CreateSAR(user string, verb string, namespace string, group string,
+	version string, resource string, subresource string, name string) *v1.SubjectAccessReview {
+
+	sar := &v1.SubjectAccessReview{
+		Spec: v1.SubjectAccessReviewSpec{
+			User: user,
+			ResourceAttributes: &v1.ResourceAttributes{
+				Namespace:   namespace,
+				Verb:        verb,
+				Group:       group,
+				Version:     version,
+				Resource:    resource,
+				Subresource: subresource,
+				Name:        name,
+			},
+		},
+	}
+	return sar
+}
+
+func IsAuthorized(user string, verb string, namespace string, group string,
+	version string, resource string, subresource string, name string, client *kubernetes.Clientset) error {
+
+	// Skip authz when in dev_mode
+	if BACKEND_MODE == "dev" || BACKEND_MODE == "development" {
+		log.Printf("Skipping authorization check in development mode")
+		return nil
+	}
+	// Skip authz when admin is explicity requested it
+	if DISABLE_AUTH {
+		log.Printf("APP_DISABLE_AUTH set to True. Skipping authorization check")
+		return nil
+	}
+
+	sar := CreateSAR(user, verb, namespace, group, version, resource, subresource, name)
+
+	res, err := client.AuthorizationV1().SubjectAccessReviews().Create(context.TODO(), sar, metav1.CreateOptions{})
+	if err != nil {
+		log.Printf("Error submitting SubjectAccessReview: %v, %s", sar, err.Error())
+		return err
+	}
+
+	if res.Status.Allowed {
+		return nil
+	}
+
+	msg := generateUnauthorizedMessage(user, verb, namespace, group, version, resource, subresource, res)
+	err = errors.New(msg)
+	return err
+}
+
+func generateUnauthorizedMessage(user string, verb string, namespace string, group string,
+	version string, resource string, subresource string, sar *v1.SubjectAccessReview) string {
+
+	msg := fmt.Sprintf("User: %s is not authorized to %s", user, verb)
+
+	if group == "" {
+		msg += fmt.Sprintf(" %s/%s", version, resource)
+	} else {
+		msg += fmt.Sprintf(" %s/%s/%s", group, version, resource)
+	}
+
+	if subresource != "" {
+		msg += fmt.Sprintf("/%s", subresource)
+	}
+
+	if namespace != "" {
+		msg += fmt.Sprintf(" in namespace: %s", namespace)
+	}
+	if sar.Status.Reason != "" {
+		msg += fmt.Sprintf(" ,reason: %s", sar.Status.Reason)
+	}
+	return msg
+}

--- a/pkg/new-ui/v1beta1/authzn.go
+++ b/pkg/new-ui/v1beta1/authzn.go
@@ -40,8 +40,8 @@ func GetUsername(r *http.Request) (string, error) {
 }
 
 // Function for constructing SubjectAccessReviews (SAR) objects
-func CreateSAR(user string, verb string, namespace string, group string,
-	version string, resource string, subresource string, name string) *v1.SubjectAccessReview {
+func CreateSAR(user, verb, namespace, group,
+	version, resource, subresource, name string) *v1.SubjectAccessReview {
 
 	sar := &v1.SubjectAccessReview{
 		Spec: v1.SubjectAccessReviewSpec{
@@ -60,8 +60,8 @@ func CreateSAR(user string, verb string, namespace string, group string,
 	return sar
 }
 
-func IsAuthorized(user string, verb string, namespace string, group string,
-	version string, resource string, subresource string, name string, client *kubernetes.Clientset) error {
+func IsAuthorized(user, verb, namespace, group,
+	version, resource, subresource, name string, client *kubernetes.Clientset) error {
 
 	// Skip authz when in dev_mode
 	if BACKEND_MODE == "dev" || BACKEND_MODE == "development" {
@@ -91,8 +91,8 @@ func IsAuthorized(user string, verb string, namespace string, group string,
 	return err
 }
 
-func generateUnauthorizedMessage(user string, verb string, namespace string, group string,
-	version string, resource string, subresource string, sar *v1.SubjectAccessReview) string {
+func generateUnauthorizedMessage(user, verb, namespace, group,
+	version, resource, subresource string, sar *v1.SubjectAccessReview) string {
 
 	msg := fmt.Sprintf("User: %s is not authorized to %s", user, verb)
 

--- a/pkg/new-ui/v1beta1/backend.go
+++ b/pkg/new-ui/v1beta1/backend.go
@@ -129,7 +129,7 @@ func (k *KatibUIHandler) CreateExperiment(w http.ResponseWriter, r *http.Request
 	}
 }
 
-func (k *KatibUIHandler) FetchNamespacedExperiments(w http.ResponseWriter, r *http.Request) {
+func (k *KatibUIHandler) FetchExperiments(w http.ResponseWriter, r *http.Request) {
 
 	// check if user's username is provided in request Header
 	user, err := GetUsername(r)

--- a/pkg/new-ui/v1beta1/backend.go
+++ b/pkg/new-ui/v1beta1/backend.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"path/filepath"
@@ -31,7 +32,6 @@ import (
 	experimentv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
 	api_pb_v1beta1 "github.com/kubeflow/katib/pkg/apis/manager/v1beta1"
 	"github.com/kubeflow/katib/pkg/util/v1beta1/katibclient"
-	"github.com/pkg/errors"
 )
 
 func NewKatibUIHandler(dbManagerAddr string) *KatibUIHandler {
@@ -40,8 +40,12 @@ func NewKatibUIHandler(dbManagerAddr string) *KatibUIHandler {
 		log.Printf("NewClient for Katib failed: %v", err)
 		panic(err)
 	}
-	// create a new client-go client for sending SAR objects in the API-SERVER
+	// create a new client for manipulating SAR objects.
 	conf, err := config.GetConfig()
+	if err != nil {
+		log.Printf("Failed to create k8s rest config: %v", err)
+		panic(err)
+	}
 	sarclient, err := kubernetes.NewForConfig(conf)
 	if err != nil {
 		log.Printf("SarClient for Katib failes: %v", err)
@@ -147,7 +151,7 @@ func (k *KatibUIHandler) FetchNamespacedExperiments(w http.ResponseWriter, r *ht
 	namespaces, ok := r.URL.Query()["namespace"]
 	if !ok {
 		log.Printf("No 'namespace' query parameter was provided.")
-		err := errors.New("No 'namespace' query parameter was provided.")
+		err := errors.New("no 'namespace' query parameter was provided")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -218,14 +222,14 @@ func (k *KatibUIHandler) DeleteExperiment(w http.ResponseWriter, r *http.Request
 	namespaces, ok := r.URL.Query()["namespace"]
 	if !ok {
 		log.Printf("No 'namespace' query parameter was provided.")
-		err := errors.New("No 'namespace' query parameter was provided.")
+		err := errors.New("no 'namespace' query parameter was provided")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	experimentNames, ok := r.URL.Query()["experimentName"]
 	if !ok {
 		log.Printf("No experimentName provided in Query parameteres! Provide an 'experimentName' param")
-		err := errors.New("No experimentName provided!")
+		err := errors.New("no experimentName provided")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -349,7 +353,7 @@ func (k *KatibUIHandler) AddTemplate(w http.ResponseWriter, r *http.Request) {
 	updatedConfigMapPath := data["updatedConfigMapPath"].(string)
 	updatedTemplateYaml := data["updatedTemplateYaml"].(string)
 
-	err = IsAuthorized(user, "add", updatedConfigMapNamespace, "", "v1", "configmaps", "", updatedConfigMapName, &k.sarClient)
+	err = IsAuthorized(user, "create", updatedConfigMapNamespace, "", "v1", "configmaps", "", updatedConfigMapName, &k.sarClient)
 	if err != nil {
 		log.Printf("The user: %s is not authorized to add configmap: %s from namespace: %s \n", user, updatedConfigMapName, updatedConfigMapNamespace)
 		http.Error(w, err.Error(), http.StatusForbidden)
@@ -404,7 +408,7 @@ func (k *KatibUIHandler) EditTemplate(w http.ResponseWriter, r *http.Request) {
 	updatedConfigMapPath := data["updatedConfigMapPath"].(string)
 	updatedTemplateYaml := data["updatedTemplateYaml"].(string)
 
-	err = IsAuthorized(user, "edit", updatedConfigMapNamespace, "", "v1", "configmaps", "", updatedConfigMapName, &k.sarClient)
+	err = IsAuthorized(user, "update", updatedConfigMapNamespace, "", "v1", "configmaps", "", updatedConfigMapName, &k.sarClient)
 	if err != nil {
 		log.Printf("The user: %s is not authorized to edit configmap: %s from namespace: %s \n", user, updatedConfigMapName, updatedConfigMapNamespace)
 		http.Error(w, err.Error(), http.StatusForbidden)
@@ -522,14 +526,14 @@ func (k *KatibUIHandler) FetchExperiment(w http.ResponseWriter, r *http.Request)
 	namespaces, ok := r.URL.Query()["namespace"]
 	if !ok {
 		log.Printf("No 'namespace' query parameter was provided.")
-		err := errors.New("No 'namespace' query parameter was provided.")
+		err := errors.New("no 'namespace' query parameter was provided")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	experimentNames, ok := r.URL.Query()["experimentName"]
 	if !ok {
 		log.Printf("No experimentName provided in Query parameteres! Provide an 'experimentName' param")
-		err := errors.New("No experimentName provided!")
+		err := errors.New("no experimentName provided")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -575,14 +579,14 @@ func (k *KatibUIHandler) FetchSuggestion(w http.ResponseWriter, r *http.Request)
 	namespaces, ok := r.URL.Query()["namespace"]
 	if !ok {
 		log.Printf("No namespace provided in Query parameters! Provide a 'namespace' param")
-		err := errors.New("No 'namespace' provided!")
+		err := errors.New("no 'namespace' provided")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	suggestionNames, ok := r.URL.Query()["suggestionName"]
 	if !ok {
 		log.Printf("No experimentName provided in Query parameteres! Provide an 'experimentName' param")
-		err := errors.New("No experimentName provided!")
+		err := errors.New("no experimentName provided")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/experiments.component.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/experiments.component.ts
@@ -125,19 +125,20 @@ export class ExperimentsComponent implements OnInit, OnDestroy {
     // Poll for new data and reset the poller if different data is found
     this.subs.add(
       this.poller.start().subscribe(() => {
-        this.backend.getExperiments().subscribe(experiments => {
-          // the backend should have proper namespace isolation
-          experiments = experiments.filter(
-            experiment => experiment.namespace === this.currNamespace,
-          );
+        if (!this.currNamespace) {
+          return;
+        }
 
-          if (isEqual(this.experiments, experiments)) {
-            return;
-          }
+        this.backend
+          .getExperiments(this.currNamespace)
+          .subscribe(experiments => {
+            if (isEqual(this.experiments, experiments)) {
+              return;
+            }
 
-          this.experiments = experiments;
-          this.poller.reset();
-        });
+            this.experiments = experiments;
+            this.poller.reset();
+          });
       }),
     );
   }

--- a/pkg/new-ui/v1beta1/frontend/src/app/services/backend.service.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/services/backend.service.ts
@@ -38,10 +38,10 @@ export class KWABackendService extends BackendService {
     return throwError(msg);
   }
 
-  getExperiments(): Observable<Experiments> {
+  getExperiments(namespace: string): Observable<Experiments> {
     // If the route doesn't end in a "/"" then the backend will return a 301 to
     // the url ending with "/".
-    const url = '/katib/fetch_experiments/';
+    const url = `/katib/fetch_namespaced_experiments/?namespace=${namespace}`;
 
     return this.http.get<any>(url).pipe(
       catchError(error => this.parseError(error)),

--- a/pkg/new-ui/v1beta1/frontend/src/app/services/backend.service.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/services/backend.service.ts
@@ -41,7 +41,7 @@ export class KWABackendService extends BackendService {
   getExperiments(namespace: string): Observable<Experiments> {
     // If the route doesn't end in a "/"" then the backend will return a 301 to
     // the url ending with "/".
-    const url = `/katib/fetch_namespaced_experiments/?namespace=${namespace}`;
+    const url = `/katib/fetch_experiments/?namespace=${namespace}`;
 
     return this.http.get<any>(url).pipe(
       catchError(error => this.parseError(error)),

--- a/pkg/new-ui/v1beta1/hp.go
+++ b/pkg/new-ui/v1beta1/hp.go
@@ -27,6 +27,8 @@ import (
 	"time"
 
 	commonv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
+	experimentv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
+	trialv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/trials/v1beta1"
 	api_pb_v1beta1 "github.com/kubeflow/katib/pkg/apis/manager/v1beta1"
 )
 
@@ -59,7 +61,7 @@ func (k *KatibUIHandler) FetchHPJobInfo(w http.ResponseWriter, r *http.Request) 
 	experimentName := experimentNames[0]
 	namespace := namespaces[0]
 
-	err = IsAuthorized(user, "get", namespace, "kubeflow.org", "v1beta1", "experiments", "", experimentName, &k.sarClient)
+	err = IsAuthorized(user, "get", namespace, "experiments", "", experimentName, experimentv1beta1.SchemeGroupVersion, k.sarClient)
 	if err != nil {
 		log.Printf("The user: %s is not authorized to get experiments from namespace: %s \n", user, namespace)
 		http.Error(w, err.Error(), http.StatusForbidden)
@@ -96,7 +98,7 @@ func (k *KatibUIHandler) FetchHPJobInfo(w http.ResponseWriter, r *http.Request) 
 	}
 	log.Printf("Got Parameters names")
 
-	err = IsAuthorized(user, "list", namespace, "kubeflow.org", "v1beta1", "trials", "", "", &k.sarClient)
+	err = IsAuthorized(user, "list", namespace, "trials", "", "", trialv1beta1.SchemeGroupVersion, k.sarClient)
 	if err != nil {
 		log.Printf("The user: %s is not authorized to list trials from namespace: %s \n", user, namespace)
 		http.Error(w, err.Error(), http.StatusForbidden)
@@ -220,7 +222,7 @@ func (k *KatibUIHandler) FetchHPJobTrialInfo(w http.ResponseWriter, r *http.Requ
 	conn, c := k.connectManager()
 	defer conn.Close()
 
-	err = IsAuthorized(user, "list", namespace, "kubeflow.org", "v1beta1", "trials", "", trialName, &k.sarClient)
+	err = IsAuthorized(user, "list", namespace, "trials", "", trialName, trialv1beta1.SchemeGroupVersion, k.sarClient)
 	if err != nil {
 		log.Printf("The user: %s is not authorized to get trial: %s from namespace: %s \n", user, trialName, namespace)
 		http.Error(w, err.Error(), http.StatusForbidden)

--- a/pkg/new-ui/v1beta1/hp.go
+++ b/pkg/new-ui/v1beta1/hp.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"strconv"
@@ -27,7 +28,6 @@ import (
 
 	commonv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
 	api_pb_v1beta1 "github.com/kubeflow/katib/pkg/apis/manager/v1beta1"
-	"github.com/pkg/errors"
 )
 
 const kfpRunIDAnnotation = "kubeflow-kale.org/kfp-run-uuid"
@@ -45,14 +45,14 @@ func (k *KatibUIHandler) FetchHPJobInfo(w http.ResponseWriter, r *http.Request) 
 	namespaces, ok := r.URL.Query()["namespace"]
 	if !ok {
 		log.Printf("No namespace provided in Query parameters! Provide a 'namespace' param")
-		err := errors.New("No 'namespace' provided!")
+		err := errors.New("no 'namespace' provided")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	experimentNames, ok := r.URL.Query()["experimentName"]
 	if !ok {
 		log.Printf("No experimentName provided in Query parameteres! Provide an 'experimentName' param")
-		err := errors.New("No experimentName provided!")
+		err := errors.New("no experimentName provided")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -201,7 +201,7 @@ func (k *KatibUIHandler) FetchHPJobTrialInfo(w http.ResponseWriter, r *http.Requ
 	namespaces, ok := r.URL.Query()["namespace"]
 	if !ok {
 		log.Printf("No namespace provided in Query parameters! Provide a 'namespace' param")
-		err := errors.New("No 'namespace' provided!")
+		err := errors.New("no 'namespace' provided")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -209,7 +209,7 @@ func (k *KatibUIHandler) FetchHPJobTrialInfo(w http.ResponseWriter, r *http.Requ
 	trialNames, ok := r.URL.Query()["trialName"]
 	if !ok {
 		log.Printf("No trialName provided in Query parameters! Provide a 'trialName' param")
-		err := errors.New("No 'trialName' provided!")
+		err := errors.New("no 'trialName' provided")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/pkg/new-ui/v1beta1/types.go
+++ b/pkg/new-ui/v1beta1/types.go
@@ -20,7 +20,7 @@ import (
 	v1beta1experiment "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 	"github.com/kubeflow/katib/pkg/util/v1beta1/katibclient"
-	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -76,7 +76,7 @@ type Template struct {
 
 type KatibUIHandler struct {
 	katibClient   katibclient.Client
-	sarClient     kubernetes.Clientset
+	sarClient     client.Client
 	dbManagerAddr string
 }
 

--- a/pkg/new-ui/v1beta1/types.go
+++ b/pkg/new-ui/v1beta1/types.go
@@ -20,6 +20,7 @@ import (
 	v1beta1experiment "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 	"github.com/kubeflow/katib/pkg/util/v1beta1/katibclient"
+	"k8s.io/client-go/kubernetes"
 )
 
 var (
@@ -75,6 +76,7 @@ type Template struct {
 
 type KatibUIHandler struct {
 	katibClient   katibclient.Client
+	sarClient     kubernetes.Clientset
 	dbManagerAddr string
 }
 

--- a/pkg/new-ui/v1beta1/types.go
+++ b/pkg/new-ui/v1beta1/types.go
@@ -20,7 +20,6 @@ import (
 	v1beta1experiment "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 	"github.com/kubeflow/katib/pkg/util/v1beta1/katibclient"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -76,7 +75,6 @@ type Template struct {
 
 type KatibUIHandler struct {
 	katibClient   katibclient.Client
-	sarClient     client.Client
 	dbManagerAddr string
 }
 

--- a/pkg/new-ui/v1beta1/util.go
+++ b/pkg/new-ui/v1beta1/util.go
@@ -104,7 +104,7 @@ func (k *KatibUIHandler) getTrialTemplatesViewList(user string) ([]TrialTemplate
 			} else {
 				// for all other namespaces check authorization rbac
 				configmapName := cmap.ObjectMeta.Name
-				err = IsAuthorized(user, "get", ns, "", "v1", "configmaps", "", configmapName, &k.sarClient)
+				err = IsAuthorized(user, "get", ns, "", "", configmapName, apiv1.SchemeGroupVersion, k.sarClient)
 				if err != nil {
 					log.Printf("The user: %s is not authorized to view configmap: %s from namespace: %s \n", user, configmapName, ns)
 					return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
The current backend for the new UI does not perform any authorization checks. It should comply with the authz guidelines (https://github.com/kubeflow/kubeflow/issues/5566) and use `SubjectAccessReviews` (SAR) to check if a user has permissions to perform an action.

This PR:
- introduces authz checks for actions on:
  - `Trials`
  - `Experiments`
  - `TrialTemplates`

- introduces three ENV variables:
  - `APP_DISABLE_AUTH`: Skip authorization if an admin is explicitly requested it.
  - `BACKEND_MODE`: dev or prod mode. Skip authorization when in dev mode.
  - `USERID_HEADER`: to check and ensure that a username is provided into the header of every http request towards the api-server.

Before any request proceed to K8s api-server:
* check if authorization must be skipped (BACKEND_MODE, APP_DISBLE_AUTH)
* check if a username is proviced in request Header (authentication)
* query the K8s api-server with SAR to ensure that the user has appropriate access privileges

Other changes:
- Introduce a client-go client to construct `SubjectAccessReview` objects.
- Replace the `/katib/fetch_experiment/` route with `/katib/fetch_namespaced_experiments`. This route expects a namespace as a query parameter from which all experiments will be fetched.
- Update the `README` of the web app to expose that devs should set `APP_DISABLE_AUTH=true` when running locally


Fixes #1547 
