### PR TITLE
More container fields for SuggestionConfig

### DIFF
--- a/pkg/controller.v1beta1/suggestion/composer/composer.go
+++ b/pkg/controller.v1beta1/suggestion/composer/composer.go
@@ -186,6 +186,11 @@ func (g *General) desiredContainers(s *suggestionsv1beta1.Suggestion,
 		Name:            consts.ContainerSuggestion,
 		Image:           suggestionConfigData.Image,
 		ImagePullPolicy: suggestionConfigData.ImagePullPolicy,
+		Command:         suggestionConfigData.Command,
+		Args:            suggestionConfigData.Args,
+		WorkingDir:      suggestionConfigData.WorkingDir,
+		EnvFrom:         suggestionConfigData.EnvFrom,
+		Env:             suggestionConfigData.Env,
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          consts.DefaultSuggestionPortName,

--- a/pkg/controller.v1beta1/suggestion/composer/composer.go
+++ b/pkg/controller.v1beta1/suggestion/composer/composer.go
@@ -181,8 +181,12 @@ func (g *General) desiredContainers(s *suggestionsv1beta1.Suggestion,
 	suggestionConfigData katibconfig.SuggestionConfig,
 	earlyStoppingConfigData katibconfig.EarlyStoppingConfig) []corev1.Container {
 
-	containers := []corev1.Container{}
-	suggestionContainer := suggestionConfigData.Container
+	var (
+		containers          []corev1.Container
+		suggestionContainer corev1.Container
+	)
+
+	suggestionConfigData.Container.DeepCopyInto(&suggestionContainer)
 
 	// Assign default values for suggestionContainer fields that are not set via
 	// the suggestion config.

--- a/pkg/controller.v1beta1/suggestion/composer/composer.go
+++ b/pkg/controller.v1beta1/suggestion/composer/composer.go
@@ -195,7 +195,8 @@ func (g *General) desiredContainers(s *suggestionsv1beta1.Suggestion,
 		suggestionContainer.Name = consts.ContainerSuggestion
 	}
 
-	if !containsContainerPort(suggestionContainer.Ports, consts.DefaultSuggestionPortName) {
+	if !containsContainerPortWithName(suggestionContainer.Ports, consts.DefaultSuggestionPortName) &&
+		!containsContainerPort(suggestionConfigData.Ports, consts.DefaultSuggestionPort) {
 		suggestionPort := corev1.ContainerPort{
 			Name:          consts.DefaultSuggestionPortName,
 			ContainerPort: consts.DefaultSuggestionPort,
@@ -236,7 +237,7 @@ func (g *General) desiredContainers(s *suggestionsv1beta1.Suggestion,
 		}
 	}
 
-	if s.Spec.ResumePolicy == experimentsv1beta1.FromVolume && !containsVolumeMount(suggestionContainer.VolumeMounts, consts.ContainerSuggestionVolumeName) {
+	if s.Spec.ResumePolicy == experimentsv1beta1.FromVolume && !containsVolumeMountWithName(suggestionContainer.VolumeMounts, consts.ContainerSuggestionVolumeName) {
 		suggestionVolume := corev1.VolumeMount{
 			Name:      consts.ContainerSuggestionVolumeName,
 			MountPath: suggestionConfigData.VolumeMountPath,
@@ -264,7 +265,7 @@ func (g *General) desiredContainers(s *suggestionsv1beta1.Suggestion,
 	return containers
 }
 
-func containsVolumeMount(volumeMounts []corev1.VolumeMount, name string) bool {
+func containsVolumeMountWithName(volumeMounts []corev1.VolumeMount, name string) bool {
 	for i := range volumeMounts {
 		if volumeMounts[i].Name == name {
 			return true
@@ -274,9 +275,19 @@ func containsVolumeMount(volumeMounts []corev1.VolumeMount, name string) bool {
 	return false
 }
 
-func containsContainerPort(ports []corev1.ContainerPort, name string) bool {
+func containsContainerPortWithName(ports []corev1.ContainerPort, name string) bool {
 	for i := range ports {
 		if ports[i].Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func containsContainerPort(ports []corev1.ContainerPort, port int32) bool {
+	for i := range ports {
+		if ports[i].ContainerPort == port {
 			return true
 		}
 	}

--- a/pkg/controller.v1beta1/suggestion/composer/composer.go
+++ b/pkg/controller.v1beta1/suggestion/composer/composer.go
@@ -184,6 +184,13 @@ func (g *General) desiredContainers(s *suggestionsv1beta1.Suggestion,
 	containers := []corev1.Container{}
 	suggestionContainer := suggestionConfigData.Container
 
+	// Assign default values for suggestionContainer fields that are not set via
+	// the suggestion config.
+
+	if suggestionContainer.Name == "" {
+		suggestionContainer.Name = consts.ContainerSuggestion
+	}
+
 	if len(suggestionContainer.Ports) == 0 {
 		suggestionContainer.Ports = []corev1.ContainerPort{
 			{

--- a/pkg/controller.v1beta1/suggestion/composer/composer_test.go
+++ b/pkg/controller.v1beta1/suggestion/composer/composer_test.go
@@ -646,18 +646,20 @@ func newFakeSuggestionConfig() katibconfig.SuggestionConfig {
 	diskQ, _ := resource.ParseQuantity(disk)
 
 	return katibconfig.SuggestionConfig{
-		Image:           image,
-		ImagePullPolicy: imagePullPolicy,
-		Resource: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:              cpuQ,
-				corev1.ResourceMemory:           memoryQ,
-				corev1.ResourceEphemeralStorage: diskQ,
-			},
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:              cpuQ,
-				corev1.ResourceMemory:           memoryQ,
-				corev1.ResourceEphemeralStorage: diskQ,
+		Container: corev1.Container{
+			Image:           image,
+			ImagePullPolicy: imagePullPolicy,
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:              cpuQ,
+					corev1.ResourceMemory:           memoryQ,
+					corev1.ResourceEphemeralStorage: diskQ,
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:              cpuQ,
+					corev1.ResourceMemory:           memoryQ,
+					corev1.ResourceEphemeralStorage: diskQ,
+				},
 			},
 		},
 		ServiceAccountName: serviceAccount,

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller_test.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller_test.go
@@ -435,7 +435,9 @@ func newKatibConfigMapInstance() *corev1.ConfigMap {
 	// Create suggestion config
 	suggestionConfig := map[string]katibconfig.SuggestionConfig{
 		"random": {
-			Image: suggestionImage,
+			Container: corev1.Container{
+				Image: suggestionImage,
+			},
 		},
 	}
 	bSuggestionConfig, _ := json.Marshal(suggestionConfig)

--- a/pkg/util/v1beta1/katibconfig/config.go
+++ b/pkg/util/v1beta1/katibconfig/config.go
@@ -34,14 +34,7 @@ import (
 
 // SuggestionConfig is the JSON suggestion structure in Katib config.
 type SuggestionConfig struct {
-	Image                     string                           `json:"image"`
-	ImagePullPolicy           corev1.PullPolicy                `json:"imagePullPolicy,omitempty"`
-	Command                   []string                         `json:"command,omitempty"`
-	Args                      []string                         `json:"args,omitempty"`
-	WorkingDir                string                           `json:"workingDir,omitempty"`
-	EnvFrom                   []corev1.EnvFromSource           `json:"envFrom,omitempty"`
-	Env                       []corev1.EnvVar                  `json:"env,omitempty"`
-	Resource                  corev1.ResourceRequirements      `json:"resources,omitempty"`
+	corev1.Container          `json:",inline"`
 	ServiceAccountName        string                           `json:"serviceAccountName,omitempty"`
 	VolumeMountPath           string                           `json:"volumeMountPath,omitempty"`
 	PersistentVolumeClaimSpec corev1.PersistentVolumeClaimSpec `json:"persistentVolumeClaimSpec,omitempty"`
@@ -103,7 +96,7 @@ func GetSuggestionConfigData(algorithmName string, client client.Client) (Sugges
 	suggestionConfigData.ImagePullPolicy = setImagePullPolicy(suggestionConfigData.ImagePullPolicy)
 
 	// Set resource requirements for suggestion
-	suggestionConfigData.Resource = setResourceRequirements(suggestionConfigData.Resource)
+	suggestionConfigData.Resources = setResourceRequirements(suggestionConfigData.Resources)
 
 	// Set default suggestion container volume mount path
 	if suggestionConfigData.VolumeMountPath == "" {

--- a/pkg/util/v1beta1/katibconfig/config.go
+++ b/pkg/util/v1beta1/katibconfig/config.go
@@ -36,6 +36,11 @@ import (
 type SuggestionConfig struct {
 	Image                     string                           `json:"image"`
 	ImagePullPolicy           corev1.PullPolicy                `json:"imagePullPolicy,omitempty"`
+	Command                   []string                         `json:"command,omitempty"`
+	Args                      []string                         `json:"args,omitempty"`
+	WorkingDir                string                           `json:"workingDir,omitempty"`
+	EnvFrom                   []corev1.EnvFromSource           `json:"envFrom,omitempty"`
+	Env                       []corev1.EnvVar                  `json:"env,omitempty"`
 	Resource                  corev1.ResourceRequirements      `json:"resources,omitempty"`
 	ServiceAccountName        string                           `json:"serviceAccountName,omitempty"`
 	VolumeMountPath           string                           `json:"volumeMountPath,omitempty"`

--- a/pkg/util/v1beta1/katibconfig/config_test.go
+++ b/pkg/util/v1beta1/katibconfig/config_test.go
@@ -54,13 +54,13 @@ func TestGetSuggestionConfigData(t *testing.T) {
 			katibConfig: func() *katibConfig {
 				kc := &katibConfig{suggestion: map[string]*SuggestionConfig{testAlgorithmName: newFakeSuggestionConfig()}}
 				kc.suggestion[testAlgorithmName].ImagePullPolicy = corev1.PullAlways
-				kc.suggestion[testAlgorithmName].Resource = *newFakeCustomResourceRequirements()
+				kc.suggestion[testAlgorithmName].Resources = *newFakeCustomResourceRequirements()
 				return kc
 			}(),
 			expected: func() *SuggestionConfig {
 				c := newFakeSuggestionConfig()
 				c.ImagePullPolicy = corev1.PullAlways
-				c.Resource = *newFakeCustomResourceRequirements()
+				c.Resources = *newFakeCustomResourceRequirements()
 				return c
 			}(),
 			inputAlgorithmName: testAlgorithmName,
@@ -107,7 +107,7 @@ func TestGetSuggestionConfigData(t *testing.T) {
 			testDescription: "GetSuggestionConfigData sets resource.requests and resource.limits for the suggestion service",
 			katibConfig: func() *katibConfig {
 				kc := &katibConfig{suggestion: map[string]*SuggestionConfig{testAlgorithmName: newFakeSuggestionConfig()}}
-				kc.suggestion[testAlgorithmName].Resource = corev1.ResourceRequirements{}
+				kc.suggestion[testAlgorithmName].Resources = corev1.ResourceRequirements{}
 				return kc
 			}(),
 			expected:           newFakeSuggestionConfig(),
@@ -402,9 +402,11 @@ func newFakeSuggestionConfig() *SuggestionConfig {
 	defaultVolumeStorage, _ := resource.ParseQuantity(consts.DefaultSuggestionVolumeStorage)
 
 	return &SuggestionConfig{
-		Image:           "suggestion-image",
-		ImagePullPolicy: consts.DefaultImagePullPolicy,
-		Resource:        *setFakeResourceRequirements(),
+		Container: corev1.Container{
+			Image:           "suggestion-image",
+			ImagePullPolicy: consts.DefaultImagePullPolicy,
+			Resources:       *setFakeResourceRequirements(),
+		},
 		VolumeMountPath: consts.DefaultContainerSuggestionVolumeMountPath,
 		PersistentVolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR adds more fields to the `SuggestionConfig` that is used to populate the main container of the Suggestion deployment. It adds fields `command`, `args`, `envs` that can be used to pass arguments to the executable. This allows the user to easily parametrize the suggestion algorithm/executable itself by passing values using these new fields.   

**Which issue(s) this PR fixes**:
Fixes #1737 (at least partly)

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/): the docs will need to mention the new fields
