### PR TITLE
Remove Certificate Chain from Cert Generator

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -58,7 +58,7 @@ make generate
 Below is a list of command-line flags accepted by Katib controller:
 
 | Name                            | Type                      | Default                       | Description                                                                                                            |
-|---------------------------------|---------------------------|-------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------- | ------------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | enable-grpc-probe-in-suggestion | bool                      | true                          | Enable grpc probe in suggestions                                                                                       |
 | experiment-suggestion-name      | string                    | "default"                     | The implementation of suggestion interface in experiment controller                                                    |
 | metrics-addr                    | string                    | ":8080"                       | The address that the metrics endpoint binds to                                                                         |
@@ -74,7 +74,7 @@ Below is a list of command-line flags accepted by Katib controller:
 Below is a list of command-line flags accepted by Katib DB Manager:
 
 | Name            | Type          | Default | Description                                             |
-|-----------------|---------------|---------|---------------------------------------------------------|
+| --------------- | ------------- | ------- | ------------------------------------------------------- |
 | connect-timeout | time.Duration | 60s     | Timeout before calling error during database connection |
 
 ## Workflow design
@@ -113,13 +113,11 @@ to generate certificates for the webhooks.
 
 Once Katib is deployed in the Kubernetes cluster, the `cert-generator` Job follows these steps:
 
-- Generate the self-signed CA certificate and private key.
+- Generate the self-signed certificate and private key.
 
-- Generate public certificate and private key signed with the key generated in the previous step.
-
-- Create a Kubernetes Secret with the signed certificate. Secret has
-  the `katib-webhook-cert` name and `cert-generator` Job's `ownerReference` to
-  clean-up resources once Katib is uninstalled.
+- Create a Kubernetes Secret with the self-signed TLS certificate and private key.
+  Secret has the `katib-webhook-cert` name and `cert-generator` Job's
+  `ownerReference` to clean-up resources once Katib is uninstalled.
 
   Once Secret is created, the Katib controller Deployment spawns the Pod,
   since the controller has the `katib-webhook-cert` Secret volume.

--- a/pkg/cert-generator/v1beta1/consts/const.go
+++ b/pkg/cert-generator/v1beta1/consts/const.go
@@ -17,10 +17,8 @@ limitations under the License.
 package consts
 
 const (
-	CAName  = "katib-ca"
 	Service = "katib-controller"
 	JobName = "katib-cert-generator"
 	Secret  = "katib-webhook-cert"
 	Webhook = "katib.kubeflow.org"
-	Katib   = "katib"
 )

--- a/pkg/cert-generator/v1beta1/generate/generate_test.go
+++ b/pkg/cert-generator/v1beta1/generate/generate_test.go
@@ -17,17 +17,18 @@ limitations under the License.
 package generate
 
 import (
+	"log"
+	"strings"
+	"testing"
+
 	"github.com/kubeflow/katib/pkg/cert-generator/v1beta1/consts"
 	admissionregistration "k8s.io/api/admissionregistration/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"log"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"strings"
-	"testing"
 )
 
 func TestGenerate(t *testing.T) {


### PR DESCRIPTION
I removed Certificate Chain from our Cert generator.
I think having chain is not necessary for Kubernetes Webhooks. I was able to create Katib Experiments in my environment with these changes.
Also, we can leave only Full Service Domain in our DNS names.

Do you have any objections @tenzen-y @johnugeorge @shaowei-su ?