### PR TITLE
[SDK] Use Katib Client without Kube Config

### DIFF
--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -30,34 +30,33 @@ import kubeflow.katib.katib_api_pb2 as katib_api_pb2
 class KatibClient(object):
     def __init__(
         self,
-        config_file=None,
-        context=None,
-        client_configuration=None,
-        persist_config=True,
+        config_file: str = None,
+        context: str = None,
+        client_configuration: client.Configuration = None,
     ):
         """KatibClient constructor.
 
         Args:
-            config_file: Name of the kube-config file. Defaults to ~/.kube/config.
+            config_file: Path to the kube-config file. Defaults to ~/.kube/config.
             context: Set the active context. Defaults to current_context from the kube-config.
-            client_configuration: The kubernetes.client.Configuration to set configs to.
-            persist_config: If True, config file will be updated when changed.
+            client_configuration: Client configuration for cluster authentication.
+                You have to provide valid configuration with Bearer token or
+                with username and password.
+                You can find an example here: https://github.com/kubernetes-client/python/blob/67f9c7a97081b4526470cad53576bc3b71fa6fcc/examples/remote_cluster.py#L31
         """
 
-        self.in_cluster = None
-        if config_file or not utils.is_running_in_k8s():
-            config.load_kube_config(
-                config_file=config_file,
-                context=context,
-                client_configuration=client_configuration,
-                persist_config=persist_config,
-            )
-            self.in_cluster = False
-        else:
-            config.load_incluster_config()
-            self.in_cluster = True
+        self.in_cluster = False
+        # If client configuration is not set, use kube-config to access Kubernetes APIs.
+        if client_configuration is None:
+            # Load kube-config or in-cluster config.
+            if config_file or not utils.is_running_in_k8s():
+                config.load_kube_config(config_file=config_file, context=context)
+            else:
+                config.load_incluster_config()
+                self.in_cluster = True
 
-        self.custom_api = client.CustomObjectsApi()
+        k8s_client = client.ApiClient(client_configuration)
+        self.custom_api = client.CustomObjectsApi(k8s_client)
         self.api_client = ApiClient()
 
     def _is_ipython(self):


### PR DESCRIPTION
Use the same logic as for the SDK Training Client: https://github.com/kubeflow/training-operator/pull/1740.

/assign @gaocegege @johnugeorge @tenzen-y 