### PR TITLE
Fix Release Script for Updating SDK Version

### DIFF
--- a/scripts/v1beta1/release.sh
+++ b/scripts/v1beta1/release.sh
@@ -85,9 +85,9 @@ make generate
 # Change version in setup.py
 cd sdk/python/v1beta1
 if [[ $(uname) == "Darwin" ]]; then
-  sed -i '' -e "s@version='.*'@version='${sdk_version}'@" setup.py
+  sed -i '' -e "s@version=\".*\"@version=\"${sdk_version}\"@" setup.py
 else
-  sed -i -e "s@version='.*'@version='${sdk_version}'@" setup.py
+  sed -i -e "s@version=\".*\"@version=\"${sdk_version}\"@" setup.py
 fi
 # Generate SDK and upload new version to PyPi.
 python3 setup.py sdist bdist_wheel


### PR DESCRIPTION
After this PR: https://github.com/kubeflow/katib/pull/1951, we should modify release script to make correct version replace.

/assign @tenzen-y @johnugeorge 