### PR TITLE
Add More Katib Presentations 2022

### DIFF
--- a/docs/presentations.md
+++ b/docs/presentations.md
@@ -4,20 +4,22 @@ Below are the list of Katib presentations and demos. If you want to add your
 presentation or demo in this list please send a pull request. Please keep the
 list in reverse chronological order.
 
-| Presentation or Demo title | Presenters | Date |
-| --- | --- | --- |
-| [Cloud Native AutoML with Argo Workflows and Katib](https://youtu.be/KjHqmS4gIxM?t=181) | Andrey Velichkevich, Johnu George | 2022-02-16 |
-| [When Machine Learning Toolkit for Kubernetes Meets PaddlePaddle](https://github.com/terrytangyuan/public-talks/tree/main/talks/when-machine-learning-toolkit-for-kubernetes-meets-paddlepaddle-wave-summit-2021) | [Yuan Tang](https://terrytangyuan.github.io/about/) | 2021-12-12 |
-| [Bridging into Python Ecosystem with Cloud-Native Distributed Machine Learning Pipelines](https://github.com/terrytangyuan/public-talks/tree/main/talks/bridging-into-python-ecosystem-with-cloud-native-distributed-machine-learning-pipelines-argocon-2021) | [Yuan Tang](https://terrytangyuan.github.io/about/) | 2021-12-08 |
-| [Towards Cloud-Native Distributed Machine Learning Pipelines at Scale](https://github.com/terrytangyuan/public-talks/tree/main/talks/towards-cloud-native-distributed-machine-learning-pipelines-at-scale-pydata-global-2021) | [Yuan Tang](https://terrytangyuan.github.io/about/) | 2021-10-29 |
-| [AutoML and Training WG Summit July 2021](https://youtube.com/playlist?list=PL2gwy7BdKoGd9HQBCz1iC7vyFVN7Wa9N2) | Kubeflow Community | 2021-07-16 |
-| [MLREPA 2021: MLOps and AutoML in Cloud-Native Way with Kubeflow and Katib](https://youtu.be/33VJ6KNBBvU) | Andrey Velichkevich | 2021-04-25 |
-| [KF Community: A Tour of Katib's new UI for Kubeflow 1.3](https://youtu.be/1DtjB_boWcQ) | Kimonas Sotirchos | 2021-03-30 |
-| [KF Community: New UI for Kubeflow components](https://youtu.be/OKqx3IS2_G4) | Stefano Fioravanzo | 2020-12-08 |
-| [KF Community: Using Pipelines in Katib](https://youtu.be/BszcHMkGLgc) | Andrey Velichkevich | 2020-11-10 |
-| [KubeCon 2020: From Notebook to Kubeflow Pipelines with HP Tuning](https://youtu.be/QK0NxhyADpM) | Stefano Fioravanzo, Ilias Katsakioris | 2020-09-04 |
-| [Kubeflow Dojo: Distributed Training and HPO Deep Dive](https://youtu.be/KJFOlhD3L1E) | Andrew Butler, Qianyang Yu, Tommy Li, Animesh Singh | 2020-07-17 |
-| [Kubeflow 101: Hyperparameter Tuning with Katib](https://youtu.be/nIKVlosDvrc) | Stephanie Wong | 2020-06-21 |
-| [KubeCon 2019: Hyperparameter Tuning Using Kubeflow](https://youtu.be/OkAoiA6A2Ac) | Richard Liu, Johnu George | 2019-07-05 |
-| [KF Community: Kubeflow Katib & Hyperparameter Tuning](https://youtu.be/1PKH_D6zjoM) | Richard Liu | 2019-03-29 |
-| [KF Community: Neural Architecture Search System on Kubeflow](https://youtu.be/WAK37UW7spo) | Andrey Velichkevich, Kirill Prosvirov, Jinan Zhou, Anubhav Garg | 2019-03-26 |
+| Title | Presenters | Event | Date |
+| --- | --- | --- | --- |
+| [Hiding Kubernetes Complexity for ML Engineers Using Kubeflow](https://docs.google.com/presentation/d/1Fepo9TUgbsO7YpxenCq17Y9KKQU_VgqYjAVBFWAFIU4/edit?usp=sharing) | Andrey Velichkevich | RE-WORK MLOps Summit | 2022-11-10 |
+| [Managing Thousands of Automatic Machine Learning Experiments with Argo and Katib](https://youtu.be/0jBNXZjQ01I) | Andrey Velichkevich, [Yuan Tang](https://terrytangyuan.github.io/about/) | ArgoCon | 2022-09-21 |
+| [Cloud Native AutoML with Argo Workflows and Katib](https://youtu.be/KjHqmS4gIxM?t=181) | Andrey Velichkevich, Johnu George | Argo Community Meeting | 2022-02-16 |
+| [When Machine Learning Toolkit for Kubernetes Meets PaddlePaddle](https://github.com/terrytangyuan/public-talks/tree/main/talks/when-machine-learning-toolkit-for-kubernetes-meets-paddlepaddle-wave-summit-2021) | [Yuan Tang](https://terrytangyuan.github.io/about/) | Wave Summit | 2021-12-12 |
+| [Bridging into Python Ecosystem with Cloud-Native Distributed Machine Learning Pipelines](https://github.com/terrytangyuan/public-talks/tree/main/talks/bridging-into-python-ecosystem-with-cloud-native-distributed-machine-learning-pipelines-argocon-2021) | [Yuan Tang](https://terrytangyuan.github.io/about/) | ArgoCon | 2021-12-08 |
+| [Towards Cloud-Native Distributed Machine Learning Pipelines at Scale](https://github.com/terrytangyuan/public-talks/tree/main/talks/towards-cloud-native-distributed-machine-learning-pipelines-at-scale-pydata-global-2021) | [Yuan Tang](https://terrytangyuan.github.io/about/) | PyData | 2021-10-29 |
+| [AutoML and Training WG Summit July 2021](https://youtube.com/playlist?list=PL2gwy7BdKoGd9HQBCz1iC7vyFVN7Wa9N2) | Kubeflow Community | Kubeflow Summit | 2021-07-16 |
+| [MLOps and AutoML in Cloud-Native Way with Kubeflow and Katib](https://youtu.be/33VJ6KNBBvU) | Andrey Velichkevich | MLREPA | 2021-04-25 |
+| [A Tour of Katib's new UI for Kubeflow 1.3](https://youtu.be/1DtjB_boWcQ) | Kimonas Sotirchos | Kubeflow Community Meeting | 2021-03-30 |
+| [New UI for Kubeflow components](https://youtu.be/OKqx3IS2_G4) | Stefano Fioravanzo | Kubeflow Community Meeting | 2020-12-08 |
+| [Using Pipelines in Katib](https://youtu.be/BszcHMkGLgc) | Andrey Velichkevich | Kubeflow Community Meeting | 2020-11-10 |
+| [From Notebook to Kubeflow Pipelines with HP Tuning](https://youtu.be/QK0NxhyADpM) | Stefano Fioravanzo, Ilias Katsakioris | KubeCon | 2020-09-04 |
+| [Distributed Training and HPO Deep Dive](https://youtu.be/KJFOlhD3L1E) | Andrew Butler, Qianyang Yu, Tommy Li, Animesh Singh | Kubeflow Dojo | 2020-07-17 |
+| [Hyperparameter Tuning with Katib](https://youtu.be/nIKVlosDvrc) | Stephanie Wong | Kubeflow 101 | 2020-06-21 |
+| [Hyperparameter Tuning Using Kubeflow](https://youtu.be/OkAoiA6A2Ac) | Richard Liu, Johnu George | KubeCon | 2019-07-05 |
+| [Kubeflow Katib & Hyperparameter Tuning](https://youtu.be/1PKH_D6zjoM) | Richard Liu | Kubeflow Community Meeting | 2019-03-29 |
+| [Neural Architecture Search System on Kubeflow](https://youtu.be/WAK37UW7spo) | Andrey Velichkevich, Kirill Prosvirov, Jinan Zhou, Anubhav Garg | Kubeflow Community Meeting | 2019-03-26 |


### PR DESCRIPTION
I've added more Katib Presentations from 2022.
Also, I've added "Event" column to the table, so we can identify the talk source easier.

Please take a look @terrytangyuan @johnugeorge @tenzen-y @kubeflow/wg-training-leads @kubeflow/wg-automl-leads 