### PR TITLE
gh-actions: Extend action to run Frontend Unit tests

### DIFF
--- a/.github/workflows/darts-cifar10-e2e-test.yaml
+++ b/.github/workflows/darts-cifar10-e2e-test.yaml
@@ -1,6 +1,8 @@
 name: E2E Test with darts-cnn-cifar10
 on:
-  - pull_request
+  pull_request:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/enas-cifar10-e2e-test.yaml
+++ b/.github/workflows/enas-cifar10-e2e-test.yaml
@@ -1,6 +1,8 @@
 name: E2E Test with enas-cnn-cifar10
 on:
-  - pull_request
+  pull_request:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mxnet-mnist-e2e-test.yaml
+++ b/.github/workflows/mxnet-mnist-e2e-test.yaml
@@ -1,6 +1,8 @@
 name: E2E Test with mxnet-mnist
 on:
-  - pull_request
+  pull_request:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-algorithm-images.yaml
+++ b/.github/workflows/publish-algorithm-images.yaml
@@ -1,8 +1,12 @@
 name: Publish AutoML Algorithm Images
 
 on:
-  - push
-  - pull_request
+  push:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
+  pull_request:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
 
 jobs:
   algorithm:

--- a/.github/workflows/publish-core-images.yaml
+++ b/.github/workflows/publish-core-images.yaml
@@ -1,8 +1,12 @@
 name: Publish Katib Core Images
 
 on:
-  - push
-  - pull_request
+  push:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
+  pull_request:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
 
 jobs:
   core:
@@ -15,7 +19,6 @@ jobs:
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-
 
     strategy:
       fail-fast: false

--- a/.github/workflows/publish-katib-ui-image.yaml
+++ b/.github/workflows/publish-katib-ui-image.yaml
@@ -1,0 +1,17 @@
+name: Publish Katib UI Image
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  ui:
+    name: Publish Image
+    uses: ./.github/workflows/build-and-publish-images.yaml
+    with:
+      component-name: katib-ui
+      platforms: linux/amd64,linux/arm64
+      dockerfile: cmd/new-ui/v1beta1/Dockerfile
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/publish-trial-images.yaml
+++ b/.github/workflows/publish-trial-images.yaml
@@ -1,8 +1,12 @@
 name: Publish Trial Images
 
 on:
-  - push
-  - pull_request
+  push:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
+  pull_request:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
 
 jobs:
   trial:

--- a/.github/workflows/pytorch-mnist-e2e-test.yaml
+++ b/.github/workflows/pytorch-mnist-e2e-test.yaml
@@ -1,6 +1,8 @@
 name: E2E Test with pytorch-mnist
 on:
-  - pull_request
+  pull_request:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/simple-pbt-e2e-test.yaml
+++ b/.github/workflows/simple-pbt-e2e-test.yaml
@@ -1,6 +1,8 @@
 name: E2E Test with simple-pbt
 on:
-  - pull_request
+  pull_request:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-charmed-katib.yaml
+++ b/.github/workflows/test-charmed-katib.yaml
@@ -1,8 +1,12 @@
 name: Charmed Katib
 
 on:
-  - push
-  - pull_request
+  push:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
+  pull_request:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
 
 jobs:
   lint:

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -1,8 +1,12 @@
 name: Go Test
 
 on:
-  - push
-  - pull_request
+  push:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
+  pull_request:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
 
 jobs:
   generatetests:

--- a/.github/workflows/test-node.yaml
+++ b/.github/workflows/test-node.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 12.18.1
 
@@ -22,3 +22,37 @@ jobs:
         run: |
           npm install prettier --prefix ./pkg/new-ui/v1beta1/frontend
           make prettier-check
+
+  frontend-unit-tests:
+    name: Frontend Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 12.18.1
+
+      - name: Fetch Kubeflow and install common code dependencies
+        run: |
+          cd /tmp && git clone https://github.com/kubeflow/kubeflow.git
+          cd kubeflow
+          git checkout c4ca7a9
+          cd components/crud-web-apps/common/frontend/kubeflow-common-lib
+          npm i
+          npm run build
+          npm link ./dist/kubeflow
+
+      - name: Install KWA dependencies
+        run: |
+          cd pkg/new-ui/v1beta1/frontend
+          npm i
+          npm link kubeflow
+
+      - name: Run unit tests
+        run: |
+          cd pkg/new-ui/v1beta1/frontend
+          npm run test:prod

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -1,8 +1,12 @@
 name: Python Test
 
 on:
-  - push
-  - pull_request
+  push:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
+  pull_request:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
 
 jobs:
   test:

--- a/.github/workflows/test-shell-script.yaml
+++ b/.github/workflows/test-shell-script.yaml
@@ -1,8 +1,12 @@
 name: Shellcheck
 
 on:
-  - push
-  - pull_request
+  push:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
+  pull_request:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
 
 jobs:
   test:

--- a/.github/workflows/tf-mnist-with-summaries-e2e-test.yaml
+++ b/.github/workflows/tf-mnist-with-summaries-e2e-test.yaml
@@ -1,6 +1,8 @@
 name: E2E Test with tf-mnist-with-summaries
 on:
-  - pull_request
+  pull_request:
+    paths-ignore:
+      - 'pkg/new-ui/v1beta1/frontend/**'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pkg/new-ui/v1beta1/frontend/package.json
+++ b/pkg/new-ui/v1beta1/frontend/package.json
@@ -8,6 +8,7 @@
     "build:prod": "npm run copyLibAssets && ng build --base-href /katib/ --deploy-url /katib/static/  --outputPath dist/static --configuration production",
     "copyLibAssets": "cp -r ./node_modules/kubeflow/assets/* ./src/assets/",
     "test": "ng test",
+    "test:prod": "ng test --browsers=ChromeHeadless --watch=false",
     "lint": "ng lint",
     "format:check": "prettier --check 'src/**/*.{jsx,js,ts,html,scss,css}' || node scripts/check-format-error.js",
     "format:write": "prettier --write 'src/**/*.{jsx,js,ts,html,scss,css}'",


### PR DESCRIPTION
This is a follow up PR to this https://github.com/kubeflow/katib/pull/1977. Here, we extend the GH action [Frontend Test](https://github.com/kubeflow/katib/blob/master/.github/workflows/test-node.yaml) to include a job that runs KWA frontend unit tests as well. This also is needed before this PR https://github.com/kubeflow/katib/pull/1991#issuecomment-1301793351 is merged to ensure that nothing breaks.