### PR TITLE
Update manifests to enable authorization check mechanisms for katib-UI in kubeflow mode

### DIFF
--- a/manifests/v1beta1/installs/katib-with-kubeflow/istio-authorizationpolicy.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/istio-authorizationpolicy.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: katib-ui
+  namespace: kubeflow
+spec:
+  action: ALLOW
+  selector:
+    matchLabels:
+      katib.kubeflow.org/component: ui
+  rules:
+    - from:
+        - source:
+            principals: ["cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"]

--- a/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   # Kubeflow Katib components.
   - kubeflow-katib-roles.yaml
   - ui-virtual-service.yaml
+  - istio-authorizationpolicy.yaml
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
@@ -20,6 +21,32 @@ images:
 
 patchesStrategicMerge:
   - patches/remove-namespace.yaml
+
+patches:
+  # Extend RBAC permission list of katib-ui so it can
+  # create SubjectAccessReview resources.
+  - target:
+      kind: ClusterRole
+      name: katib-ui
+      group: rbac.authorization.k8s.io
+      version: v1
+    path: patches/ui-rbac.yaml
+  # Enable RBAC authz checks in UI's backend.
+  - target:
+      version: v1
+      kind: Deployment
+      name: katib-ui
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: APP_DISABLE_AUTH
+          value: "false"
+  # Allow istio sidecar injection in katib-UI Pod.
+  - target:
+      kind: Deployment
+      name: katib-ui
+    path: patches/istio-sidecar-injection.yaml
 
 vars:
   - fieldref:

--- a/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
@@ -36,12 +36,7 @@ patches:
       version: v1
       kind: Deployment
       name: katib-ui
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: APP_DISABLE_AUTH
-          value: "false"
+    path: patches/enable-ui-authz-checks.yaml
   # Allow istio sidecar injection in katib-UI Pod.
   - target:
       kind: Deployment

--- a/manifests/v1beta1/installs/katib-with-kubeflow/patches/enable-ui-authz-checks.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/patches/enable-ui-authz-checks.yaml
@@ -1,0 +1,6 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: APP_DISABLE_AUTH
+    value: "false"

--- a/manifests/v1beta1/installs/katib-with-kubeflow/patches/istio-sidecar-injection.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/patches/istio-sidecar-injection.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "katib-ui"
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"

--- a/manifests/v1beta1/installs/katib-with-kubeflow/patches/ui-rbac.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/patches/ui-rbac.yaml
@@ -1,0 +1,7 @@
+---
+- op: add
+  path: /rules/-
+  value:
+    apiGroups: [authorization.k8s.io]
+    resources: [subjectaccessreviews]
+    verbs: [create]

--- a/pkg/new-ui/v1beta1/backend.go
+++ b/pkg/new-ui/v1beta1/backend.go
@@ -33,7 +33,6 @@ import (
 	experimentv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
 	suggestionv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/suggestions/v1beta1"
 	trialsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/trials/v1beta1"
-	trialv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/trials/v1beta1"
 	api_pb_v1beta1 "github.com/kubeflow/katib/pkg/apis/manager/v1beta1"
 	consts "github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 	"github.com/kubeflow/katib/pkg/util/v1beta1/katibclient"
@@ -41,7 +40,6 @@ import (
 
 	common "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
 	mccommon "github.com/kubeflow/katib/pkg/metricscollector/v1beta1/common"
-	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -585,7 +583,7 @@ func (k *KatibUIHandler) FetchTrial(w http.ResponseWriter, r *http.Request) {
 	trialName := trialNames[0]
 	namespace := namespaces[0]
 
-	user, err := IsAuthorized(consts.ActionTypeGet, namespace, consts.PluralTrial, "", trialName, trialv1beta1.SchemeGroupVersion, k.katibClient.GetClient(), r)
+	user, err := IsAuthorized(consts.ActionTypeGet, namespace, consts.PluralTrial, "", trialName, trialsv1beta1.SchemeGroupVersion, k.katibClient.GetClient(), r)
 	if user == "" && err != nil {
 		log.Printf("No user provided in kubeflow-userid header.")
 		http.Error(w, err.Error(), http.StatusUnauthorized)
@@ -680,7 +678,7 @@ func (k *KatibUIHandler) FetchTrialLogs(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	podLogOpts := apiv1.PodLogOptions{}
+	podLogOpts := corev1.PodLogOptions{}
 	podLogOpts.Container = trial.Spec.PrimaryContainerName
 	if trial.Spec.MetricsCollector.Collector.Kind == common.StdOutCollector {
 		podLogOpts.Container = mccommon.MetricLoggerCollectorContainerName
@@ -743,7 +741,7 @@ An example can be found here: https://github.com/kubeflow/katib/blob/7bf39225f72
 }
 
 // fetchPodLogs returns logs of a pod for the given job name and namespace
-func fetchPodLogs(clientset *kubernetes.Clientset, namespace string, podName string, podLogOpts apiv1.PodLogOptions) (string, error) {
+func fetchPodLogs(clientset *kubernetes.Clientset, namespace string, podName string, podLogOpts corev1.PodLogOptions) (string, error) {
 	req := clientset.CoreV1().Pods(namespace).GetLogs(podName, &podLogOpts)
 	podLogs, err := req.Stream(context.Background())
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This is a follow-up PR from: https://github.com/kubeflow/katib/pull/1983


Currently, in kubeflow mode, any workload/pod can set the `kubeflow-userid` header and communicate with the backend of the Katib UI. Since the code for securing the backend is merged we need to provide a way to enable this feature.

Changes to `install-with-kubeflow` manifests:

- Enable Istio sidecar injection for katib-ui component
- Introduce AuthorizationPolicies: 
  - `katib-ui`: Allow traffic only from the `istio-ingressgateway` towards the UI backend. We can trust `IGW` as we are sure it's setting the user header correctly.
- Enable authz checks for `katib-ui` backend (set `APP_DISABLE_AUTH` ENV var to false)
- Update `ClusterRole` to provide RBAC persmissions for the `katib-ui` so it can create `SubjectAccessReview` objects

Refs: https://github.com/kubeflow/katib/issues/1547