### PR TITLE
[SDK] Get Trial Metrics from Katib DB

### DIFF
--- a/sdk/python/v1beta1/.gitignore
+++ b/sdk/python/v1beta1/.gitignore
@@ -1,2 +1,5 @@
 # Distribution / packaging
 dist/
+
+# Katib gRPC APIs
+kubeflow/katib/katib_api_pb2.py

--- a/sdk/python/v1beta1/kubeflow/katib/constants/constants.py
+++ b/sdk/python/v1beta1/kubeflow/katib/constants/constants.py
@@ -14,7 +14,7 @@
 
 import os
 
-# How long to wait in seconds for requests to the ApiServer
+# How long to wait in seconds for requests to the Kubernetes or gRPC API Server.
 APISERVER_TIMEOUT = 120
 
 # Global CRD version
@@ -36,3 +36,5 @@ BASE_IMAGE_TENSORFLOW = "docker.io/tensorflow/tensorflow:2.9.1"
 BASE_IMAGE_TENSORFLOW_GPU = "docker.io/tensorflow/tensorflow:2.9.1-gpu"
 BASE_IMAGE_PYTORCH = "docker.io/pytorch/pytorch:1.12.1-cuda11.3-cudnn8-runtime"
 BASE_IMAGE_MXNET = "docker.io/mxnet/python:1.9.1_native_py3"
+
+DEFAULT_DB_MANAGER_ADDRESS = "katib-db-manager.kubeflow:6789"

--- a/sdk/python/v1beta1/setup.py
+++ b/sdk/python/v1beta1/setup.py
@@ -25,13 +25,13 @@ REQUIRES = [
     "grpcio==1.41.1",
 ]
 
-katib_grpc_api_file = "kubeflow/katib/katib_api_pb2.py"
+katib_grpc_api_file = "../../../pkg/apis/manager/v1beta1/python/api_pb2.py"
 
 # Copy Katib gRPC Python APIs to use it in the Katib SDK Client.
-# We need to copy this file only on the SDK building stage, not on installation stage.
-if not os.path.exists(katib_grpc_api_file):
+# We need to always copy this file only on the SDK building stage, not on SDK installation stage.
+if os.path.exists(katib_grpc_api_file):
     shutil.copy(
-        "../../../pkg/apis/manager/v1beta1/python/api_pb2.py", katib_grpc_api_file,
+        katib_grpc_api_file, "kubeflow/katib/katib_api_pb2.py",
     )
 
 setuptools.setup(

--- a/sdk/python/v1beta1/setup.py
+++ b/sdk/python/v1beta1/setup.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import shutil
 import setuptools
 
 REQUIRES = [
@@ -20,7 +22,17 @@ REQUIRES = [
     "setuptools>=21.0.0",
     "urllib3>=1.15.1",
     "kubernetes>=23.6.0",
+    "grpcio==1.41.1",
 ]
+
+katib_grpc_api_file = "kubeflow/katib/katib_api_pb2.py"
+
+# Copy Katib gRPC Python APIs to use it in the Katib SDK Client.
+# We need to copy this file only on the SDK building stage, not on installation stage.
+if not os.path.exists(katib_grpc_api_file):
+    shutil.copy(
+        "../../../pkg/apis/manager/v1beta1/python/api_pb2.py", katib_grpc_api_file,
+    )
 
 setuptools.setup(
     name="kubeflow-katib",


### PR DESCRIPTION
Related: https://github.com/kubeflow/katib/issues/2022.

I've added API to get Trial metrics from the Katib DB using Katib DB Manager gRPC API.
Usage:
```python
cl = KatibClient()
trial_name = cl.get_experiment(name="test-experiment-1")["status"]["succeededTrialList"][0]
cl.get_trial_metrics(name=trial_name)[0]

"
time_stamp: "2022-12-05T14:42:08Z"
metric {
  name: "Train-accuracy"
  value: "0.112390"
}
"
```

Since we don't publish our gRPC as Python package, we can't modify [the requirements for our Katib SDK](https://github.com/andreyvelich/katib/blob/b6755bbdc4d73eee18f8025c0bc68b5d90c8747b/sdk/python/v1beta1/setup.py#L19-L26).
In the `setup.py` script [I copied the Katib gRPC APIs file to the appropriate location](https://github.com/kubeflow/katib/blob/b6755bbdc4d73eee18f8025c0bc68b5d90c8747b/sdk/python/v1beta1/setup.py#L30-L36), so we can use it in the Katib client.


What do you think about it @johnugeorge @gaocegege @tenzen-y @kimwnasptd @anencore94  ?

In the long-term (if we are going to create Katib API Server) we might want to consider publishing the Katib API Server Python APIs to PyPI, so other users can make integration on top of it (what @anencore94 mentioned here: https://github.com/kubeflow/katib/issues/2022#issuecomment-1336863064).

Kubeflow Pipelines team also publish their [python `kfp-server-api ` to the public registry](https://github.com/kubeflow/pipelines/tree/6e364d35b1e66e6b7a7985b2364d29e52ba316ce/backend/api/v2beta1/python_http_client).

/assign @johnugeorge @kimwnasptd @tenzen-y @anencore94 

/hold for review