### PR TITLE
frontend: Add source maps in the browser

### DIFF
--- a/pkg/new-ui/v1beta1/frontend/angular.json
+++ b/pkg/new-ui/v1beta1/frontend/angular.json
@@ -37,7 +37,12 @@
             "vendorChunk": true,
             "extractLicenses": false,
             "buildOptimizer": false,
-            "sourceMap": true,
+            "sourceMap": {
+              "scripts": true,
+              "styles": true,
+              "hidden": false,
+              "vendor": true
+            },
             "optimization": false,
             "namedChunks": true
           },
@@ -51,7 +56,12 @@
               ],
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": {
+                "scripts": true,
+                "styles": true,
+                "hidden": false,
+                "vendor": true
+              },
               "namedChunks": false,
               "extractLicenses": true,
               "vendorChunk": false,


### PR DESCRIPTION
In this PR, we enable source maps for all scripts, styles and node modules in both development and production in KWA.

Related PR: https://github.com/kubeflow/kubeflow/pull/6787