### PR TITLE
feature: Adding trial name as env for metrics collectors

### DIFF
--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -103,6 +103,8 @@ const (
 	// DefaultKatibComposerEnvName is the default env name of katib suggestion composer
 	DefaultKatibComposerEnvName = "KATIB_SUGGESTION_COMPOSER"
 
+	KatibTrialEnvName = "KATIB_TRIAL_NAME"
+
 	// DefaultKatibDBManagerServiceNamespaceEnvName is the env name of Katib DB Manager namespace
 	DefaultKatibDBManagerServiceNamespaceEnvName = "KATIB_DB_MANAGER_SERVICE_NAMESPACE"
 	// DefaultKatibDBManagerServiceIPEnvName is the env name of Katib DB Manager IP

--- a/pkg/webhook/v1beta1/pod/inject_webhook.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook.go
@@ -234,6 +234,10 @@ func (s *SidecarInjector) getMetricsCollectorContainer(trial *trialsv1beta1.Tria
 		Args:            args,
 		ImagePullPolicy: metricsCollectorConfigData.ImagePullPolicy,
 		Resources:       metricsCollectorConfigData.Resource,
+		Env: []v1.EnvVar{{
+			Name:  consts.KatibTrialEnvName,
+			Value: trial.Name,
+		}},
 	}
 
 	// Inject the security context when the flag is enabled.

--- a/pkg/webhook/v1beta1/pod/inject_webhook.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook.go
@@ -144,6 +144,9 @@ func (s *SidecarInjector) Mutate(pod *v1.Pod, namespace string) (*v1.Pod, error)
 		return nil, err
 	}
 
+	// Add KATIB_TRIAL_NAME env name to all containers
+	mutatePodContainersEnv(mutatedPod, trial)
+
 	// Add Katib Trial labels to the Pod metadata.
 	mutatePodMetadata(mutatedPod, trial)
 

--- a/pkg/webhook/v1beta1/pod/inject_webhook_test.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook_test.go
@@ -1065,3 +1065,68 @@ func TestMutatePodMetadata(t *testing.T) {
 		}
 	}
 }
+
+func TestMutatePodContainersEnv(t *testing.T) {
+	testTrialName := "hello-trial"
+
+	testCases := []struct {
+		pod             *v1.Pod
+		trial           *trialsv1beta1.Trial
+		mutatedPod      *v1.Pod
+		testDescription string
+	}{
+		{
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "container-1",
+							Env:  []v1.EnvVar{},
+						},
+						{
+							Name: "container-2",
+							Env:  []v1.EnvVar{},
+						},
+					},
+				},
+			},
+			trial: &trialsv1beta1.Trial{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testTrialName,
+				},
+			},
+			mutatedPod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "container-1",
+							Env: []v1.EnvVar{
+								{
+									Name:  "KATIB_TRIAL_NAME",
+									Value: testTrialName,
+								},
+							},
+						},
+						{
+							Name: "container-2",
+							Env: []v1.EnvVar{
+								{
+									Name:  "KATIB_TRIAL_NAME",
+									Value: testTrialName,
+								},
+							},
+						},
+					},
+				},
+			},
+			testDescription: "todo",
+		},
+	}
+
+	for _, tc := range testCases {
+		mutatePodContainersEnv(tc.pod, tc.trial)
+		if !reflect.DeepEqual(tc.mutatedPod, tc.pod) {
+			t.Errorf("Case %v. Expected Pod %v, got %v", tc.testDescription, tc.mutatedPod, tc.pod)
+		}
+	}
+}

--- a/pkg/webhook/v1beta1/pod/inject_webhook_test.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook_test.go
@@ -1102,7 +1102,7 @@ func TestMutatePodContainersEnv(t *testing.T) {
 							Name: "container-1",
 							Env: []v1.EnvVar{
 								{
-									Name:  "KATIB_TRIAL_NAME",
+									Name:  consts.KatibTrialEnvName,
 									Value: testTrialName,
 								},
 							},
@@ -1111,7 +1111,7 @@ func TestMutatePodContainersEnv(t *testing.T) {
 							Name: "container-2",
 							Env: []v1.EnvVar{
 								{
-									Name:  "KATIB_TRIAL_NAME",
+									Name:  consts.KatibTrialEnvName,
 									Value: testTrialName,
 								},
 							},
@@ -1119,7 +1119,7 @@ func TestMutatePodContainersEnv(t *testing.T) {
 					},
 				},
 			},
-			testDescription: "todo",
+			testDescription: "Mutated Pod should have all containers with KATIB_TRIAL_NAME env",
 		},
 	}
 

--- a/pkg/webhook/v1beta1/pod/utils.go
+++ b/pkg/webhook/v1beta1/pod/utils.go
@@ -265,7 +265,7 @@ func mutatePodContainersEnv(pod *v1.Pod, trial *trialsv1beta1.Trial) {
 	for i := range pod.Spec.Containers {
 		container := &pod.Spec.Containers[i]
 		container.Env = append(container.Env, v1.EnvVar{
-			Name:  "KATIB_TRIAL_NAME",
+			Name:  consts.KatibTrialEnvName,
 			Value: trial.Name,
 		})
 	}

--- a/pkg/webhook/v1beta1/pod/utils.go
+++ b/pkg/webhook/v1beta1/pod/utils.go
@@ -261,6 +261,16 @@ func mutateMetricsCollectorVolume(pod *v1.Pod, mountPath, sidecarContainerName, 
 	return nil
 }
 
+func mutatePodContainersEnv(pod *v1.Pod, trial *trialsv1beta1.Trial) {
+	for i := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[i]
+		container.Env = append(container.Env, v1.EnvVar{
+			Name:  "KATIB_TRIAL_NAME",
+			Value: trial.Name,
+		})
+	}
+}
+
 func mutatePodMetadata(pod *v1.Pod, trial *trialsv1beta1.Trial) {
 	podLabels := map[string]string{}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This will add the `KATIB_TRIAL_NAME `  env containing the trial name to all the containers.

This would simply many interactions, the trial name is injected for every metrics collectors, which made it more difficult to create custom collectors.

The typical example is the following in the https://github.com/kubeflow/katib/pull/2118

https://github.com/kubeflow/katib/blob/25ac27f644fc5fb2439ab375366fa3d3c66b3aba/cmd/metricscollector/v1beta1/kfp-metricscollector/v1/main.py#L68

Parsing the pod_name is not really a good practice. Instead injecting with a proper env is probably more suitable.
Injecting in every pods make it also easier for trial without metrics collector to push themself metrics to katib.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
