### PR TITLE
Upgrade the actions-setup-minikube version to v2.7.2

### DIFF
--- a/.github/workflows/template-setup-e2e-test/action.yaml
+++ b/.github/workflows/template-setup-e2e-test/action.yaml
@@ -11,11 +11,12 @@ runs:
   using: composite
   steps:
     - name: Set Up Minikube Cluster
-      uses: manusa/actions-setup-minikube@v2.6.0
+      uses: manusa/actions-setup-minikube@v2.7.2
       with:
-        minikube version: "v1.25.2"
+        minikube version: 'v1.28.0'
         kubernetes version: ${{ inputs.kubernetes-version }}
-        start args: --driver none --wait-timeout=60s
+        start args: --wait-timeout=60s
+        driver: 'none'
         github token: ${{ env.GITHUB_TOKEN }}
 
     - name: Set Up Docker Buildx


### PR DESCRIPTION
Signed-off-by: tenzen-y <yuki.iwai.tz@gmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I upgraded the [`actions-setup-minikube`](https://github.com/manusa/actions-setup-minikube) version to v2.7.2 to resolve the following error:

> stderr:
time="2022-12-14T13:37:48Z" level=fatal msg="validate service connection: CRI v1 runtime API is not implemented for endpoint \"unix:///var/run/cri-dockerd.sock\": rpc error: code = Unimplemented desc = unknown service runtime.v1.RuntimeService"

https://github.com/kubeflow/katib/actions/runs/3695006408/jobs/6257556328#step:3:131

ref: https://github.com/manusa/actions-setup-minikube/releases/tag/v2.7.2

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
