### PR TITLE
[UI] Fix Trial Logs when Kubernetes Job Fails

### DIFF
--- a/pkg/new-ui/v1beta1/backend.go
+++ b/pkg/new-ui/v1beta1/backend.go
@@ -733,10 +733,15 @@ func fetchMasterPodName(clientset *kubernetes.Clientset, trial *trialsv1beta1.Tr
 		field to "true" in the Experiment definition. If this error persists then the Pod's logs are not currently
 		persisted in the cluster.`)
 	}
-	if len(podList.Items) > 1 {
-		return "", errors.New("More than one master replica found")
+
+	// If Pod is Running or Succeeded Pod, return it.
+	for _, pod := range podList.Items {
+		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodRunning {
+			return pod.Name, nil
+		}
 	}
 
+	// Otherwise, return the first Failed Pod.
 	return podList.Items[0].Name, nil
 }
 

--- a/pkg/new-ui/v1beta1/backend.go
+++ b/pkg/new-ui/v1beta1/backend.go
@@ -742,7 +742,14 @@ func fetchMasterPodName(clientset *kubernetes.Clientset, trial *trialsv1beta1.Tr
 	}
 
 	// Otherwise, return the first Failed Pod.
-	return podList.Items[0].Name, nil
+	for _, pod := range podList.Items {
+		if pod.Status.Phase == corev1.PodFailed {
+			return pod.Name, nil
+		}
+	}
+
+	// Otherwise, return error since Pod is in the Pending state.
+	return "", errors.New("Failed to get logs for this Trial. Pod is in the Pending or Unknown state.")
 }
 
 // fetchPodLogs returns logs of a pod for the given job name and namespace


### PR DESCRIPTION
I fixed UI backend that should return proper value when Kubernetes Job Fails. When Job Fails, it spawns multiple Pods and our UI shows this: `More than one master replica found`.

To fix this, I follow this:

1.  If one Succeeded or Running Pod exists, we print the logs.
1. Otherwise, print logs from one of Failed Pods.

/assign @tenzen-y @kimwnasptd @johnugeorge @apo-ger @d-gol