### PR TITLE
Replace action to setup minikube with medyagh/setup-minikube

### DIFF
--- a/.github/workflows/e2e-test-darts-cifar10.yaml
+++ b/.github/workflows/e2e-test-darts-cifar10.yaml
@@ -9,9 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   e2e:
     runs-on: ubuntu-20.04
@@ -36,6 +33,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.23.13", "v1.24.7", "v1.25.3"]
+        kubernetes-version: ["v1.23.17", "v1.24.16", "v1.25.12"]
         # Comma Delimited
         experiments: ["darts-cpu"]

--- a/.github/workflows/e2e-test-enas-cifar10.yaml
+++ b/.github/workflows/e2e-test-enas-cifar10.yaml
@@ -9,9 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   e2e:
     runs-on: ubuntu-20.04
@@ -36,6 +33,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.23.13", "v1.24.7", "v1.25.3"]
+        kubernetes-version: ["v1.23.17", "v1.24.16", "v1.25.12"]
         # Comma Delimited
         experiments: ["enas-cpu"]

--- a/.github/workflows/e2e-test-mxnet-mnist.yaml
+++ b/.github/workflows/e2e-test-mxnet-mnist.yaml
@@ -9,9 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   e2e:
     runs-on: ubuntu-20.04
@@ -36,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.23.13", "v1.24.7", "v1.25.3"]
+        kubernetes-version: ["v1.23.17", "v1.24.16", "v1.25.12"]
         # Comma Delimited
         experiments:
           # suggestion-hyperopt

--- a/.github/workflows/e2e-test-pytorch-mnist.yaml
+++ b/.github/workflows/e2e-test-pytorch-mnist.yaml
@@ -9,9 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   e2e:
     runs-on: ubuntu-20.04
@@ -37,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.23.13", "v1.24.7", "v1.25.3"]
+        kubernetes-version: ["v1.23.17", "v1.24.16", "v1.25.12"]
         # Comma Delimited
         experiments:
           - "file-metrics-collector,pytorchjob-mnist"

--- a/.github/workflows/e2e-test-simple-pbt.yaml
+++ b/.github/workflows/e2e-test-simple-pbt.yaml
@@ -9,9 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   e2e:
     runs-on: ubuntu-20.04
@@ -36,6 +33,6 @@ jobs:
       fail-fast: false
       matrix:
         # Detail: https://hub.docker.com/r/kindest/node
-        kubernetes-version: ["v1.23.13", "v1.24.7", "v1.25.3"]
+        kubernetes-version: ["v1.23.17", "v1.24.16", "v1.25.12"]
         # Comma Delimited
         experiments: ["simple-pbt"]

--- a/.github/workflows/e2e-test-tf-mnist-with-summaries.yaml
+++ b/.github/workflows/e2e-test-tf-mnist-with-summaries.yaml
@@ -9,9 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   e2e:
     runs-on: ubuntu-20.04
@@ -36,6 +33,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.23.13", "v1.24.7", "v1.25.3"]
+        kubernetes-version: ["v1.23.17", "v1.24.16", "v1.25.12"]
         # Comma Delimited
         experiments: ["tfjob-mnist-with-summaries"]

--- a/.github/workflows/e2e-test-ui-random-search-postgres.yaml
+++ b/.github/workflows/e2e-test-ui-random-search-postgres.yaml
@@ -7,9 +7,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   e2e:
     runs-on: ubuntu-20.04
@@ -35,4 +32,4 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["v1.23.13", "v1.24.7", "v1.25.3"]
+        kubernetes-version: ["v1.23.17", "v1.24.16", "v1.25.12"]

--- a/.github/workflows/template-publish-image/action.yaml
+++ b/.github/workflows/template-publish-image/action.yaml
@@ -28,6 +28,12 @@ runs:
         sudo rm -rf /opt/ghc
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/local/share/powershell
+        sudo rm -rf /usr/share/swift
+
+        echo "Disk usage after cleanup:"
+        df -h
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/template-setup-e2e-test/action.yaml
+++ b/.github/workflows/template-setup-e2e-test/action.yaml
@@ -15,14 +15,36 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup Minikube Cluster
-      uses: manusa/actions-setup-minikube@v2.7.2
+    # This step is a Workaround to avoid the "No space left on device" error.
+    # ref: https://github.com/actions/runner-images/issues/2840
+    - name: Remove unnecessary files
+      shell: bash
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/local/share/powershell
+        sudo rm -rf /usr/share/swift
+
+        echo "Disk usage after cleanup:"
+        df -h
+
+    - name: Setup kubectl
+      uses: azure/setup-kubectl@v3
       with:
-        minikube version: v1.28.0
-        kubernetes version: ${{ inputs.kubernetes-version }}
-        start args: --wait-timeout=60s
+        version: ${{ inputs.kubernetes-version }}
+
+    - name: Setup Minikube Cluster
+      uses: medyagh/setup-minikube@v0.0.14
+      with:
+        network-plugin: cni
+        cni: flannel
         driver: none
-        github token: ${{ env.GITHUB_TOKEN }}
+        kubernetes-version: ${{ inputs.kubernetes-version }}
+        minikube-version: 1.31.1
+        start-args: --wait-timeout=120s
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I replaced actions to set up minikube with [medyagh/setup-minikube](https://github.com/medyagh/setup-minikube) since using manusa/actions-setup-minikube seems to no longer be maintained, and the action doesn't support kubernetes v1.26.

related to: https://github.com/kubeflow/katib/pull/2177

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
