### PR TITLE
Allow install binaries for the arm64 in the envtest

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -63,5 +63,5 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Detail: `setup-envtest list --arch amd64`
+        # Detail: `setup-envtest list`
         kubernetes-version: ["1.25.0", "1.26.1", "1.27.1"]

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ TEST_TENSORFLOW_EVENT_FILE_PATH ?= $(CURDIR)/test/unit/v1beta1/metricscollector/
 # Run tests
 .PHONY: test
 test: envtest
-	KUBEBUILDER_ASSETS="$(shell setup-envtest --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)" go test ./pkg/... ./cmd/... -coverprofile coverage.out
+	KUBEBUILDER_ASSETS="$(shell setup-envtest use $(ENVTEST_K8S_VERSION) -p path)" go test ./pkg/... ./cmd/... -coverprofile coverage.out
 
 envtest:
 ifndef HAS_SETUP_ENVTEST


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
We can stop explicitly setting a cpu architecture because the tool supports the arm64 platform since K8s v1.24.

https://github.com/kubernetes-sigs/kubebuilder/issues/2664#issuecomment-1149956592

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
