### PR TITLE
[kwa-kfp-component] Introduce KWA's frontend component for kfp links

### DIFF
--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/kfp-run/kfp-run.component.html
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/kfp-run/kfp-run.component.html
@@ -1,0 +1,13 @@
+<a
+  *ngIf="trialKfpRunUrl"
+  class="svg-color-enabled"
+  [href]="trialKfpRunUrl"
+  target="_blank"
+  rel="noopener noreferrer"
+>
+  <mat-icon svgIcon="pipeline-centered"> </mat-icon>
+</a>
+
+<div *ngIf="!trialKfpRunUrl" class="svg-color-disabled" matTooltip="No KFP run">
+  <mat-icon svgIcon="pipeline-centered"> </mat-icon>
+</div>

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/kfp-run/kfp-run.component.scss
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/kfp-run/kfp-run.component.scss
@@ -1,0 +1,7 @@
+.svg-color-enabled {
+  color: #1e88e5;
+}
+
+.svg-color-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/kfp-run/kfp-run.component.spec.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/kfp-run/kfp-run.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatIconModule } from '@angular/material/icon';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+
+import { KfpRunComponent } from './kfp-run.component';
+
+describe('KfpRunComponent', () => {
+  let component: KfpRunComponent;
+  let fixture: ComponentFixture<KfpRunComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatIconModule, MatIconTestingModule],
+      declarations: [KfpRunComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(KfpRunComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/kfp-run/kfp-run.component.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/kfp-run/kfp-run.component.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+import { TableColumnComponent } from 'kubeflow/lib/resource-table/component-value/component-value.component';
+
+@Component({
+  selector: 'app-kfp-run',
+  templateUrl: './kfp-run.component.html',
+  styleUrls: ['./kfp-run.component.scss'],
+})
+export class KfpRunComponent implements TableColumnComponent {
+  constructor() {}
+
+  trialKfpRunUrl: string = '';
+
+  set element(experiment: any) {
+    if (experiment?.['kfp run']) {
+      this.trialKfpRunUrl = `/pipeline/#/runs/details/${experiment['kfp run']}`;
+    } else {
+      this.trialKfpRunUrl = '';
+    }
+  }
+}


### PR DESCRIPTION
In this PR:
- Introduce the `kfp-run` component as a distinct component.
- Make the pipeline button a link.

Here's a screenshot:
![image](https://user-images.githubusercontent.com/87971102/199739578-0cc242b5-b57e-470f-9ebd-2488ff3f3729.png)

Signed-off-by: Elena Zioga <elena@arrikto.com>
