### PR TITLE
UI: Remove an unsed import, EventV1beta1Api

### DIFF
--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/nas-operations/operation/operation.component.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-creation/nas-operations/operation/operation.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { EventsV1beta1Api } from '@kubernetes/client-node';
 
 @Component({
   selector: 'app-nas-operation',


### PR DESCRIPTION
Signed-off-by: Yuki Iwai <yuki.iwai.tz@gmail.com>

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I removed an unused import, `EventsV1beta1Api`.

Blocking: #2111 

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
