### PR TITLE
frontend: Enable sorting in KWA's main table

### DIFF
--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/config.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/config.ts
@@ -26,6 +26,7 @@ export const experimentsTableConfig: TableConfig = {
       value: new StatusValue({
         valueFn: parseStatus,
       }),
+      sort: true,
     },
     {
       matHeaderCellDef: 'Name',
@@ -34,6 +35,7 @@ export const experimentsTableConfig: TableConfig = {
         field: 'name',
         isLink: true,
       }),
+      sort: true,
     },
     {
       matHeaderCellDef: 'Created at',
@@ -42,6 +44,7 @@ export const experimentsTableConfig: TableConfig = {
       value: new DateTimeValue({
         field: 'startTime',
       }),
+      sort: true,
     },
     {
       matHeaderCellDef: 'Successful trials',
@@ -50,6 +53,7 @@ export const experimentsTableConfig: TableConfig = {
       value: new PropertyValue({
         valueFn: parseSucceededTrials,
       }),
+      sort: true,
     },
     {
       matHeaderCellDef: 'Running trials',
@@ -58,6 +62,7 @@ export const experimentsTableConfig: TableConfig = {
       value: new PropertyValue({
         valueFn: parseRunningTrials,
       }),
+      sort: true,
     },
     {
       matHeaderCellDef: 'Failed trials',
@@ -66,6 +71,7 @@ export const experimentsTableConfig: TableConfig = {
       value: new PropertyValue({
         valueFn: parseFailedTrials,
       }),
+      sort: true,
     },
     {
       matHeaderCellDef: 'Optimal trial',


### PR DESCRIPTION
This PR enables sorting in KWA's main table based on the following columns:
- Status
- Name
- Created at
- Successful trials
- Running trials
- Failed trials

Here's a screenshot of the app:
![image](https://user-images.githubusercontent.com/87971102/202425609-c4c4580f-bfd5-43cb-ad2b-a77b058cbc39.png)

I marked this PR as `WIP` since I couldn't build an image and tested in my cluster because of the bug reported here: https://github.com/kubeflow/katib/issues/2016 
Update: Managed to build an image and tested in my cluster. It worked as expected!

Related PRs: https://github.com/kubeflow/kubeflow/pull/6742