### PR TITLE
Upgrade grpc-health-probe version to fix some security issues

### DIFF
--- a/cmd/db-manager/v1beta1/Dockerfile
+++ b/cmd/db-manager/v1beta1/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:alpine AS build-env
 
 ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
 
 WORKDIR /go/src/github.com/kubeflow/katib
 

--- a/cmd/suggestion/goptuna/v1beta1/Dockerfile
+++ b/cmd/suggestion/goptuna/v1beta1/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:alpine AS build-env
 
 ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
 
 WORKDIR /go/src/github.com/kubeflow/katib
 

--- a/cmd/suggestion/hyperband/v1beta1/Dockerfile
+++ b/cmd/suggestion/hyperband/v1beta1/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15 AS downloader
 
 ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
 
 RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
   && chmod +x /bin/grpc_health_probe

--- a/cmd/suggestion/hyperopt/v1beta1/Dockerfile
+++ b/cmd/suggestion/hyperopt/v1beta1/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15 AS downloader
 
 ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
 
 RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
   && chmod +x /bin/grpc_health_probe

--- a/cmd/suggestion/nas/darts/v1beta1/Dockerfile
+++ b/cmd/suggestion/nas/darts/v1beta1/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15 as downloader
 
 ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
 
 RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
   && chmod +x /bin/grpc_health_probe

--- a/cmd/suggestion/nas/enas/v1beta1/Dockerfile
+++ b/cmd/suggestion/nas/enas/v1beta1/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15 AS downloader
 
 ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
 
 RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
   && chmod +x /bin/grpc_health_probe
@@ -11,7 +11,7 @@ FROM python:3.10-slim
 ARG TARGETARCH
 ENV TARGET_DIR /opt/katib
 ENV SUGGESTION_DIR cmd/suggestion/nas/enas/v1beta1
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
 ENV PYTHONPATH ${TARGET_DIR}:${TARGET_DIR}/pkg/apis/manager/v1beta1/python:${TARGET_DIR}/pkg/apis/manager/health/python
 
 RUN if [ "${TARGETARCH}" = "ppc64le" ] || [ "${TARGETARCH}" = "aarch64" ]; then \

--- a/cmd/suggestion/optuna/v1beta1/Dockerfile
+++ b/cmd/suggestion/optuna/v1beta1/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15 AS downloader
 
 ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
 
 RUN wget -qO /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
   && chmod +x /bin/grpc_health_probe

--- a/cmd/suggestion/pbt/v1beta1/Dockerfile
+++ b/cmd/suggestion/pbt/v1beta1/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15 AS downloader
 
 ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
 
 RUN wget -qO /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
   && chmod +x /bin/grpc_health_probe

--- a/cmd/suggestion/skopt/v1beta1/Dockerfile
+++ b/cmd/suggestion/skopt/v1beta1/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15 AS downloader
 
 ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.11
+ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
 
 RUN wget -qO /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
   && chmod +x /bin/grpc_health_probe


### PR DESCRIPTION
Signed-off-by: Yuki Iwai <yuki.iwai.tz@gmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I upgraded the grpc-health-probe version to fix some security issues.

- CVE-2022-27664
- CVE-2022-32149

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
