### PR TITLE
Reformat katib-operators

### DIFF
--- a/operators/katib-ui/src/charm.py
+++ b/operators/katib-ui/src/charm.py
@@ -42,7 +42,6 @@ class Operator(CharmBase):
 
     def set_pod_spec(self, event):
         try:
-
             self._check_leader()
 
             interfaces = self._get_interfaces()


### PR DESCRIPTION
Signed-off-by: Yuki Iwai <yuki.iwai.tz@gmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I reformated katib-operators with `black operators/*/src`.
This PR will fix the following error:

```shell
would reformat /home/runner/work/katib/katib/operators/katib-ui/src/charm.py

Oh no! 💥 💔 💥
1 file would be reformatted, 2 files would be left unchanged.
Error: Process completed with exit code 1.
```

https://github.com/kubeflow/katib/actions/runs/4173685371/jobs/7226319287

After:

```shell
$ black --check operators/*/src
All done! ✨ 🍰 ✨
3 files would be left unchanged.
```

Blocking: #2101 

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
