### PR TITLE
[bugfix] Fix value passing bug in New Experiment form

### DIFF
--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/experiment-creation.component.spec.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/experiment-creation.component.spec.ts
@@ -81,6 +81,7 @@ ExperimentFormServiceStub = {
       path: new FormControl(),
       scheme: new FormControl(),
       host: new FormControl(),
+      customYaml: new FormControl(),
     }),
   createTrialTemplateForm: () =>
     new FormGroup({

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/metrics-collector/metrics-collector.component.html
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/metrics-collector/metrics-collector.component.html
@@ -70,6 +70,7 @@
       <ng-container *ngSwitchCase="kind.CUSTOM">
         <lib-monaco-editor
           [(text)]="customYaml"
+          (textChange)="onTextChange()"
           [language]="'yaml'"
           [readOnly]="false"
           [width]="375"

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/metrics-collector/metrics-collector.component.spec.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/metrics-collector/metrics-collector.component.spec.ts
@@ -38,6 +38,7 @@ describe('FormMetricsCollectorComponent', () => {
       scheme: new FormControl(),
       host: new FormControl(),
       prometheus: new FormControl(),
+      customYaml: new FormControl(),
     });
     fixture.detectChanges();
   });

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/metrics-collector/metrics-collector.component.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/metrics-collector/metrics-collector.component.ts
@@ -10,10 +10,15 @@ import { CollectorKind } from 'src/app/enumerations/metrics-collector';
 export class FormMetricsCollectorComponent implements OnInit {
   @Input() formGroup: FormGroup;
   kind = CollectorKind;
-  customYaml =
-    'name: metrics-collector\nimage: <collector-image>\nresources: {}';
+  customYaml: string;
 
   constructor() {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.customYaml = this.formGroup.get('customYaml').value;
+  }
+
+  onTextChange() {
+    this.formGroup.patchValue({ customYaml: this.customYaml });
+  }
 }

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/yaml-modal/yaml-modal.component.spec.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/yaml-modal/yaml-modal.component.spec.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatDialogModule } from '@angular/material/dialog';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { EditorModule, FormModule } from 'kubeflow';
 
 import { YamlModalComponent } from './yaml-modal.component';
@@ -13,7 +14,13 @@ describe('YamlModalComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [CommonModule, MatDialogModule, FormModule, EditorModule],
+        imports: [
+          CommonModule,
+          MatDialogModule,
+          FormModule,
+          EditorModule,
+          MatSnackBarModule,
+        ],
         declarations: [YamlModalComponent],
         providers: [
           { provide: MatDialogRef, useValue: {} },

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/yaml-modal/yaml-modal.component.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/yaml-modal/yaml-modal.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, Inject } from '@angular/core';
 import { load, dump } from 'js-yaml';
+import { SnackBarService, SnackType } from 'kubeflow';
 import {
   MatDialog,
   MatDialogRef,
@@ -17,12 +18,17 @@ export class YamlModalComponent {
   constructor(
     public dialogRef: MatDialogRef<YamlModalComponent>,
     @Inject(MAT_DIALOG_DATA) public data: any,
+    private snack: SnackBarService,
   ) {
     this.yaml = dump(data);
   }
 
   save() {
-    this.dialogRef.close(load(this.yaml));
+    try {
+      this.dialogRef.close(load(this.yaml));
+    } catch (e) {
+      this.snack.open(`${e.reason}`, SnackType.Error, 4000);
+    }
   }
 
   close() {

--- a/pkg/new-ui/v1beta1/frontend/src/app/services/experiment-form.service.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/services/experiment-form.service.ts
@@ -207,6 +207,8 @@ export class ExperimentFormService {
         host: this.builder.control(''),
         httpHeaders: this.builder.array([]),
       }),
+      customYaml:
+        'name: metrics-collector\nimage: <collector-image>\nresources: {}',
     });
   }
 
@@ -391,8 +393,17 @@ export class ExperimentFormService {
       return metrics;
     }
 
-    /* TODO(kimwnasptd): We need to handle the Custom case */
     if (kind === 'Custom') {
+      delete metrics.source.fileSystemPath;
+      try {
+        metrics.collector.customCollector = load(group.get('customYaml').value);
+      } catch (e) {
+        this.snack.open(
+          'Metrics Colletor(Custom): ' + `${e.reason}`,
+          SnackType.Error,
+          4000,
+        );
+      }
       return metrics;
     }
 
@@ -421,7 +432,11 @@ export class ExperimentFormService {
       try {
         trialTemplate.trialSpec = load(formValue.yaml);
       } catch (e) {
-        this.snack.open(`${e.reason}`, SnackType.Warning, 4000);
+        this.snack.open(
+          'Trial Template: ' + `${e.reason}`,
+          SnackType.Error,
+          4000,
+        );
       }
 
       return trialTemplate;


### PR DESCRIPTION
While looking at the integration of our previous YAML editor (`ace-editor`), we found out that we do not take the appropriate actions in order to pass the `customYaml` input as part of the form it is in.

**Steps to reproduce the issue:**
* Write any kind of input in `Metrics Collector` > `Kind: Custom` > `Editor`
* Click `Create` or `Edit and Submit YAML`
An error will come up since we haven't set up properly a new experiment but if in our browser we use `Inspect` > `Network (tab)` > `create_experiment` > `postData` > `spec`. We can see `metricsCollectorSpec` > `source` hasn't any updated data in the section below:
(https://github.com/kubeflow/katib/blob/master/examples/v1beta1/metrics-collector/custom-metrics-collector.yaml#L18-L35)
```
    collector:
      kind: Custom
      customCollector:
        args:
          - -m
          - accuracy
          - -s
          - katib-db-manager.kubeflow:6789
          - -path
          - /katib/mnist.log
        image: kubeflowkatib/custom-metrics-collector:latest
        imagePullPolicy: Always
        name: custom-metrics-logger-and-collector
        env:
          - name: TrialNamePrefix
            valueFrom:
              fieldRef:
                fieldPath: metadata.name
```

This PR resolves the above bug by adding missing logic in New Experiment form in order to pass the value of the editor content in Metrics Collector tab, when Kind is set to Custom. 