### PR TITLE
frontend: Enable actions in experiment graph

### DIFF
--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-graph-echarts/trials-graph-echarts.component.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-graph-echarts/trials-graph-echarts.component.ts
@@ -245,6 +245,13 @@ export class TrialsGraphEchartsComponent implements OnChanges {
         padding: 10,
         borderWidth: 1,
       },
+      toolbox: {
+        show: true,
+        feature: {
+          restore: {},
+          saveAsImage: {},
+        },
+      },
       parallelAxis: parallelAxis,
       visualMap: {
         min: 0,


### PR DESCRIPTION
This PR enables actions in the experiment graph and specifically:
- Restore action which resets the graph
- Save image action

![image](https://user-images.githubusercontent.com/87971102/207827129-302c0733-ac81-44b8-91f4-0cfa1730823c.png)
