### PR TITLE
Fix conformance docker image

### DIFF
--- a/Dockerfile.conformance
+++ b/Dockerfile.conformance
@@ -20,6 +20,7 @@ WORKDIR /kubeflow/katib
 COPY sdk/ /kubeflow/katib/sdk/
 COPY examples/ /kubeflow/katib/examples/
 COPY test/ /kubeflow/katib/test/
+COPY pkg/ /kubeflow/katib/pkg/
 
 COPY conformance/run.sh .
 


### PR DESCRIPTION

**What this PR does / why we need it**: 

* Currently, the conformance docker image raises an import error `ModuleNotFoundError: No module named 'kubeflow.katib.katib_api_pb2'`
* It seems in `setup.py` we're copying a file from `pkg/` directory to `kubeflow/katib` directory which we don't check in into github. https://github.com/kubeflow/katib/blob/master/sdk/python/v1beta1/setup.py#L29-L36
* Since `katib_api_pb2.py` was present in `.gitingore`, it was not highlighted in my ide/terminal and somehow I missed it in my local testing. https://github.com/kubeflow/katib/blob/master/sdk/python/v1beta1/.gitignore#L5

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
