### PR TITLE
Replace grpc_health_probe with the built-in gRPC container probe feature

### DIFF
--- a/cmd/db-manager/v1beta1/Dockerfile
+++ b/cmd/db-manager/v1beta1/Dockerfile
@@ -2,7 +2,6 @@
 FROM golang:alpine AS build-env
 
 ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
 
 WORKDIR /go/src/github.com/kubeflow/katib
 
@@ -18,13 +17,8 @@ COPY pkg/ pkg/
 # Build the binary.
 RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" go build -a -o katib-db-manager ./cmd/db-manager/v1beta1
 
-# Add GRPC health probe.
-RUN wget -qO /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
-  && chmod +x /bin/grpc_health_probe
-
 # Copy the db-manager into a thin image.
 FROM alpine:3.15
 WORKDIR /app
-COPY --from=build-env /bin/grpc_health_probe /bin/
 COPY --from=build-env /go/src/github.com/kubeflow/katib/katib-db-manager /app/
 ENTRYPOINT ["./katib-db-manager"]

--- a/cmd/suggestion/goptuna/v1beta1/Dockerfile
+++ b/cmd/suggestion/goptuna/v1beta1/Dockerfile
@@ -2,7 +2,6 @@
 FROM golang:alpine AS build-env
 
 ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
 
 WORKDIR /go/src/github.com/kubeflow/katib
 
@@ -18,10 +17,6 @@ COPY pkg/ pkg/
 # Build the binary.
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o goptuna-suggestion ./cmd/suggestion/goptuna/v1beta1
 
-# Add GRPC health probe.
-RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
-  && chmod +x /bin/grpc_health_probe
-
 # Copy the Goptuna suggestion into a thin image.
 FROM alpine:3.15
 
@@ -29,7 +24,6 @@ ENV TARGET_DIR /opt/katib
 
 WORKDIR ${TARGET_DIR}
 
-COPY --from=build-env /bin/grpc_health_probe /bin/
 COPY --from=build-env /go/src/github.com/kubeflow/katib/goptuna-suggestion ${TARGET_DIR}/
 
 RUN chgrp -R 0 ${TARGET_DIR} \

--- a/cmd/suggestion/hyperband/v1beta1/Dockerfile
+++ b/cmd/suggestion/hyperband/v1beta1/Dockerfile
@@ -1,11 +1,3 @@
-FROM alpine:3.15 AS downloader
-
-ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
-
-RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
-  && chmod +x /bin/grpc_health_probe
-
 FROM python:3.10-slim
 
 ARG TARGETARCH
@@ -22,7 +14,6 @@ RUN if [ "${TARGETARCH}" = "ppc64le" ] || [ "${TARGETARCH}" = "arm64" ]; then \
 
 ADD ./pkg/ ${TARGET_DIR}/pkg/
 ADD ./${SUGGESTION_DIR}/ ${TARGET_DIR}/${SUGGESTION_DIR}/
-COPY --from=downloader /bin/grpc_health_probe /bin/grpc_health_probe
 
 WORKDIR  ${TARGET_DIR}/${SUGGESTION_DIR}
 

--- a/cmd/suggestion/hyperopt/v1beta1/Dockerfile
+++ b/cmd/suggestion/hyperopt/v1beta1/Dockerfile
@@ -1,11 +1,3 @@
-FROM alpine:3.15 AS downloader
-
-ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
-
-RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
-  && chmod +x /bin/grpc_health_probe
-
 FROM python:3.10-slim
 
 ARG TARGETARCH
@@ -22,7 +14,6 @@ RUN if [ "${TARGETARCH}" = "ppc64le" ]; then \
 
 ADD ./pkg/ ${TARGET_DIR}/pkg/
 ADD ./${SUGGESTION_DIR}/ ${TARGET_DIR}/${SUGGESTION_DIR}/
-COPY --from=downloader /bin/grpc_health_probe /bin/grpc_health_probe
 
 WORKDIR  ${TARGET_DIR}/${SUGGESTION_DIR}
 

--- a/cmd/suggestion/nas/darts/v1beta1/Dockerfile
+++ b/cmd/suggestion/nas/darts/v1beta1/Dockerfile
@@ -1,11 +1,3 @@
-FROM alpine:3.15 as downloader
-
-ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
-
-RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
-  && chmod +x /bin/grpc_health_probe
-
 FROM python:3.10-slim
 
 ARG TARGETARCH
@@ -22,7 +14,6 @@ RUN if [ "${TARGETARCH}" = "ppc64le" ]; then \
 
 ADD ./pkg/ ${TARGET_DIR}/pkg/
 ADD ./${SUGGESTION_DIR}/ ${TARGET_DIR}/${SUGGESTION_DIR}/
-COPY --from=downloader /bin/grpc_health_probe /bin/grpc_health_probe
 
 WORKDIR  ${TARGET_DIR}/${SUGGESTION_DIR}
 

--- a/cmd/suggestion/nas/enas/v1beta1/Dockerfile
+++ b/cmd/suggestion/nas/enas/v1beta1/Dockerfile
@@ -1,17 +1,8 @@
-FROM alpine:3.15 AS downloader
-
-ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
-
-RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
-  && chmod +x /bin/grpc_health_probe
-
 FROM python:3.10-slim
 
 ARG TARGETARCH
 ENV TARGET_DIR /opt/katib
 ENV SUGGESTION_DIR cmd/suggestion/nas/enas/v1beta1
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
 ENV PYTHONPATH ${TARGET_DIR}:${TARGET_DIR}/pkg/apis/manager/v1beta1/python:${TARGET_DIR}/pkg/apis/manager/health/python
 
 RUN if [ "${TARGETARCH}" = "ppc64le" ]; then \
@@ -23,7 +14,6 @@ RUN if [ "${TARGETARCH}" = "ppc64le" ]; then \
 
 ADD ./pkg/ ${TARGET_DIR}/pkg/
 ADD ./${SUGGESTION_DIR}/ ${TARGET_DIR}/${SUGGESTION_DIR}/
-COPY --from=downloader /bin/grpc_health_probe /bin/grpc_health_probe
 
 WORKDIR  ${TARGET_DIR}/${SUGGESTION_DIR}
 

--- a/cmd/suggestion/optuna/v1beta1/Dockerfile
+++ b/cmd/suggestion/optuna/v1beta1/Dockerfile
@@ -1,11 +1,3 @@
-FROM alpine:3.15 AS downloader
-
-ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
-
-RUN wget -qO /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
-  && chmod +x /bin/grpc_health_probe
-
 FROM python:3.10-slim
 
 ARG TARGETARCH
@@ -22,7 +14,6 @@ RUN if [ "${TARGETARCH}" = "ppc64le" ]; then \
 
 ADD ./pkg/ ${TARGET_DIR}/pkg/
 ADD ./${SUGGESTION_DIR}/ ${TARGET_DIR}/${SUGGESTION_DIR}/
-COPY --from=downloader /bin/grpc_health_probe /bin/grpc_health_probe
 
 WORKDIR  ${TARGET_DIR}/${SUGGESTION_DIR}
 

--- a/cmd/suggestion/pbt/v1beta1/Dockerfile
+++ b/cmd/suggestion/pbt/v1beta1/Dockerfile
@@ -1,11 +1,3 @@
-FROM alpine:3.15 AS downloader
-
-ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
-
-RUN wget -qO /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
-  && chmod +x /bin/grpc_health_probe
-
 FROM python:3.10-slim
 
 ARG TARGETARCH
@@ -22,7 +14,6 @@ RUN if [ "${TARGETARCH}" = "ppc64le" ]; then \
 
 ADD ./pkg/ ${TARGET_DIR}/pkg/
 ADD ./${SUGGESTION_DIR}/ ${TARGET_DIR}/${SUGGESTION_DIR}/
-COPY --from=downloader /bin/grpc_health_probe /bin/grpc_health_probe
 
 WORKDIR  ${TARGET_DIR}/${SUGGESTION_DIR}
 

--- a/cmd/suggestion/skopt/v1beta1/Dockerfile
+++ b/cmd/suggestion/skopt/v1beta1/Dockerfile
@@ -1,11 +1,3 @@
-FROM alpine:3.15 AS downloader
-
-ARG TARGETARCH
-ENV GRPC_HEALTH_PROBE_VERSION v0.4.15
-
-RUN wget -qO /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} \
-  && chmod +x /bin/grpc_health_probe
-
 FROM python:3.10-slim
 
 ARG TARGETARCH
@@ -22,7 +14,6 @@ RUN if [ "${TARGETARCH}" = "ppc64le" ]; then \
 
 ADD ./pkg/ ${TARGET_DIR}/pkg/
 ADD ./${SUGGESTION_DIR}/ ${TARGET_DIR}/${SUGGESTION_DIR}/
-COPY --from=downloader /bin/grpc_health_probe /bin/grpc_health_probe
 
 WORKDIR  ${TARGET_DIR}/${SUGGESTION_DIR}
 

--- a/manifests/v1beta1/components/db-manager/db-manager.yaml
+++ b/manifests/v1beta1/components/db-manager/db-manager.yaml
@@ -35,8 +35,8 @@ spec:
             - name: api
               containerPort: 6789
           livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:6789"]
+            grpc:
+              port: 6789
             initialDelaySeconds: 10
             periodSeconds: 60
             failureThreshold: 5

--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -87,10 +87,6 @@ const (
 	// DefaultEarlyStoppingPort is the default port of EarlyStopping service.
 	DefaultEarlyStoppingPort = 6788
 
-	// DefaultGRPCService is the default suggestion service name,
-	// which is used to run healthz check using grpc probe.
-	DefaultGRPCService = "manager.v1beta1.Suggestion"
-
 	// DefaultGRPCRetryAttempts is the the maximum number of retries for gRPC calls
 	DefaultGRPCRetryAttempts = 10
 	// DefaultGRPCRetryPeriod is a fixed period of time between gRPC call retries
@@ -170,6 +166,10 @@ var (
 	DefaultKatibDBManagerServiceIP = env.GetEnvOrDefault(DefaultKatibDBManagerServiceIPEnvName, "katib-db-manager")
 	// DefaultKatibDBManagerServicePort is the default Port of Katib DB Manager
 	DefaultKatibDBManagerServicePort = env.GetEnvOrDefault(DefaultKatibDBManagerServicePortEnvName, "6789")
+
+	// DefaultGRPCService is the default suggestion service name,
+	// which is used to run healthz check using grpc probe.
+	DefaultGRPCService = "manager.v1beta1.Suggestion"
 
 	// List of all valid keys of trial metadata for substitution in Trial template
 	TrialTemplateMetaKeys = []string{

--- a/pkg/controller.v1beta1/suggestion/composer/composer.go
+++ b/pkg/controller.v1beta1/suggestion/composer/composer.go
@@ -44,8 +44,6 @@ const (
 	defaultPeriodForReady      = 10
 	defaultPeriodForLive       = 120
 	defaultFailureThreshold    = 12
-	// Ref https://github.com/grpc-ecosystem/grpc-health-probe/
-	defaultGRPCHealthCheckProbe = "/bin/grpc_health_probe"
 )
 
 var (
@@ -210,12 +208,9 @@ func (g *General) desiredContainers(s *suggestionsv1beta1.Suggestion,
 	if viper.GetBool(consts.ConfigEnableGRPCProbeInSuggestion) && suggestionContainer.ReadinessProbe == nil {
 		suggestionContainer.ReadinessProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
-				Exec: &corev1.ExecAction{
-					Command: []string{
-						defaultGRPCHealthCheckProbe,
-						fmt.Sprintf("-addr=:%d", consts.DefaultSuggestionPort),
-						fmt.Sprintf("-service=%s", consts.DefaultGRPCService),
-					},
+				GRPC: &corev1.GRPCAction{
+					Port:    consts.DefaultSuggestionPort,
+					Service: &consts.DefaultGRPCService,
 				},
 			},
 			InitialDelaySeconds: defaultInitialDelaySeconds,
@@ -225,12 +220,9 @@ func (g *General) desiredContainers(s *suggestionsv1beta1.Suggestion,
 	if viper.GetBool(consts.ConfigEnableGRPCProbeInSuggestion) && suggestionContainer.LivenessProbe == nil {
 		suggestionContainer.LivenessProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
-				Exec: &corev1.ExecAction{
-					Command: []string{
-						defaultGRPCHealthCheckProbe,
-						fmt.Sprintf("-addr=:%d", consts.DefaultSuggestionPort),
-						fmt.Sprintf("-service=%s", consts.DefaultGRPCService),
-					},
+				GRPC: &corev1.GRPCAction{
+					Port:    consts.DefaultSuggestionPort,
+					Service: &consts.DefaultGRPCService,
 				},
 			},
 			// Ref https://srcco.de/posts/kubernetes-liveness-probes-are-dangerous.html

--- a/pkg/controller.v1beta1/suggestion/composer/composer_test.go
+++ b/pkg/controller.v1beta1/suggestion/composer/composer_test.go
@@ -817,12 +817,9 @@ func newFakeContainers() []corev1.Container {
 			},
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
-					Exec: &corev1.ExecAction{
-						Command: []string{
-							defaultGRPCHealthCheckProbe,
-							fmt.Sprintf("-addr=:%d", consts.DefaultSuggestionPort),
-							fmt.Sprintf("-service=%s", consts.DefaultGRPCService),
-						},
+					GRPC: &corev1.GRPCAction{
+						Port:    consts.DefaultSuggestionPort,
+						Service: &consts.DefaultGRPCService,
 					},
 				},
 				InitialDelaySeconds: defaultInitialDelaySeconds,
@@ -830,12 +827,9 @@ func newFakeContainers() []corev1.Container {
 			},
 			LivenessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
-					Exec: &corev1.ExecAction{
-						Command: []string{
-							defaultGRPCHealthCheckProbe,
-							fmt.Sprintf("-addr=:%d", consts.DefaultSuggestionPort),
-							fmt.Sprintf("-service=%s", consts.DefaultGRPCService),
-						},
+					GRPC: &corev1.GRPCAction{
+						Port:    consts.DefaultSuggestionPort,
+						Service: &consts.DefaultGRPCService,
 					},
 				},
 				InitialDelaySeconds: defaultInitialDelaySeconds,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
The built-in gRPC container probe has been enabled as a default since K8s v1.24.

https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-grpc-liveness-probe

So we should replace grpc_health_probe with a built-in one.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
