### PR TITLE
[Fix] add early stopped trials in converter

### DIFF
--- a/pkg/apis/controller/trials/v1beta1/util.go
+++ b/pkg/apis/controller/trials/v1beta1/util.go
@@ -92,6 +92,9 @@ func (trial *Trial) IsMetricsUnavailable() bool {
 
 // IsObservationAvailable return ture if the Trial has valid observations updated
 func (trial *Trial) IsObservationAvailable() bool {
+	if trial.Spec.Objective == nil {
+		return false
+	}
 	objectiveMetricName := trial.Spec.Objective.ObjectiveMetricName
 	if trial.Status.Observation != nil && trial.Status.Observation.Metrics != nil {
 		for _, metric := range trial.Status.Observation.Metrics {

--- a/pkg/apis/controller/trials/v1beta1/util.go
+++ b/pkg/apis/controller/trials/v1beta1/util.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"errors"
+	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -87,6 +88,19 @@ func (trial *Trial) IsKilled() bool {
 // IsMetricsUnavailable returns true if Trial metrics are not available
 func (trial *Trial) IsMetricsUnavailable() bool {
 	return hasCondition(trial, TrialMetricsUnavailable)
+}
+
+// IsObservationAvailable return ture if the Trial has valid observations updated
+func (trial *Trial) IsObservationAvailable() bool {
+	objectiveMetricName := trial.Spec.Objective.ObjectiveMetricName
+	if trial.Status.Observation != nil && trial.Status.Observation.Metrics != nil {
+		for _, metric := range trial.Status.Observation.Metrics {
+			if metric.Name == objectiveMetricName && metric.Latest != consts.UnavailableMetricValue {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (trial *Trial) IsCompleted() bool {

--- a/pkg/controller.v1beta1/suggestion/suggestionclient/suggestionclient.go
+++ b/pkg/controller.v1beta1/suggestion/suggestionclient/suggestionclient.go
@@ -343,7 +343,7 @@ func (g *General) ConvertTrials(ts []trialsv1beta1.Trial) []*suggestionapi.Trial
 		if t.IsMetricsUnavailable() {
 			continue
 		}
-		if !t.IsObservationAvailable() {
+		if !t.IsObservationAvailable() && t.IsEarlyStopped() {
 			continue
 		}
 		trial := &suggestionapi.Trial{

--- a/pkg/controller.v1beta1/suggestion/suggestionclient/suggestionclient.go
+++ b/pkg/controller.v1beta1/suggestion/suggestionclient/suggestionclient.go
@@ -343,6 +343,9 @@ func (g *General) ConvertTrials(ts []trialsv1beta1.Trial) []*suggestionapi.Trial
 		if t.IsMetricsUnavailable() {
 			continue
 		}
+		if !t.IsObservationAvailable() {
+			continue
+		}
 		trial := &suggestionapi.Trial{
 			Name: t.Name,
 			Spec: &suggestionapi.TrialSpec{

--- a/pkg/controller.v1beta1/suggestion/suggestionclient/suggestionclient_test.go
+++ b/pkg/controller.v1beta1/suggestion/suggestionclient/suggestionclient_test.go
@@ -804,6 +804,14 @@ func newFakeTrials() []trialsv1beta1.Trial {
 			Type: trialsv1beta1.TrialSucceeded,
 		},
 	}
+
+	fakeEarlyStoppedConditions := []trialsv1beta1.TrialCondition{
+		{
+			Type:   trialsv1beta1.TrialEarlyStopped,
+			Status: corev1.ConditionTrue,
+		},
+	}
+
 	return []trialsv1beta1.Trial{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -868,6 +876,54 @@ func newFakeTrials() []trialsv1beta1.Trial {
 						Message: "Metrics are not available",
 					},
 				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "trial4-name",
+				Namespace: "namespace",
+			},
+			Spec: trialsv1beta1.TrialSpec{
+				Objective: newFakeObjective(),
+				ParameterAssignments: []commonapiv1beta1.ParameterAssignment{
+					{
+						Name:  "param1-name",
+						Value: "4",
+					},
+					{
+						Name:  "param2-name",
+						Value: "0.4",
+					},
+				},
+				Labels: map[string]string{},
+			},
+			Status: trialsv1beta1.TrialStatus{
+				Conditions:  fakeEarlyStoppedConditions,
+				Observation: nil,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "trial5-name",
+				Namespace: "namespace",
+			},
+			Spec: trialsv1beta1.TrialSpec{
+				Objective: newFakeObjective(),
+				ParameterAssignments: []commonapiv1beta1.ParameterAssignment{
+					{
+						Name:  "param1-name",
+						Value: "5",
+					},
+					{
+						Name:  "param2-name",
+						Value: "0.5",
+					},
+				},
+				Labels: map[string]string{},
+			},
+			Status: trialsv1beta1.TrialStatus{
+				Conditions:  fakeEarlyStoppedConditions,
+				Observation: newFakeSuggestionTrialObservation(),
 			},
 		},
 	}
@@ -1010,6 +1066,38 @@ func newFakeRequest() *suggestionapi.GetSuggestionsRequest {
 					StartTime:      "",
 					CompletionTime: "",
 					Condition:      suggestionapi.TrialStatus_SUCCEEDED,
+					Observation: &suggestionapi.Observation{
+						Metrics: []*suggestionapi.Metric{
+							{
+								Name:  "metric1-name",
+								Value: "0.95",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "trial5-name",
+				Spec: &suggestionapi.TrialSpec{
+					Objective: fakeObjective,
+					ParameterAssignments: &suggestionapi.TrialSpec_ParameterAssignments{
+						Assignments: []*suggestionapi.ParameterAssignment{
+							{
+								Name:  "param1-name",
+								Value: "5",
+							},
+							{
+								Name:  "param2-name",
+								Value: "0.5",
+							},
+						},
+					},
+					Labels: fakeLabels,
+				},
+				Status: &suggestionapi.TrialStatus{
+					StartTime:      "",
+					CompletionTime: "",
+					Condition:      suggestionapi.TrialStatus_EARLYSTOPPED,
 					Observation: &suggestionapi.Observation{
 						Metrics: []*suggestionapi.Metric{
 							{

--- a/pkg/controller.v1beta1/suggestion/suggestionclient/suggestionclient_test.go
+++ b/pkg/controller.v1beta1/suggestion/suggestionclient/suggestionclient_test.go
@@ -637,6 +637,14 @@ func newFakeTrialObservation() *commonv1beta1.Observation {
 	}
 }
 
+func newFakeSuggestionTrialObservation() *commonv1beta1.Observation {
+	return &commonv1beta1.Observation{
+		Metrics: []commonv1beta1.Metric{
+			{Name: "metric1-name", Min: "0.95", Max: "0.95", Latest: "0.95"},
+		},
+	}
+}
+
 func newFakeRequestObservation() *suggestionapi.Observation {
 	return &suggestionapi.Observation{
 		Metrics: []*suggestionapi.Metric{
@@ -664,6 +672,9 @@ func newFakeObjective() *commonapiv1beta1.ObjectiveSpec {
 		ObjectiveMetricName:   "metric1-name",
 		AdditionalMetricNames: []string{"metric2-name"},
 		Goal:                  &goal,
+		MetricStrategies: []commonapiv1beta1.MetricStrategy{
+			{Name: "metric1-name", Value: commonapiv1beta1.ExtractByLatest},
+		},
 	}
 }
 
@@ -817,6 +828,7 @@ func newFakeTrials() []trialsv1beta1.Trial {
 				StartTime:      newFakeTime(),
 				CompletionTime: newFakeTime(),
 				Conditions:     fakeConditions,
+				Observation:    newFakeSuggestionTrialObservation(),
 			},
 		},
 		{
@@ -839,7 +851,8 @@ func newFakeTrials() []trialsv1beta1.Trial {
 				Labels: map[string]string{},
 			},
 			Status: trialsv1beta1.TrialStatus{
-				Conditions: fakeConditions,
+				Conditions:  fakeConditions,
+				Observation: newFakeSuggestionTrialObservation(),
 			},
 		},
 		{
@@ -965,7 +978,14 @@ func newFakeRequest() *suggestionapi.GetSuggestionsRequest {
 					StartTime:      newFakeTime().Format(timeFormat),
 					CompletionTime: newFakeTime().Format(timeFormat),
 					Condition:      suggestionapi.TrialStatus_SUCCEEDED,
-					Observation:    &suggestionapi.Observation{},
+					Observation: &suggestionapi.Observation{
+						Metrics: []*suggestionapi.Metric{
+							{
+								Name:  "metric1-name",
+								Value: "0.95",
+							},
+						},
+					},
 				},
 			},
 			{
@@ -990,7 +1010,14 @@ func newFakeRequest() *suggestionapi.GetSuggestionsRequest {
 					StartTime:      "",
 					CompletionTime: "",
 					Condition:      suggestionapi.TrialStatus_SUCCEEDED,
-					Observation:    &suggestionapi.Observation{},
+					Observation: &suggestionapi.Observation{
+						Metrics: []*suggestionapi.Metric{
+							{
+								Name:  "metric1-name",
+								Value: "0.95",
+							},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/controller.v1beta1/trial/trial_controller_util.go
+++ b/pkg/controller.v1beta1/trial/trial_controller_util.go
@@ -45,7 +45,7 @@ func (r *ReconcileTrial) UpdateTrialStatusCondition(instance *trialsv1beta1.Tria
 	timeNow := metav1.Now()
 
 	if jobStatus.Condition == trialutil.JobSucceeded {
-		if isTrialObservationAvailable(instance) && !instance.IsSucceeded() {
+		if instance.IsObservationAvailable() && !instance.IsSucceeded() {
 			if !instance.IsEarlyStopped() {
 				msg := "Trial has succeeded"
 				reason := TrialSucceededReason
@@ -160,18 +160,6 @@ func (r *ReconcileTrial) updateFinalizers(instance *trialsv1beta1.Trial, finaliz
 		// Need to requeue because finalizer update does not change metadata.generation
 		return reconcile.Result{Requeue: true}, err
 	}
-}
-
-func isTrialObservationAvailable(instance *trialsv1beta1.Trial) bool {
-	objectiveMetricName := instance.Spec.Objective.ObjectiveMetricName
-	if instance.Status.Observation != nil && instance.Status.Observation.Metrics != nil {
-		for _, metric := range instance.Status.Observation.Metrics {
-			if metric.Name == objectiveMetricName && metric.Latest != consts.UnavailableMetricValue {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func getMetrics(metricLogs []*api_pb.MetricLog, strategies []commonv1beta1.MetricStrategy) (*commonv1beta1.Observation, error) {

--- a/pkg/suggestion/v1beta1/internal/trial.py
+++ b/pkg/suggestion/v1beta1/internal/trial.py
@@ -41,7 +41,8 @@ class Trial(object):
     def convert(trials):
         res = []
         for trial in trials:
-            if trial.status.condition == api.TrialStatus.TrialConditionType.SUCCEEDED:
+            if trial.status.condition == api.TrialStatus.TrialConditionType.SUCCEEDED or
+             trial.status.condition == api.TrialStatus.TrialConditionType.EARLYSTOPPED:
                 new_trial = Trial.convertTrial(trial)
                 if new_trial is not None:
                     res.append(Trial.convertTrial(trial))

--- a/pkg/suggestion/v1beta1/internal/trial.py
+++ b/pkg/suggestion/v1beta1/internal/trial.py
@@ -42,7 +42,7 @@ class Trial(object):
         res = []
         for trial in trials:
             if trial.status.condition == api.TrialStatus.TrialConditionType.SUCCEEDED or
-             trial.status.condition == api.TrialStatus.TrialConditionType.EARLYSTOPPED:
+              trial.status.condition == api.TrialStatus.TrialConditionType.EARLYSTOPPED:
                 new_trial = Trial.convertTrial(trial)
                 if new_trial is not None:
                     res.append(Trial.convertTrial(trial))

--- a/pkg/suggestion/v1beta1/internal/trial.py
+++ b/pkg/suggestion/v1beta1/internal/trial.py
@@ -41,7 +41,7 @@ class Trial(object):
     def convert(trials):
         res = []
         for trial in trials:
-            if trial.status.condition == api.TrialStatus.TrialConditionType.SUCCEEDED or
+            if trial.status.condition == api.TrialStatus.TrialConditionType.SUCCEEDED or \
               trial.status.condition == api.TrialStatus.TrialConditionType.EARLYSTOPPED:
                 new_trial = Trial.convertTrial(trial)
                 if new_trial is not None:

--- a/pkg/suggestion/v1beta1/skopt/base_service.py
+++ b/pkg/suggestion/v1beta1/skopt/base_service.py
@@ -73,7 +73,7 @@ class BaseSkoptService(object):
         Get the new suggested trials with skopt algorithm.
         """
         logger.info("-" * 100 + "\n")
-        logger.info("New GetSuggestions call\n")
+        logger.info("New GetSuggestions call with current request number: {}\n".format(current_request_number))
         skopt_suggested = []
         loss_for_skopt = []
         if len(trials) > self.succeeded_trials or self.succeeded_trials == 0:
@@ -113,8 +113,6 @@ class BaseSkoptService(object):
 
         else:
             logger.error("Succeeded Trials didn't change: {}\n".format(self.succeeded_trials))
-            logger.error("No new suggestions could be generated, return early..\n")
-            return []
 
         logger.info("Running Optimizer ask to query new parameters for Trials\n")
 

--- a/pkg/suggestion/v1beta1/skopt/base_service.py
+++ b/pkg/suggestion/v1beta1/skopt/base_service.py
@@ -112,7 +112,9 @@ class BaseSkoptService(object):
                 logger.info("List of recorded Trials names: {}\n".format(self.recorded_trials_names))
 
         else:
-            logger.info("Succeeded Trials didn't change: {}\n".format(self.succeeded_trials))
+            logger.error("Succeeded Trials didn't change: {}\n".format(self.succeeded_trials))
+            logger.error("No new suggestions could be generated, return early..\n")
+            return []
 
         logger.info("Running Optimizer ask to query new parameters for Trials\n")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->
Python suggestion services will convert the trials from request payload before passing in actual search algos. However, early stopped trials are filtered out in this process and thus no updates are provided to search algo and there are duplicated trials created.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

https://github.com/kubeflow/katib/issues/2002

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
