### PR TITLE
[chore] Upgrade docker/metadata-action, actions/checkout, and actions/setup-python version

### DIFF
--- a/.github/workflows/build-and-publish-images.yaml
+++ b/.github/workflows/build-and-publish-images.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Docker Login
         # Trigger workflow only for kubeflow/katib repository with specific branch (master, release-.*) or tag (v.*).

--- a/.github/workflows/darts-cifar10-e2e-test.yaml
+++ b/.github/workflows/darts-cifar10-e2e-test.yaml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Test Env
         uses: ./.github/workflows/template-setup-e2e-test

--- a/.github/workflows/enas-cifar10-e2e-test.yaml
+++ b/.github/workflows/enas-cifar10-e2e-test.yaml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Test Env
         uses: ./.github/workflows/template-setup-e2e-test

--- a/.github/workflows/katib-ui-e2e-test.yaml
+++ b/.github/workflows/katib-ui-e2e-test.yaml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Test Env
         uses: ./.github/workflows/template-setup-e2e-test

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/mxnet-mnist-e2e-test.yaml
+++ b/.github/workflows/mxnet-mnist-e2e-test.yaml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Test Env
         uses: ./.github/workflows/template-setup-e2e-test

--- a/.github/workflows/pytorch-mnist-e2e-test.yaml
+++ b/.github/workflows/pytorch-mnist-e2e-test.yaml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Test Env
         uses: ./.github/workflows/template-setup-e2e-test

--- a/.github/workflows/simple-pbt-e2e-test.yaml
+++ b/.github/workflows/simple-pbt-e2e-test.yaml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Test Env
         uses: ./.github/workflows/template-setup-e2e-test

--- a/.github/workflows/template-publish-image/action.yaml
+++ b/.github/workflows/template-publish-image/action.yaml
@@ -27,7 +27,7 @@ runs:
 
     - name: Add Docker Tags
       id: meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v4
       with:
         images: ${{ inputs.image }}
         tags: |

--- a/.github/workflows/test-charmed-katib.yaml
+++ b/.github/workflows/test-charmed-katib.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - uses: balchua/microk8s-actions@v0.2.2
         with:

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -15,7 +15,7 @@ jobs:
         working-directory: ${{ env.GOPATH }}/src/github.com/kubeflow/katib
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{ env.GOPATH }}/src/github.com/kubeflow/katib
 
@@ -48,7 +48,7 @@ jobs:
         working-directory: ${{ env.GOPATH }}/src/github.com/kubeflow/katib
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{ env.GOPATH }}/src/github.com/kubeflow/katib
 

--- a/.github/workflows/test-node.yaml
+++ b/.github/workflows/test-node.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/test-shell-script.yaml
+++ b/.github/workflows/test-shell-script.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run shellcheck
         run: make shellcheck

--- a/.github/workflows/tf-mnist-with-summaries-e2e-test.yaml
+++ b/.github/workflows/tf-mnist-with-summaries-e2e-test.yaml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Test Env
         uses: ./.github/workflows/template-setup-e2e-test


### PR DESCRIPTION
Signed-off-by: tenzen-y <yuki.iwai.tz@gmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
To resolve the following warning, I upgraded docker/metadata-action to v4, actions/checkout to v3, and actions/setup-python to v4.

```shell
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, docker/metadata-action, actions/checkout
```

```shell
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-python, actions/setup-python, actions/checkout
```

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
