### PR TITLE
[kwa-show-status-first] Show the trials table's status column first

### DIFF
--- a/pkg/new-ui/v1beta1/hp.go
+++ b/pkg/new-ui/v1beta1/hp.go
@@ -41,7 +41,7 @@ func (k *KatibUIHandler) FetchHPJobInfo(w http.ResponseWriter, r *http.Request) 
 	conn, c := k.connectManager()
 	defer conn.Close()
 
-	resultText := "trialName,Status"
+	resultText := "Status,trialName"
 	experiment, err := k.katibClient.GetExperiment(experimentName, namespace)
 	if err != nil {
 		log.Printf("GetExperiment from HP job failed: %v", err)
@@ -129,7 +129,7 @@ func (k *KatibUIHandler) FetchHPJobInfo(w http.ResponseWriter, r *http.Request) 
 		for _, trialParam := range t.Spec.ParameterAssignments {
 			trialResText[paramList[trialParam.Name]] = trialParam.Value
 		}
-		resultText += "\n" + t.Name + "," + lastTrialCondition + "," + strings.Join(trialResText, ",")
+		resultText += "\n" + lastTrialCondition + "," + t.Name + "," + strings.Join(trialResText, ",")
 		if foundPipelineUID {
 			resultText += "," + runUid
 		}


### PR DESCRIPTION
In this PR, we move the status column to the first position of the trials table as it is in the other tables.

Here's a screenshot:
![image](https://user-images.githubusercontent.com/87971102/199214837-872c0e6e-1ab7-4485-a1ea-91ece183bdfc.png)

Signed-off-by: Elena Zioga <elena@arrikto.com>