### PR TITLE
SDK: Import all Kubernetes Models

### DIFF
--- a/hack/gen-python-sdk/post_gen.py
+++ b/hack/gen-python-sdk/post_gen.py
@@ -53,12 +53,7 @@ def _rewrite_helper(input_file, output_file, rewrite_rules):
     if (output_file == "sdk/python/v1beta1/kubeflow/katib/models/__init__.py"):
         lines.append("\n")
         lines.append("# Import Kubernetes models.\n")
-        lines.append("from kubernetes.client import V1ObjectMeta\n")
-        lines.append("from kubernetes.client import V1ListMeta\n")
-        lines.append("from kubernetes.client import V1Container\n")
-        lines.append("from kubernetes.client import V1HTTPGetAction\n")
-        lines.append("from kubernetes.client import V1ManagedFieldsEntry\n")
-        lines.append("from kubernetes.client import V1OwnerReference\n")
+        lines.append("from kubernetes.client import *\n")
 
     with open(output_file, 'w') as f:
         f.writelines(lines)

--- a/sdk/python/v1beta1/kubeflow/katib/models/__init__.py
+++ b/sdk/python/v1beta1/kubeflow/katib/models/__init__.py
@@ -57,9 +57,4 @@ from kubeflow.katib.models.v1beta1_trial_status import V1beta1TrialStatus
 from kubeflow.katib.models.v1beta1_trial_template import V1beta1TrialTemplate
 
 # Import Kubernetes models.
-from kubernetes.client import V1ObjectMeta
-from kubernetes.client import V1ListMeta
-from kubernetes.client import V1Container
-from kubernetes.client import V1HTTPGetAction
-from kubernetes.client import V1ManagedFieldsEntry
-from kubernetes.client import V1OwnerReference
+from kubernetes.client import *


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/katib/issues/2110
Currently, we need to import all Kubernetes models to Katib SDK, so SDK can do proper deserialization.

We need to track better solution in: https://github.com/kubeflow/training-operator/issues/1723

/assign @johnugeorge @tenzen-y @votti