### PR TITLE
Sending an empty data to the certsReady channel

### DIFF
--- a/cmd/katib-controller/v1beta1/main.go
+++ b/cmd/katib-controller/v1beta1/main.go
@@ -135,13 +135,13 @@ func main() {
 
 	ctx := signals.SetupSignalHandler()
 	certsReady := make(chan struct{})
-
+	defer close(certsReady)
 	if initConfig.CertGeneratorConfig.Enable {
 		if err = cert.AddToManager(mgr, initConfig.CertGeneratorConfig, certsReady); err != nil {
 			log.Error(err, "Failed to set up cert-generator")
 		}
 	} else {
-		close(certsReady)
+		certsReady <- struct{}{}
 	}
 
 	// The setupControllers will register controllers to the manager

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -114,6 +114,9 @@ Once the `cert-generator` finished, the Katib controller starts to register cont
 
 You can find the `cert-generator` source code [here](../pkg/certgenerator/v1beta1).
 
+NOTE: the Katib also supports the [cert-manager](https://cert-manager.io/) to generate certs for the admission webhooks instead of using cert-generator.
+You can find the installation with the cert-manager [here](../manifests/v1beta1/installs/katib-cert-manager).
+
 ## Implement a new algorithm and use it in Katib
 
 Please see [new-algorithm-service.md](./new-algorithm-service.md).

--- a/pkg/certgenerator/v1beta1/generator.go
+++ b/pkg/certgenerator/v1beta1/generator.go
@@ -67,8 +67,8 @@ func (c *CertGenerator) Start(ctx context.Context) error {
 	if err := c.generate(ctx); err != nil {
 		return err
 	}
-	// Close a certsReady means start to register controllers to the manager.
-	close(c.certsReady)
+	// Sending an empty data to a certsReady means it starts to register controllers to the manager.
+	c.certsReady <- struct{}{}
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
The current implementation potentially has an issue to occur a memory leak since the katib-controller doesn't verify if the channel is closed. 

Also, I added docs about cert-manager integration to developer guide.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
