### PR TITLE
UI: Rename and right align the age column

### DIFF
--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/config.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/config.ts
@@ -36,8 +36,9 @@ export const experimentsTableConfig: TableConfig = {
       }),
     },
     {
-      matHeaderCellDef: 'Age',
+      matHeaderCellDef: 'Created at',
       matColumnDef: 'age',
+      textAlignment: 'right',
       value: new DateTimeValue({
         field: 'startTime',
       }),


### PR DESCRIPTION
In this PR, we rename the `Age` header of app's main table to `Created at` and right align it.

Related PR: https://github.com/kubeflow/kubeflow/pull/6694

Signed-off-by: Elena Zioga <elena@arrikto.com>
