### PR TITLE
Upgrade Python version to 3.10

### DIFF
--- a/cmd/earlystopping/medianstop/v1beta1/Dockerfile
+++ b/cmd/earlystopping/medianstop/v1beta1/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ARG TARGETARCH
 ENV TARGET_DIR /opt/katib

--- a/cmd/metricscollector/v1beta1/tfevent-metricscollector/Dockerfile
+++ b/cmd/metricscollector/v1beta1/tfevent-metricscollector/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ARG TARGETARCH
 ENV TARGET_DIR /opt/katib

--- a/cmd/metricscollector/v1beta1/tfevent-metricscollector/requirements.txt
+++ b/cmd/metricscollector/v1beta1/tfevent-metricscollector/requirements.txt
@@ -1,4 +1,4 @@
-psutil==5.8.0
+psutil==5.9.4
 rfc3339>=6.2
 grpcio==1.41.1
 googleapis-common-protos==1.6.0

--- a/cmd/suggestion/hyperband/v1beta1/Dockerfile
+++ b/cmd/suggestion/hyperband/v1beta1/Dockerfile
@@ -6,7 +6,7 @@ ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
 RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
   && chmod +x /bin/grpc_health_probe
 
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ARG TARGETARCH
 ENV TARGET_DIR /opt/katib

--- a/cmd/suggestion/hyperopt/v1beta1/Dockerfile
+++ b/cmd/suggestion/hyperopt/v1beta1/Dockerfile
@@ -6,7 +6,7 @@ ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
 RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
   && chmod +x /bin/grpc_health_probe
 
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ARG TARGETARCH
 ENV TARGET_DIR /opt/katib

--- a/cmd/suggestion/nas/darts/v1beta1/Dockerfile
+++ b/cmd/suggestion/nas/darts/v1beta1/Dockerfile
@@ -6,7 +6,7 @@ ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
 RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
   && chmod +x /bin/grpc_health_probe
 
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ARG TARGETARCH
 ENV TARGET_DIR /opt/katib

--- a/cmd/suggestion/nas/enas/v1beta1/Dockerfile
+++ b/cmd/suggestion/nas/enas/v1beta1/Dockerfile
@@ -6,7 +6,7 @@ ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
 RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
   && chmod +x /bin/grpc_health_probe
 
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ARG TARGETARCH
 ENV TARGET_DIR /opt/katib

--- a/cmd/suggestion/optuna/v1beta1/Dockerfile
+++ b/cmd/suggestion/optuna/v1beta1/Dockerfile
@@ -6,7 +6,7 @@ ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
 RUN wget -qO /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
   && chmod +x /bin/grpc_health_probe
 
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ARG TARGETARCH
 ENV TARGET_DIR /opt/katib

--- a/cmd/suggestion/pbt/v1beta1/Dockerfile
+++ b/cmd/suggestion/pbt/v1beta1/Dockerfile
@@ -6,7 +6,7 @@ ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
 RUN wget -qO /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
   && chmod +x /bin/grpc_health_probe
 
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ARG TARGETARCH
 ENV TARGET_DIR /opt/katib

--- a/cmd/suggestion/skopt/v1beta1/Dockerfile
+++ b/cmd/suggestion/skopt/v1beta1/Dockerfile
@@ -6,7 +6,7 @@ ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
 RUN wget -qO /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
   && chmod +x /bin/grpc_health_probe
 
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ARG TARGETARCH
 ENV TARGET_DIR /opt/katib

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -16,7 +16,7 @@ see the following user guides:
 - [Docker](https://docs.docker.com/) (20.10 or later)
 - [Docker Buildx](https://docs.docker.com/build/buildx/) (0.8.0 or later)
 - [Java](https://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html) (8 or later)
-- [Python](https://www.python.org/) (3.9 or later)
+- [Python](https://www.python.org/) (3.10 or later)
 - [kustomize](https://kustomize.io/) (4.0.5 or later)
 
 ## Build from source code

--- a/examples/v1beta1/trial-images/darts-cnn-cifar10/Dockerfile.cpu
+++ b/examples/v1beta1/trial-images/darts-cnn-cifar10/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ENV TARGET_DIR /opt/darts-cnn-cifar10
 

--- a/examples/v1beta1/trial-images/enas-cnn-cifar10/Dockerfile.cpu
+++ b/examples/v1beta1/trial-images/enas-cnn-cifar10/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ARG TARGETARCH
 ENV TARGET_DIR /opt/enas-cnn-cifar10

--- a/examples/v1beta1/trial-images/mxnet-mnist/Dockerfile
+++ b/examples/v1beta1/trial-images/mxnet-mnist/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ARG TARGETARCH
 ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:/opt/arm/armpl_22.0.2_gcc-11.2/lib"

--- a/examples/v1beta1/trial-images/pytorch-mnist/Dockerfile.cpu
+++ b/examples/v1beta1/trial-images/pytorch-mnist/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ADD examples/v1beta1/trial-images/pytorch-mnist /opt/pytorch-mnist
 

--- a/examples/v1beta1/trial-images/simple-pbt/Dockerfile
+++ b/examples/v1beta1/trial-images/simple-pbt/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ADD examples/v1beta1/trial-images/simple-pbt /opt/pbt
 

--- a/examples/v1beta1/trial-images/tf-mnist-with-summaries/Dockerfile
+++ b/examples/v1beta1/trial-images/tf-mnist-with-summaries/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ARG TARGETARCH
 

--- a/test/unit/v1beta1/requirements.txt
+++ b/test/unit/v1beta1/requirements.txt
@@ -1,2 +1,2 @@
 grpcio-testing==1.41.1
-pytest==5.1.2
+pytest==7.2.0


### PR DESCRIPTION
Signed-off-by: tenzen-y <yuki.iwai.tz@gmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I upgraded Python version to 3.10 since Python 3.9 no longer fixes bugs, according to [this](https://devguide.python.org/versions/#supported-versions).

> 3.9 | PEP 596 | security | 2020-10-05 | 2025-10 | Łukasz Langa

Also, I upgraded pytest version to avoid the error, `E   TypeError: required field "lineno" missing from alias`.

ref: https://github.com/pytest-dev/pytest/pull/8540

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
