### PR TITLE
Add Katib ROADMAP 2022/2023

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,7 @@
 - Conformance tests for Katib - [#2044](https://github.com/kubeflow/katib/issues/2044)
 - Support push-based metrics collection in Katib - [#577](https://github.com/kubeflow/katib/issues/577)
 - Support PostgreSQL as a Katib DB - [#915](https://github.com/kubeflow/katib/issues/915)
+- Improve Katib scalability - [#1847](https://github.com/kubeflow/katib/issues/1847)
 - Promote Katib CRDs (`Experiment`, `Suggestion`, and `Trial`) to the `v1` version
 - Support multiple CRD versions (`v1beta1`, `v1`) with conversion webhook
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,20 +4,21 @@
 
 - Support advance HyperParameter tuning algorithms:
 
-  - Population Based Training - [#1382](https://github.com/kubeflow/katib/issues/1382)
+  - Population Based Training (PBT) - [#1382](https://github.com/kubeflow/katib/issues/1382)
   - Tree of Parzen Estimators (TPE)
   - Multivariate TPE
   - Sobol’s Quasirandom Sequence
   - Asynchronous Successive Halving - [ASHA](https://arxiv.org/pdf/1810.05934.pdf)
 
+- Support multi-objective optimization - [#1549](https://github.com/kubeflow/katib/issues/1549)
+- Support various HP distributions (log-uniform, uniform, normal) - [#1207](https://github.com/kubeflow/katib/issues/1207)
 - Support Auto Model Compression - [#460](https://github.com/kubeflow/katib/issues/460)
 - Support Auto Feature Engineering - [#475](https://github.com/kubeflow/katib/issues/475)
-- Improve Neural Architecture Search design.
+- Improve Neural Architecture Search design
 
 ## Backend and API Enhancements
 
 - Conformance tests for Katib - [#2044](https://github.com/kubeflow/katib/issues/2044)
-- Support various HP distributions (log-uniform, uniform, normal) - [#1207](https://github.com/kubeflow/katib/issues/1207)
 - Support push-based metrics collection in Katib - [#577](https://github.com/kubeflow/katib/issues/577)
 - Support PostgreSQL as a Katib DB - [#915](https://github.com/kubeflow/katib/issues/915)
 - Promote Katib CRDs (`Experiment`, `Suggestion`, and `Trial`) to the `v1` version

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@
 - Support push-based metrics collection in Katib - [#577](https://github.com/kubeflow/katib/issues/577)
 - Support PostgreSQL as a Katib DB - [#915](https://github.com/kubeflow/katib/issues/915)
 - Improve Katib scalability - [#1847](https://github.com/kubeflow/katib/issues/1847)
-- Promote Katib CRDs (`Experiment`, `Suggestion`, and `Trial`) to the `v1` version
+- Promote Katib APIs to the `v1` version
 - Support multiple CRD versions (`v1beta1`, `v1`) with conversion webhook
 
 ## Improve Katib User Experience

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,3 +1,43 @@
+# Katib 2022/2023 Roadmap
+
+## AutoML Features
+
+- Support advance HyperParameter tuning algorithms:
+
+  - Population Based Training - [#1382](https://github.com/kubeflow/katib/issues/1382)
+  - Tree of Parzen Estimators (TPE)
+  - Multivariate TPE
+  - Sobol’s Quasirandom Sequence
+  - Asynchronous Successive Halving - [ASHA](https://arxiv.org/pdf/1810.05934.pdf)
+
+- Support Auto Model Compression - [#460](https://github.com/kubeflow/katib/issues/460)
+- Support Auto Feature Engineering - [#475](https://github.com/kubeflow/katib/issues/475)
+- Improve Neural Architecture Search design.
+
+## Backend and API Enhancements
+
+- Conformance tests for Katib - [#2044](https://github.com/kubeflow/katib/issues/2044)
+- Support various HP distributions (log-uniform, uniform, normal) - [#1207](https://github.com/kubeflow/katib/issues/1207)
+- Support push-based metrics collection in Katib - [#577](https://github.com/kubeflow/katib/issues/577)
+- Support PostgreSQL as a Katib DB - [#915](https://github.com/kubeflow/katib/issues/915)
+- Promote Katib CRDs (`Experiment`, `Suggestion`, and `Trial`) to the `v1` version
+- Support multiple CRD versions (`v1beta1`, `v1`) with conversion webhook
+
+## Improve Katib User Experience
+
+- Simplify Katib Experiment creation with Katib SDK - [#1951](https://github.com/kubeflow/katib/pull/1951)
+- Fully migrate to a new Katib UI - [Project 1](https://github.com/kubeflow/katib/projects/1)
+- Expose Trial logs in Katib UI - [#971](https://github.com/kubeflow/katib/issues/971)
+- Enhance Katib UI visualization metrics for AutoML Experiments
+- Improve Katib Config UX - [#2150](https://github.com/kubeflow/katib/issues/2150)
+
+## Integration with Kubeflow Components
+
+- Kubeflow Pipeline as a Katib Trial target - [#1914](https://github.com/kubeflow/katib/issues/1914)
+- Improve data passing when Katib Experiment is part of Kubeflow Pipeline - [#1846](https://github.com/kubeflow/katib/issues/1846)
+
+# History
+
 # Katib 2021 Roadmap
 
 ## New Features
@@ -23,8 +63,6 @@
 - Refactor Hyperband [#1389](https://github.com/kubeflow/katib/issues/1389)
 - Support multiple CRD version with conversion webhook
 - MLMD integration with Katib Experiments
-
-# History
 
 # Katib 2020 Roadmap
 


### PR DESCRIPTION
I created initial draft for Katib ROADMAP 2022/2023.
I tried to consolidated features that we implemented in 2022, since we didn't update the ROADMAP in 2022 (if I missed some significant features that we've done, please let me know).

Please let me know if you have better ideas how to name headers.

Let's discuss the items during next month and finalise the ROADMAP.


/cc @johnugeorge @gaocegege @tenzen-y @anencore94 @kimwnasptd @elenzio9 @orfeas-k @apo-ger @d-gol @shaowei-su @zhixian82 @fischor @keisuke-umezawa @jbottum @DnPlas @juliusvonkohout 


cc @kubeflow/wg-training-leads 