### PR TITLE
Fix main process retrieve logic for early stopping

### DIFF
--- a/cmd/metricscollector/v1beta1/file-metricscollector/main.go
+++ b/cmd/metricscollector/v1beta1/file-metricscollector/main.go
@@ -161,7 +161,9 @@ func watchMetricsFile(mFile string, stopRules stopRulesFlag, filters []string, f
 	checkMetricFile(mFile)
 
 	// Get Main process.
-	_, mainProcPid, err := common.GetMainProcesses(mFile)
+	// Extract the metric file dir path based on the file name.
+	mDirPath, _ := filepath.Split(mFile)
+	_, mainProcPid, err := common.GetMainProcesses(mDirPath)
 	if err != nil {
 		klog.Fatalf("GetMainProcesses failed: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
The GetMainProcesses function expects the directory for completed marker, e.g.  `/var/log/katib`:
https://github.com/kubeflow/katib/blob/master/pkg/metricscollector/v1beta1/common/pns.go#L94
The current code will pass the entire log file i.e `/var/log/katib/metrics.log`. When there is only single container, this code path will work since if will assign the first non-0 pid as main process. However, when multiple sidecar containers presented this method will break.


**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
