### PR TITLE
Pin the NumPy version with v1.23.5 in some images

### DIFF
--- a/cmd/suggestion/skopt/v1beta1/requirements.txt
+++ b/cmd/suggestion/skopt/v1beta1/requirements.txt
@@ -1,6 +1,9 @@
 grpcio==1.41.1
 cloudpickle==0.5.6
-numpy>=1.20.0
+# This is a workaround to avoid the following error.
+# AttributeError: module 'numpy' has no attribute 'int'
+# See more: https://github.com/numpy/numpy/pull/22607
+numpy==1.23.5
 scikit-learn>=0.24.0
 scipy>=1.5.4
 forestci==0.3

--- a/examples/v1beta1/trial-images/mxnet-mnist/Dockerfile
+++ b/examples/v1beta1/trial-images/mxnet-mnist/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get -y update \
 RUN if [ "${TARGETARCH}" = "arm64" ]; then \
       /opt/mxnet-mnist/install-arm-performance-libraries.sh; \
     fi
-RUN pip install mxnet==1.9.1
+RUN pip install -r requirements.txt
 RUN chgrp -R 0 /opt/mxnet-mnist \
   && chmod -R g+rwX /opt/mxnet-mnist
 

--- a/examples/v1beta1/trial-images/mxnet-mnist/requirements.txt
+++ b/examples/v1beta1/trial-images/mxnet-mnist/requirements.txt
@@ -1,0 +1,5 @@
+mxnet==1.9.1
+# This is a workaround to avoid the following error.
+# AttributeError: module 'numpy' has no attribute 'bool'
+# See more: https://github.com/numpy/numpy/pull/22607
+numpy==1.23.5


### PR DESCRIPTION
Signed-off-by: Yuki Iwai <yuki.iwai.tz@gmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I pinned the NumPy version with v1.23.5 in the mxnet-mnist image and the skopt suggestion image to avoid the following errors:

- mxnet-mnist

```sh
I1223 17:32:59.235460      19 main.go:396] Trial Name: grid-ssmbrpvl
I1223 17:33:07.242688      19 main.go:139] /usr/local/lib/python3.9/site-packages/mxnet/numpy/utils.py:37: FutureWarning: In the future `np.bool` will be defined as the corresponding NumPy scalar.  (This may have returned Python scalars in past versions.
I1223 17:33:07.242711      19 main.go:139]   bool = onp.bool
I1223 17:33:07.244035      19 main.go:139] Traceback (most recent call last):
I1223 17:33:07.244094      19 main.go:139]   File "/opt/mxnet-mnist/mnist.py", line 24, in <module>
I1223 17:33:07.245554      19 main.go:139]     import mxnet as mx
I1223 17:33:07.245565      19 main.go:139]   File "/usr/local/lib/python3.9/site-packages/mxnet/__init__.py", line 33, in <module>
I1223 17:33:07.245949      19 main.go:139]     from . import contrib
I1223 17:33:07.245959      19 main.go:139]   File "/usr/local/lib/python3.9/site-packages/mxnet/contrib/__init__.py", line 30, in <module>
I1223 17:33:07.246245      19 main.go:139]     from . import text
I1223 17:33:07.246299      19 main.go:139]   File "/usr/local/lib/python3.9/site-packages/mxnet/contrib/text/__init__.py", line 23, in <module>
I1223 17:33:07.246526      19 main.go:139]     from . import embedding
I1223 17:33:07.246539      19 main.go:139]   File "/usr/local/lib/python3.9/site-packages/mxnet/contrib/text/embedding.py", line 36, in <module>
I1223 17:33:07.246899      19 main.go:139]     from ... import numpy as _mx_np
I1223 17:33:07.246914      19 main.go:139]   File "/usr/local/lib/python3.9/site-packages/mxnet/numpy/__init__.py", line 23, in <module>
I1223 17:33:07.247114      19 main.go:139]     from .multiarray import *  # pylint: disable=wildcard-import
I1223 17:33:07.247122      19 main.go:139]   File "/usr/local/lib/python3.9/site-packages/mxnet/numpy/multiarray.py", line 47, in <module>
I1223 17:33:07.247384      19 main.go:139]     from .utils import _get_np_op
I1223 17:33:07.247435      19 main.go:139]   File "/usr/local/lib/python3.9/site-packages/mxnet/numpy/utils.py", line 37, in <module>
I1223 17:33:07.247715      19 main.go:139]     bool = onp.bool
I1223 17:33:07.247731      19 main.go:139]   File "/usr/local/lib/python3.9/site-packages/numpy/__init__.py", line 284, in __getattr__
I1223 17:33:07.248506      19 main.go:139]     raise AttributeError("module {!r} has no attribute "
I1223 17:33:07.248685      19 main.go:139] AttributeError: module 'numpy' has no attribute 'bool'
```

- skopt suggestion service

```sh
ERROR:grpc._server:Exception calling application: module 'numpy' has no attribute 'int'
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/grpc/_server.py", line 443, in _call_behavior
    response_or_iterator = behavior(argument, context)
  File "/opt/katib/pkg/suggestion/v1beta1/skopt/service.py", line 55, in GetSuggestions
    new_trials = self.base_service.getSuggestions(trials, request.current_request_number)
  File "/opt/katib/pkg/suggestion/v1beta1/skopt/base_service.py", line 121, in getSuggestions
    skopt_suggested = self.skopt_optimizer.ask(n_points=current_request_number)
  File "/usr/local/lib/python3.9/site-packages/skopt/optimizer/optimizer.py", line 395, in ask
    x = opt.ask()
  File "/usr/local/lib/python3.9/site-packages/skopt/optimizer/optimizer.py", line 367, in ask
    return self._ask()
  File "/usr/local/lib/python3.9/site-packages/skopt/optimizer/optimizer.py", line 434, in _ask
    return self.space.rvs(random_state=self.rng)[0]
  File "/usr/local/lib/python3.9/site-packages/skopt/space/space.py", line 900, in rvs
    columns.append(dim.rvs(n_samples=n_samples, random_state=rng))
  File "/usr/local/lib/python3.9/site-packages/skopt/space/space.py", line 158, in rvs
    return self.inverse_transform(samples)
  File "/usr/local/lib/python3.9/site-packages/skopt/space/space.py", line 528, in inverse_transform
    inv_transform = super(Integer, self).inverse_transform(Xt)
  File "/usr/local/lib/python3.9/site-packages/skopt/space/space.py", line 168, in inverse_transform
    return self.transformer.inverse_transform(Xt)
  File "/usr/local/lib/python3.9/site-packages/skopt/space/transformers.py", line 309, in inverse_transform
    X = transformer.inverse_transform(X)
  File "/usr/local/lib/python3.9/site-packages/skopt/space/transformers.py", line 275, in inverse_transform
    return np.round(X_orig).astype(np.int)
  File "/usr/local/lib/python3.9/site-packages/numpy/__init__.py", line 284, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'int'
```

/assign @andreyvelich @johnugeorge @gaocegege 

Blocking: #2039 #2060 #2067

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
