### PR TITLE
Adding groups support in SubjectAccessReviewSpec from request header

### DIFF
--- a/examples/v1beta1/argo/argo-workflow.yaml
+++ b/examples/v1beta1/argo/argo-workflow.yaml
@@ -76,7 +76,7 @@ spec:
                 - name: num-examples
             container:
               name: model-training
-              image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+              image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/argo/argo-workflow.yaml
+++ b/examples/v1beta1/argo/argo-workflow.yaml
@@ -76,7 +76,7 @@ spec:
                 - name: num-examples
             container:
               name: model-training
-              image: docker.io/kubeflowkatib/mxnet-mnist:latest
+              image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/argo/argo-workflow.yaml
+++ b/examples/v1beta1/argo/argo-workflow.yaml
@@ -76,7 +76,7 @@ spec:
                 - name: num-examples
             container:
               name: model-training
-              image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+              image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/early-stopping/median-stop-with-json-format.yaml
+++ b/examples/v1beta1/early-stopping/median-stop-with-json-format.yaml
@@ -62,7 +62,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:latest
+                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/early-stopping/median-stop-with-json-format.yaml
+++ b/examples/v1beta1/early-stopping/median-stop-with-json-format.yaml
@@ -62,7 +62,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0
                 command:
                   - "python3"
                   - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/early-stopping/median-stop-with-json-format.yaml
+++ b/examples/v1beta1/early-stopping/median-stop-with-json-format.yaml
@@ -62,7 +62,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/early-stopping/median-stop.yaml
+++ b/examples/v1beta1/early-stopping/median-stop.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:latest
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/early-stopping/median-stop.yaml
+++ b/examples/v1beta1/early-stopping/median-stop.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/early-stopping/median-stop.yaml
+++ b/examples/v1beta1/early-stopping/median-stop.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/bayesian-optimization.yaml
+++ b/examples/v1beta1/hp-tuning/bayesian-optimization.yaml
@@ -57,7 +57,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/bayesian-optimization.yaml
+++ b/examples/v1beta1/hp-tuning/bayesian-optimization.yaml
@@ -57,7 +57,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:latest
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/bayesian-optimization.yaml
+++ b/examples/v1beta1/hp-tuning/bayesian-optimization.yaml
@@ -57,7 +57,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/cma-es.yaml
+++ b/examples/v1beta1/hp-tuning/cma-es.yaml
@@ -57,7 +57,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/cma-es.yaml
+++ b/examples/v1beta1/hp-tuning/cma-es.yaml
@@ -57,7 +57,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:latest
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/cma-es.yaml
+++ b/examples/v1beta1/hp-tuning/cma-es.yaml
@@ -57,7 +57,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/grid.yaml
+++ b/examples/v1beta1/hp-tuning/grid.yaml
@@ -55,7 +55,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:latest
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/grid.yaml
+++ b/examples/v1beta1/hp-tuning/grid.yaml
@@ -55,7 +55,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/grid.yaml
+++ b/examples/v1beta1/hp-tuning/grid.yaml
@@ -55,7 +55,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/hyperband.yaml
+++ b/examples/v1beta1/hp-tuning/hyperband.yaml
@@ -69,7 +69,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/hyperband.yaml
+++ b/examples/v1beta1/hp-tuning/hyperband.yaml
@@ -69,7 +69,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/hyperband.yaml
+++ b/examples/v1beta1/hp-tuning/hyperband.yaml
@@ -69,7 +69,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:latest
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/multivariate-tpe.yaml
+++ b/examples/v1beta1/hp-tuning/multivariate-tpe.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:latest
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/multivariate-tpe.yaml
+++ b/examples/v1beta1/hp-tuning/multivariate-tpe.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/multivariate-tpe.yaml
+++ b/examples/v1beta1/hp-tuning/multivariate-tpe.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/random.yaml
+++ b/examples/v1beta1/hp-tuning/random.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:latest
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/random.yaml
+++ b/examples/v1beta1/hp-tuning/random.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/random.yaml
+++ b/examples/v1beta1/hp-tuning/random.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/simple-pbt.yaml
+++ b/examples/v1beta1/hp-tuning/simple-pbt.yaml
@@ -43,7 +43,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/simple-pbt:latest
+                image: docker.io/kubeflowkatib/simple-pbt:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/pbt/pbt_test.py"

--- a/examples/v1beta1/hp-tuning/simple-pbt.yaml
+++ b/examples/v1beta1/hp-tuning/simple-pbt.yaml
@@ -43,7 +43,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/simple-pbt:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/simple-pbt:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/pbt/pbt_test.py"

--- a/examples/v1beta1/hp-tuning/simple-pbt.yaml
+++ b/examples/v1beta1/hp-tuning/simple-pbt.yaml
@@ -43,7 +43,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/simple-pbt:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/simple-pbt:v0.15.0
                 command:
                   - "python3"
                   - "/opt/pbt/pbt_test.py"

--- a/examples/v1beta1/hp-tuning/sobol.yaml
+++ b/examples/v1beta1/hp-tuning/sobol.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:latest
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/sobol.yaml
+++ b/examples/v1beta1/hp-tuning/sobol.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/sobol.yaml
+++ b/examples/v1beta1/hp-tuning/sobol.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/tpe.yaml
+++ b/examples/v1beta1/hp-tuning/tpe.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:latest
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/tpe.yaml
+++ b/examples/v1beta1/hp-tuning/tpe.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/hp-tuning/tpe.yaml
+++ b/examples/v1beta1/hp-tuning/tpe.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/kubeflow-training-operator/pytorchjob-mnist.yaml
+++ b/examples/v1beta1/kubeflow-training-operator/pytorchjob-mnist.yaml
@@ -46,7 +46,7 @@ spec:
               spec:
                 containers:
                   - name: pytorch
-                    image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
+                    image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.1
                     command:
                       - "python3"
                       - "/opt/pytorch-mnist/mnist.py"
@@ -61,7 +61,7 @@ spec:
               spec:
                 containers:
                   - name: pytorch
-                    image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
+                    image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.1
                     command:
                       - "python3"
                       - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/kubeflow-training-operator/pytorchjob-mnist.yaml
+++ b/examples/v1beta1/kubeflow-training-operator/pytorchjob-mnist.yaml
@@ -46,7 +46,7 @@ spec:
               spec:
                 containers:
                   - name: pytorch
-                    image: docker.io/kubeflowkatib/pytorch-mnist-cpu:latest
+                    image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
                     command:
                       - "python3"
                       - "/opt/pytorch-mnist/mnist.py"
@@ -61,7 +61,7 @@ spec:
               spec:
                 containers:
                   - name: pytorch
-                    image: docker.io/kubeflowkatib/pytorch-mnist-cpu:latest
+                    image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
                     command:
                       - "python3"
                       - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/kubeflow-training-operator/pytorchjob-mnist.yaml
+++ b/examples/v1beta1/kubeflow-training-operator/pytorchjob-mnist.yaml
@@ -46,7 +46,7 @@ spec:
               spec:
                 containers:
                   - name: pytorch
-                    image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.1
+                    image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0
                     command:
                       - "python3"
                       - "/opt/pytorch-mnist/mnist.py"
@@ -61,7 +61,7 @@ spec:
               spec:
                 containers:
                   - name: pytorch
-                    image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.1
+                    image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0
                     command:
                       - "python3"
                       - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/kubeflow-training-operator/tfjob-mnist-with-summaries.yaml
+++ b/examples/v1beta1/kubeflow-training-operator/tfjob-mnist-with-summaries.yaml
@@ -56,7 +56,7 @@ spec:
               spec:
                 containers:
                   - name: tensorflow
-                    image: docker.io/kubeflowkatib/tf-mnist-with-summaries:v0.15.0-rc.1
+                    image: docker.io/kubeflowkatib/tf-mnist-with-summaries:v0.15.0
                     command:
                       - "python"
                       - "/opt/tf-mnist-with-summaries/mnist.py"

--- a/examples/v1beta1/kubeflow-training-operator/tfjob-mnist-with-summaries.yaml
+++ b/examples/v1beta1/kubeflow-training-operator/tfjob-mnist-with-summaries.yaml
@@ -56,7 +56,7 @@ spec:
               spec:
                 containers:
                   - name: tensorflow
-                    image: docker.io/kubeflowkatib/tf-mnist-with-summaries:v0.15.0-rc.0
+                    image: docker.io/kubeflowkatib/tf-mnist-with-summaries:v0.15.0-rc.1
                     command:
                       - "python"
                       - "/opt/tf-mnist-with-summaries/mnist.py"

--- a/examples/v1beta1/kubeflow-training-operator/tfjob-mnist-with-summaries.yaml
+++ b/examples/v1beta1/kubeflow-training-operator/tfjob-mnist-with-summaries.yaml
@@ -56,7 +56,7 @@ spec:
               spec:
                 containers:
                   - name: tensorflow
-                    image: docker.io/kubeflowkatib/tf-mnist-with-summaries:latest
+                    image: docker.io/kubeflowkatib/tf-mnist-with-summaries:v0.15.0-rc.0
                     command:
                       - "python"
                       - "/opt/tf-mnist-with-summaries/mnist.py"

--- a/examples/v1beta1/metrics-collector/custom-metrics-collector.yaml
+++ b/examples/v1beta1/metrics-collector/custom-metrics-collector.yaml
@@ -67,7 +67,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/metrics-collector/custom-metrics-collector.yaml
+++ b/examples/v1beta1/metrics-collector/custom-metrics-collector.yaml
@@ -67,7 +67,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0
                 command:
                   - "python3"
                   - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/metrics-collector/custom-metrics-collector.yaml
+++ b/examples/v1beta1/metrics-collector/custom-metrics-collector.yaml
@@ -67,7 +67,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:latest
+                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/metrics-collector/file-metrics-collector-with-json-format.yaml
+++ b/examples/v1beta1/metrics-collector/file-metrics-collector-with-json-format.yaml
@@ -52,7 +52,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/metrics-collector/file-metrics-collector-with-json-format.yaml
+++ b/examples/v1beta1/metrics-collector/file-metrics-collector-with-json-format.yaml
@@ -52,7 +52,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0
                 command:
                   - "python3"
                   - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/metrics-collector/file-metrics-collector-with-json-format.yaml
+++ b/examples/v1beta1/metrics-collector/file-metrics-collector-with-json-format.yaml
@@ -52,7 +52,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:latest
+                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/metrics-collector/file-metrics-collector.yaml
+++ b/examples/v1beta1/metrics-collector/file-metrics-collector.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:latest
+                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/metrics-collector/file-metrics-collector.yaml
+++ b/examples/v1beta1/metrics-collector/file-metrics-collector.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0
                 command:
                   - "python3"
                   - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/metrics-collector/file-metrics-collector.yaml
+++ b/examples/v1beta1/metrics-collector/file-metrics-collector.yaml
@@ -54,7 +54,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/pytorch-mnist/mnist.py"

--- a/examples/v1beta1/metrics-collector/metrics-collection-strategy.yaml
+++ b/examples/v1beta1/metrics-collector/metrics-collection-strategy.yaml
@@ -59,7 +59,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:latest
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/metrics-collector/metrics-collection-strategy.yaml
+++ b/examples/v1beta1/metrics-collector/metrics-collection-strategy.yaml
@@ -59,7 +59,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/metrics-collector/metrics-collection-strategy.yaml
+++ b/examples/v1beta1/metrics-collector/metrics-collection-strategy.yaml
@@ -59,7 +59,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/nas/darts-cpu.yaml
+++ b/examples/v1beta1/nas/darts-cpu.yaml
@@ -60,7 +60,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/darts-cnn-cifar10-cpu:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/darts-cnn-cifar10-cpu:v0.15.0-rc.1
                 command:
                   - python3
                   - run_trial.py

--- a/examples/v1beta1/nas/darts-cpu.yaml
+++ b/examples/v1beta1/nas/darts-cpu.yaml
@@ -60,7 +60,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/darts-cnn-cifar10-cpu:latest
+                image: docker.io/kubeflowkatib/darts-cnn-cifar10-cpu:v0.15.0-rc.0
                 command:
                   - python3
                   - run_trial.py

--- a/examples/v1beta1/nas/darts-cpu.yaml
+++ b/examples/v1beta1/nas/darts-cpu.yaml
@@ -60,7 +60,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/darts-cnn-cifar10-cpu:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/darts-cnn-cifar10-cpu:v0.15.0
                 command:
                   - python3
                   - run_trial.py

--- a/examples/v1beta1/nas/darts-gpu.yaml
+++ b/examples/v1beta1/nas/darts-gpu.yaml
@@ -77,7 +77,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/darts-cnn-cifar10-gpu:latest
+                image: docker.io/kubeflowkatib/darts-cnn-cifar10-gpu:v0.15.0-rc.0
                 command:
                   - python3
                   - run_trial.py

--- a/examples/v1beta1/nas/darts-gpu.yaml
+++ b/examples/v1beta1/nas/darts-gpu.yaml
@@ -77,7 +77,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/darts-cnn-cifar10-gpu:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/darts-cnn-cifar10-gpu:v0.15.0-rc.1
                 command:
                   - python3
                   - run_trial.py

--- a/examples/v1beta1/nas/darts-gpu.yaml
+++ b/examples/v1beta1/nas/darts-gpu.yaml
@@ -77,7 +77,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/darts-cnn-cifar10-gpu:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/darts-cnn-cifar10-gpu:v0.15.0
                 command:
                   - python3
                   - run_trial.py

--- a/examples/v1beta1/nas/enas-cpu.yaml
+++ b/examples/v1beta1/nas/enas-cpu.yaml
@@ -139,7 +139,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.15.0
                 command:
                   - python3
                   - -u

--- a/examples/v1beta1/nas/enas-cpu.yaml
+++ b/examples/v1beta1/nas/enas-cpu.yaml
@@ -139,7 +139,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.15.0-rc.1
                 command:
                   - python3
                   - -u

--- a/examples/v1beta1/nas/enas-cpu.yaml
+++ b/examples/v1beta1/nas/enas-cpu.yaml
@@ -139,7 +139,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:latest
+                image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.15.0-rc.0
                 command:
                   - python3
                   - -u

--- a/examples/v1beta1/nas/enas-gpu.yaml
+++ b/examples/v1beta1/nas/enas-gpu.yaml
@@ -136,7 +136,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/enas-cnn-cifar10-gpu:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/enas-cnn-cifar10-gpu:v0.15.0-rc.1
                 command:
                   - python3
                   - -u

--- a/examples/v1beta1/nas/enas-gpu.yaml
+++ b/examples/v1beta1/nas/enas-gpu.yaml
@@ -136,7 +136,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/enas-cnn-cifar10-gpu:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/enas-cnn-cifar10-gpu:v0.15.0
                 command:
                   - python3
                   - -u

--- a/examples/v1beta1/nas/enas-gpu.yaml
+++ b/examples/v1beta1/nas/enas-gpu.yaml
@@ -136,7 +136,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/enas-cnn-cifar10-gpu:latest
+                image: docker.io/kubeflowkatib/enas-cnn-cifar10-gpu:v0.15.0-rc.0
                 command:
                   - python3
                   - -u

--- a/examples/v1beta1/resume-experiment/from-volume-resume.yaml
+++ b/examples/v1beta1/resume-experiment/from-volume-resume.yaml
@@ -55,7 +55,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:latest
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/resume-experiment/from-volume-resume.yaml
+++ b/examples/v1beta1/resume-experiment/from-volume-resume.yaml
@@ -55,7 +55,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/resume-experiment/from-volume-resume.yaml
+++ b/examples/v1beta1/resume-experiment/from-volume-resume.yaml
@@ -55,7 +55,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/resume-experiment/long-running-resume.yaml
+++ b/examples/v1beta1/resume-experiment/long-running-resume.yaml
@@ -55,7 +55,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:latest
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/resume-experiment/long-running-resume.yaml
+++ b/examples/v1beta1/resume-experiment/long-running-resume.yaml
@@ -55,7 +55,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/resume-experiment/long-running-resume.yaml
+++ b/examples/v1beta1/resume-experiment/long-running-resume.yaml
@@ -55,7 +55,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/tekton/pipeline-run.yaml
+++ b/examples/v1beta1/tekton/pipeline-run.yaml
@@ -89,7 +89,7 @@ spec:
                     description: Number of training examples
                 steps:
                   - name: model-training
-                    image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+                    image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
                     command:
                       - "python3"
                       - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/tekton/pipeline-run.yaml
+++ b/examples/v1beta1/tekton/pipeline-run.yaml
@@ -89,7 +89,7 @@ spec:
                     description: Number of training examples
                 steps:
                   - name: model-training
-                    image: docker.io/kubeflowkatib/mxnet-mnist:latest
+                    image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
                     command:
                       - "python3"
                       - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/tekton/pipeline-run.yaml
+++ b/examples/v1beta1/tekton/pipeline-run.yaml
@@ -89,7 +89,7 @@ spec:
                     description: Number of training examples
                 steps:
                   - name: model-training
-                    image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+                    image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
                     command:
                       - "python3"
                       - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/trial-template/trial-metadata-substitution.yaml
+++ b/examples/v1beta1/trial-template/trial-metadata-substitution.yaml
@@ -60,7 +60,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:latest
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/trial-template/trial-metadata-substitution.yaml
+++ b/examples/v1beta1/trial-template/trial-metadata-substitution.yaml
@@ -60,7 +60,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/examples/v1beta1/trial-template/trial-metadata-substitution.yaml
+++ b/examples/v1beta1/trial-template/trial-metadata-substitution.yaml
@@ -60,7 +60,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/manifests/v1beta1/components/controller/katib-config.yaml
+++ b/manifests/v1beta1/components/controller/katib-config.yaml
@@ -8,13 +8,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.15.0-rc.1"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.15.0"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.15.0-rc.1"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.15.0"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.15.0-rc.1",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.15.0",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -25,31 +25,31 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.15.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.15.0"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.15.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.15.0"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.15.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.15.0"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.15.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.15.0"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.15.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.15.0"
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.15.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.15.0"
       },
       "sobol": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.15.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.15.0"
       },
       "multivariate-tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.15.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.15.0"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v0.15.0-rc.1",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v0.15.0",
         "resources": {
           "limits": {
             "memory": "200Mi"
@@ -57,10 +57,10 @@ data:
         }
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v0.15.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v0.15.0"
       },
       "pbt": {
-        "image": "docker.io/kubeflowkatib/suggestion-pbt:v0.15.0-rc.1",
+        "image": "docker.io/kubeflowkatib/suggestion-pbt:v0.15.0",
         "persistentVolumeClaimSpec": {
           "accessModes": [
             "ReadWriteMany"
@@ -76,6 +76,6 @@ data:
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.15.0-rc.1"
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.15.0"
       }
     }

--- a/manifests/v1beta1/components/controller/katib-config.yaml
+++ b/manifests/v1beta1/components/controller/katib-config.yaml
@@ -8,13 +8,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.15.0-rc.1"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.15.0-rc.1"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.15.0-rc.0",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.15.0-rc.1",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -25,31 +25,31 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.15.0-rc.1"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.15.0-rc.1"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.15.0-rc.1"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.15.0-rc.1"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.15.0-rc.1"
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.15.0-rc.1"
       },
       "sobol": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.15.0-rc.1"
       },
       "multivariate-tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.15.0-rc.1"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v0.15.0-rc.0",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v0.15.0-rc.1",
         "resources": {
           "limits": {
             "memory": "200Mi"
@@ -57,10 +57,10 @@ data:
         }
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v0.15.0-rc.1"
       },
       "pbt": {
-        "image": "docker.io/kubeflowkatib/suggestion-pbt:v0.15.0-rc.0",
+        "image": "docker.io/kubeflowkatib/suggestion-pbt:v0.15.0-rc.1",
         "persistentVolumeClaimSpec": {
           "accessModes": [
             "ReadWriteMany"
@@ -76,6 +76,6 @@ data:
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.15.0-rc.1"
       }
     }

--- a/manifests/v1beta1/components/controller/katib-config.yaml
+++ b/manifests/v1beta1/components/controller/katib-config.yaml
@@ -8,13 +8,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:latest"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.15.0-rc.0"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:latest"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.15.0-rc.0"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:latest",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.15.0-rc.0",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -25,31 +25,31 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:latest"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.15.0-rc.0"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:latest"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.15.0-rc.0"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-optuna:latest"
+        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.15.0-rc.0"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:latest"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.15.0-rc.0"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:latest"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.15.0-rc.0"
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:latest"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.15.0-rc.0"
       },
       "sobol": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:latest"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.15.0-rc.0"
       },
       "multivariate-tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-optuna:latest"
+        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.15.0-rc.0"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:latest",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v0.15.0-rc.0",
         "resources": {
           "limits": {
             "memory": "200Mi"
@@ -57,10 +57,10 @@ data:
         }
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:latest"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v0.15.0-rc.0"
       },
       "pbt": {
-        "image": "docker.io/kubeflowkatib/suggestion-pbt:latest",
+        "image": "docker.io/kubeflowkatib/suggestion-pbt:v0.15.0-rc.0",
         "persistentVolumeClaimSpec": {
           "accessModes": [
             "ReadWriteMany"
@@ -76,6 +76,6 @@ data:
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:latest"
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.15.0-rc.0"
       }
     }

--- a/manifests/v1beta1/components/controller/trial-templates.yaml
+++ b/manifests/v1beta1/components/controller/trial-templates.yaml
@@ -15,7 +15,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+              image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -33,7 +33,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.15.0-rc.0
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.15.0-rc.1
               command:
                 - python3
                 - -u
@@ -54,7 +54,7 @@ data:
             spec:
               containers:
                 - name: pytorch
-                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
+                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.1
                   command:
                     - "python3"
                     - "/opt/pytorch-mnist/mnist.py"
@@ -68,7 +68,7 @@ data:
             spec:
               containers:
                 - name: pytorch
-                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
+                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.1
                   command:
                     - "python3"
                     - "/opt/pytorch-mnist/mnist.py"

--- a/manifests/v1beta1/components/controller/trial-templates.yaml
+++ b/manifests/v1beta1/components/controller/trial-templates.yaml
@@ -15,7 +15,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+              image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -33,7 +33,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.15.0-rc.1
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.15.0
               command:
                 - python3
                 - -u
@@ -54,7 +54,7 @@ data:
             spec:
               containers:
                 - name: pytorch
-                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.1
+                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0
                   command:
                     - "python3"
                     - "/opt/pytorch-mnist/mnist.py"
@@ -68,7 +68,7 @@ data:
             spec:
               containers:
                 - name: pytorch
-                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.1
+                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0
                   command:
                     - "python3"
                     - "/opt/pytorch-mnist/mnist.py"

--- a/manifests/v1beta1/components/controller/trial-templates.yaml
+++ b/manifests/v1beta1/components/controller/trial-templates.yaml
@@ -15,7 +15,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:latest
+              image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -33,7 +33,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:latest
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.15.0-rc.0
               command:
                 - python3
                 - -u
@@ -54,7 +54,7 @@ data:
             spec:
               containers:
                 - name: pytorch
-                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:latest
+                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
                   command:
                     - "python3"
                     - "/opt/pytorch-mnist/mnist.py"
@@ -68,7 +68,7 @@ data:
             spec:
               containers:
                 - name: pytorch
-                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:latest
+                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.15.0-rc.0
                   command:
                     - "python3"
                     - "/opt/pytorch-mnist/mnist.py"

--- a/manifests/v1beta1/installs/katib-cert-manager/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-cert-manager/kustomization.yaml
@@ -22,13 +22,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
 
 patchesStrategicMerge:
   - patches/katib-cert-injection.yaml

--- a/manifests/v1beta1/installs/katib-cert-manager/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-cert-manager/kustomization.yaml
@@ -22,13 +22,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
 
 patchesStrategicMerge:
   - patches/katib-cert-injection.yaml

--- a/manifests/v1beta1/installs/katib-cert-manager/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-cert-manager/kustomization.yaml
@@ -22,13 +22,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: latest
+    newTag: v0.15.0-rc.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: latest
+    newTag: v0.15.0-rc.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: latest
+    newTag: v0.15.0-rc.0
 
 patchesStrategicMerge:
   - patches/katib-cert-injection.yaml

--- a/manifests/v1beta1/installs/katib-external-db/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-external-db/kustomization.yaml
@@ -20,16 +20,16 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
   - name: docker.io/kubeflowkatib/cert-generator
     newName: docker.io/kubeflowkatib/cert-generator
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
 patchesStrategicMerge:
   - patches/db-manager.yaml
 # Modify katib-mysql-secrets with parameters for the DB.

--- a/manifests/v1beta1/installs/katib-external-db/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-external-db/kustomization.yaml
@@ -20,16 +20,16 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
   - name: docker.io/kubeflowkatib/cert-generator
     newName: docker.io/kubeflowkatib/cert-generator
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
 patchesStrategicMerge:
   - patches/db-manager.yaml
 # Modify katib-mysql-secrets with parameters for the DB.

--- a/manifests/v1beta1/installs/katib-external-db/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-external-db/kustomization.yaml
@@ -20,16 +20,16 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: latest
+    newTag: v0.15.0-rc.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: latest
+    newTag: v0.15.0-rc.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: latest
+    newTag: v0.15.0-rc.0
   - name: docker.io/kubeflowkatib/cert-generator
     newName: docker.io/kubeflowkatib/cert-generator
-    newTag: latest
+    newTag: v0.15.0-rc.0
 patchesStrategicMerge:
   - patches/db-manager.yaml
 # Modify katib-mysql-secrets with parameters for the DB.

--- a/manifests/v1beta1/installs/katib-openshift/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-openshift/kustomization.yaml
@@ -30,13 +30,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
 
 patchesJson6902:
   # Annotate Service to delegate TLS-secret generation to OpenShift service controller

--- a/manifests/v1beta1/installs/katib-openshift/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-openshift/kustomization.yaml
@@ -30,13 +30,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
 
 patchesJson6902:
   # Annotate Service to delegate TLS-secret generation to OpenShift service controller

--- a/manifests/v1beta1/installs/katib-openshift/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-openshift/kustomization.yaml
@@ -30,13 +30,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: latest
+    newTag: v0.15.0-rc.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: latest
+    newTag: v0.15.0-rc.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: latest
+    newTag: v0.15.0-rc.0
 
 patchesJson6902:
   # Annotate Service to delegate TLS-secret generation to OpenShift service controller

--- a/manifests/v1beta1/installs/katib-standalone-postgres/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-standalone-postgres/kustomization.yaml
@@ -22,16 +22,16 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
   - name: docker.io/kubeflowkatib/cert-generator
     newName: docker.io/kubeflowkatib/cert-generator
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
 patchesJson6902:
   - target:
       group: apps

--- a/manifests/v1beta1/installs/katib-standalone-postgres/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-standalone-postgres/kustomization.yaml
@@ -22,16 +22,16 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
   - name: docker.io/kubeflowkatib/cert-generator
     newName: docker.io/kubeflowkatib/cert-generator
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
 patchesJson6902:
   - target:
       group: apps

--- a/manifests/v1beta1/installs/katib-standalone-postgres/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-standalone-postgres/kustomization.yaml
@@ -22,16 +22,16 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: latest
+    newTag: v0.15.0-rc.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: latest
+    newTag: v0.15.0-rc.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: latest
+    newTag: v0.15.0-rc.0
   - name: docker.io/kubeflowkatib/cert-generator
     newName: docker.io/kubeflowkatib/cert-generator
-    newTag: latest
+    newTag: v0.15.0-rc.0
 patchesJson6902:
   - target:
       group: apps

--- a/manifests/v1beta1/installs/katib-standalone/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-standalone/kustomization.yaml
@@ -22,13 +22,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
   - name: docker.io/kubeflowkatib/cert-generator
     newName: docker.io/kubeflowkatib/cert-generator
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1

--- a/manifests/v1beta1/installs/katib-standalone/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-standalone/kustomization.yaml
@@ -22,13 +22,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
   - name: docker.io/kubeflowkatib/cert-generator
     newName: docker.io/kubeflowkatib/cert-generator
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0

--- a/manifests/v1beta1/installs/katib-standalone/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-standalone/kustomization.yaml
@@ -22,13 +22,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: latest
+    newTag: v0.15.0-rc.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: latest
+    newTag: v0.15.0-rc.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: latest
+    newTag: v0.15.0-rc.0
   - name: docker.io/kubeflowkatib/cert-generator
     newName: docker.io/kubeflowkatib/cert-generator
-    newTag: latest
+    newTag: v0.15.0-rc.0

--- a/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
@@ -11,13 +11,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.15.0-rc.0
+    newTag: v0.15.0-rc.1
 
 patchesStrategicMerge:
   - patches/remove-namespace.yaml

--- a/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
@@ -11,13 +11,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.15.0-rc.1
+    newTag: v0.15.0
 
 patchesStrategicMerge:
   - patches/remove-namespace.yaml

--- a/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
@@ -11,13 +11,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: latest
+    newTag: v0.15.0-rc.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: latest
+    newTag: v0.15.0-rc.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: latest
+    newTag: v0.15.0-rc.0
 
 patchesStrategicMerge:
   - patches/remove-namespace.yaml

--- a/operators/katib-controller/src/defaultTrialTemplate.yaml
+++ b/operators/katib-controller/src/defaultTrialTemplate.yaml
@@ -5,7 +5,7 @@ spec:
     spec:
       containers:
         - name: training-container
-          image: docker.io/kubeflowkatib/mxnet-mnist:latest
+          image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
           command:
             - "python3"
             - "/opt/mxnet-mnist/mnist.py"

--- a/operators/katib-controller/src/defaultTrialTemplate.yaml
+++ b/operators/katib-controller/src/defaultTrialTemplate.yaml
@@ -5,7 +5,7 @@ spec:
     spec:
       containers:
         - name: training-container
-          image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+          image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
           command:
             - "python3"
             - "/opt/mxnet-mnist/mnist.py"

--- a/operators/katib-controller/src/defaultTrialTemplate.yaml
+++ b/operators/katib-controller/src/defaultTrialTemplate.yaml
@@ -5,7 +5,7 @@ spec:
     spec:
       containers:
         - name: training-container
-          image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+          image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
           command:
             - "python3"
             - "/opt/mxnet-mnist/mnist.py"

--- a/operators/katib-controller/src/enasCPUTemplate.yaml
+++ b/operators/katib-controller/src/enasCPUTemplate.yaml
@@ -5,7 +5,7 @@ spec:
     spec:
       containers:
         - name: training-container
-          image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:latest
+          image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.15.0-rc.0
           command:
             - python3
             - -u

--- a/operators/katib-controller/src/enasCPUTemplate.yaml
+++ b/operators/katib-controller/src/enasCPUTemplate.yaml
@@ -5,7 +5,7 @@ spec:
     spec:
       containers:
         - name: training-container
-          image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.15.0-rc.0
+          image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.15.0-rc.1
           command:
             - python3
             - -u

--- a/operators/katib-controller/src/enasCPUTemplate.yaml
+++ b/operators/katib-controller/src/enasCPUTemplate.yaml
@@ -5,7 +5,7 @@ spec:
     spec:
       containers:
         - name: training-container
-          image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.15.0-rc.1
+          image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.15.0
           command:
             - python3
             - -u

--- a/operators/katib-ui/src/charm.py
+++ b/operators/katib-ui/src/charm.py
@@ -42,7 +42,6 @@ class Operator(CharmBase):
 
     def set_pod_spec(self, event):
         try:
-
             self._check_leader()
 
             interfaces = self._get_interfaces()

--- a/pkg/new-ui/v1beta1/backend.go
+++ b/pkg/new-ui/v1beta1/backend.go
@@ -729,9 +729,9 @@ func fetchMasterPodName(clientset *kubernetes.Clientset, trial *trialsv1beta1.Tr
 	}
 
 	if len(podList.Items) == 0 {
-		return "", errors.New(`Logs for the trial could not be found.
-Was 'retain: true' specified in the Experiment definition?
-An example can be found here: https://github.com/kubeflow/katib/blob/7bf39225f7235ee4ba6cf285ecc2c455c6471234/examples/v1beta1/argo/argo-workflow.yaml#L33`)
+		return "", errors.New(`Failed to find logs for this Trial. Make sure you've set "spec.trialTemplate.retain"
+		field to "true" in the Experiment definition. If this error persists then the Pod's logs are not currently
+		persisted in the cluster.`)
 	}
 	if len(podList.Items) > 1 {
 		return "", errors.New("More than one master replica found")

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-details.component.html
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-details.component.html
@@ -46,6 +46,16 @@
           ></app-trial-overview>
         </ng-template>
       </mat-tab>
+
+      <mat-tab label="LOGS">
+        <ng-template matTabContent>
+          <app-trial-logs
+            [trialLogs]="trialLogs"
+            [logsRequestError]="logsRequestError"
+          ></app-trial-logs>
+        </ng-template>
+      </mat-tab>
+
       <mat-tab label="YAML">
         <ng-template matTabContent>
           <app-trial-yaml [trialJson]="trialDetails"></app-trial-yaml>

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-details.component.spec.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-details.component.spec.ts
@@ -21,6 +21,7 @@ let NamespaceServiceStub: Partial<NamespaceService>;
 KWABackendServiceStub = {
   getTrial: () => of([]),
   getTrialInfo: () => of(),
+  getTrialLogs: () => of(),
 };
 
 NamespaceServiceStub = {

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-details.component.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-details.component.ts
@@ -30,6 +30,8 @@ export class TrialDetailsComponent implements OnInit, OnDestroy {
   experimentName: string;
   showTrialGraph: boolean = false;
   options: {};
+  trialLogs: string;
+  logsRequestError: string;
   chartData: ChartPoint[] = [];
   yScaleMax = 0;
   yScaleMin = 1;
@@ -133,6 +135,17 @@ export class TrialDetailsComponent implements OnInit, OnDestroy {
         }
         this.pageLoading = false;
       });
+
+    this.backendService.getTrialLogs(this.trialName, this.namespace).subscribe(
+      logs => {
+        this.trialLogs = logs;
+        this.logsRequestError = null;
+      },
+      error => {
+        this.trialLogs = null;
+        this.logsRequestError = error;
+      },
+    );
   }
 
   private trialStatus(trial: TrialK8s): StatusEnum {

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-details.module.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-details.module.ts
@@ -16,6 +16,7 @@ import {
   PanelModule,
 } from 'kubeflow';
 import { NgxEchartsModule } from 'ngx-echarts';
+import { TrialLogsModule } from './trial-logs/trial-logs.module';
 
 @NgModule({
   declarations: [TrialDetailsComponent],
@@ -36,6 +37,7 @@ import { NgxEchartsModule } from 'ngx-echarts';
     NgxEchartsModule.forRoot({
       echarts: () => import('echarts'),
     }),
+    TrialLogsModule,
   ],
   exports: [TrialDetailsComponent],
 })

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-logs/trial-logs.component.html
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-logs/trial-logs.component.html
@@ -1,0 +1,15 @@
+<!--if no logs are present at all then show a warning message-->
+<ng-container *ngIf="logsRequestError">
+  <lib-panel icon="error" color="warn">
+    {{ logsRequestError }}
+  </lib-panel>
+</ng-container>
+
+<ng-container *ngIf="!logsRequestError">
+  <lib-logs-viewer
+    class="logs-viewer"
+    heading="Trial Logs"
+    [subHeading]="''"
+    [logs]="logs"
+  ></lib-logs-viewer>
+</ng-container>

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-logs/trial-logs.component.scss
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-logs/trial-logs.component.scss
@@ -1,0 +1,9 @@
+lib-panel {
+  display: block;
+  margin-top: 1rem;
+}
+
+.logs-viewer {
+  margin-bottom: 2rem;
+  margin-top: 1rem;
+}

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-logs/trial-logs.component.spec.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-logs/trial-logs.component.spec.ts
@@ -1,0 +1,36 @@
+import { CommonModule } from '@angular/common';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  HeadingSubheadingRowModule,
+  KubeflowModule,
+  LogsViewerModule,
+} from 'kubeflow';
+
+import { TrialLogsComponent } from './trial-logs.component';
+
+describe('TrialLogsComponent', () => {
+  let component: TrialLogsComponent;
+  let fixture: ComponentFixture<TrialLogsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TrialLogsComponent],
+      imports: [
+        CommonModule,
+        KubeflowModule,
+        HeadingSubheadingRowModule,
+        LogsViewerModule,
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TrialLogsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-logs/trial-logs.component.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-logs/trial-logs.component.ts
@@ -1,0 +1,21 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-trial-logs',
+  templateUrl: './trial-logs.component.html',
+  styleUrls: ['./trial-logs.component.scss'],
+})
+export class TrialLogsComponent {
+  public logs: string[];
+
+  @Input() logsRequestError: string;
+
+  @Input()
+  set trialLogs(trialLogs: string) {
+    if (!trialLogs) {
+      return;
+    }
+
+    this.logs = trialLogs.split('\n');
+  }
+}

--- a/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-logs/trial-logs.module.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/pages/experiment-details/trials-table/trial-details/trial-logs/trial-logs.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TrialLogsComponent } from './trial-logs.component';
+import {
+  HeadingSubheadingRowModule,
+  KubeflowModule,
+  LogsViewerModule,
+} from 'kubeflow';
+
+@NgModule({
+  declarations: [TrialLogsComponent],
+  imports: [
+    CommonModule,
+    KubeflowModule,
+    HeadingSubheadingRowModule,
+    LogsViewerModule,
+  ],
+  exports: [TrialLogsComponent],
+})
+export class TrialLogsModule {}

--- a/pkg/new-ui/v1beta1/frontend/src/app/services/backend.service.ts
+++ b/pkg/new-ui/v1beta1/frontend/src/app/services/backend.service.ts
@@ -102,4 +102,25 @@ export class KWABackendService extends BackendService {
       .post(url, { postData: exp })
       .pipe(catchError(error => this.parseError(error)));
   }
+
+  getTrialLogs(name: string, namespace: string): Observable<any> {
+    const url = `/katib/fetch_trial_logs/?trialName=${name}&namespace=${namespace}`;
+
+    return this.http
+      .get(url)
+      .pipe(catchError(error => this.handleError(error, false)));
+  }
+
+  // ---------------------------Error Handling---------------------------------
+
+  // Override common service's getBackendErrorLog
+  // in order to properly show the message the backend has sent
+  public getBackendErrorLog(error: HttpErrorResponse): string {
+    if (error.error === null) {
+      return error.message;
+    } else {
+      // Show the message the backend has sent
+      return error.error.log ? error.error.log : error.error;
+    }
+  }
 }

--- a/sdk/python/v1beta1/setup.py
+++ b/sdk/python/v1beta1/setup.py
@@ -37,7 +37,7 @@ if os.path.exists(katib_grpc_api_file):
 
 setuptools.setup(
     name="kubeflow-katib",
-    version="0.15.0rc0",
+    version="0.15.0rc1",
     author="Kubeflow Authors",
     author_email="premnath.vel@gmail.com",
     license="Apache License Version 2.0",

--- a/sdk/python/v1beta1/setup.py
+++ b/sdk/python/v1beta1/setup.py
@@ -37,7 +37,7 @@ if os.path.exists(katib_grpc_api_file):
 
 setuptools.setup(
     name="kubeflow-katib",
-    version="0.15.0rc1",
+    version="0.15.0",
     author="Kubeflow Authors",
     author_email="premnath.vel@gmail.com",
     license="Apache License Version 2.0",

--- a/sdk/python/v1beta1/setup.py
+++ b/sdk/python/v1beta1/setup.py
@@ -37,7 +37,7 @@ if os.path.exists(katib_grpc_api_file):
 
 setuptools.setup(
     name="kubeflow-katib",
-    version="0.14.0",
+    version="0.15.0rc0",
     author="Kubeflow Authors",
     author_email="premnath.vel@gmail.com",
     license="Apache License Version 2.0",

--- a/test/e2e/v1beta1/testdata/invalid-experiment.yaml
+++ b/test/e2e/v1beta1/testdata/invalid-experiment.yaml
@@ -52,7 +52,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/test/e2e/v1beta1/testdata/invalid-experiment.yaml
+++ b/test/e2e/v1beta1/testdata/invalid-experiment.yaml
@@ -52,7 +52,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:latest
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/test/e2e/v1beta1/testdata/invalid-experiment.yaml
+++ b/test/e2e/v1beta1/testdata/invalid-experiment.yaml
@@ -52,7 +52,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/test/e2e/v1beta1/testdata/valid-experiment.yaml
+++ b/test/e2e/v1beta1/testdata/valid-experiment.yaml
@@ -52,7 +52,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/test/e2e/v1beta1/testdata/valid-experiment.yaml
+++ b/test/e2e/v1beta1/testdata/valid-experiment.yaml
@@ -52,7 +52,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:latest
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"

--- a/test/e2e/v1beta1/testdata/valid-experiment.yaml
+++ b/test/e2e/v1beta1/testdata/valid-experiment.yaml
@@ -52,7 +52,7 @@ spec:
           spec:
             containers:
               - name: training-container
-                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0-rc.1
+                image: docker.io/kubeflowkatib/mxnet-mnist:v0.15.0
                 command:
                   - "python3"
                   - "/opt/mxnet-mnist/mnist.py"


### PR DESCRIPTION
## Description

The [oidc-authservice](https://github.com/arrikto/oidc-authservice) support the `GROUPS_HEADER`. In the current implementation the `Groups` field in the `SubjectAccessReviewSpec` is not used. Kubernetes have a build-in support for them.

The format for the value of `GROUPS_HEADER` is a string containing the groups separated with commas. 

By default `Kubeflow` and specifically the `authn-filter` envoyFilter will not propagate the `kubeflow-groups` header only the `kubeflow-userid`, but this is only a configuration files, the changes in this PR will allow to get the groups the user is associated with, and create a subject review with its user-id (email) and groups. 
