### PR TITLE
Bump Katib Python SDK to 0.15.0rc0 version

### DIFF
--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -90,9 +90,6 @@ Follow these steps to cut a new Katib release:
    - Push above changes to the Katib upstream `release-X.Y` branch with this commit:
      `Katib official release vX.Y.Z`
 
-1. If the new branch was created, submit a PR to allow tests on the `release-X.Y` branch
-   (e.g. [`#965`](https://github.com/kubeflow/testing/pull/965)).
-
 1. Submit a PR to update the SDK version on the `master` branch to the latest release.
    (e.g. [`#1640`](https://github.com/kubeflow/katib/pull/1640)).
 

--- a/sdk/python/v1beta1/setup.py
+++ b/sdk/python/v1beta1/setup.py
@@ -37,7 +37,7 @@ if os.path.exists(katib_grpc_api_file):
 
 setuptools.setup(
     name="kubeflow-katib",
-    version="0.14.0",
+    version="0.15.0rc0",
     author="Kubeflow Authors",
     author_email="premnath.vel@gmail.com",
     license="Apache License Version 2.0",


### PR DESCRIPTION
Updating Katib Python SDK to the latest version.

Also, I removed item from the release script doc.

/assign @johnugeorge @tenzen-y 