### PR TITLE
Bug: Wait for the certs to be mounted inside the container

### DIFF
--- a/pkg/certgenerator/v1beta1/generator_test.go
+++ b/pkg/certgenerator/v1beta1/generator_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -263,7 +264,8 @@ func TestEnsureCertMounted(t *testing.T) {
 					t.Fatalf("Failed to create tls.crt: %v", err)
 				}
 			}
-			got, _ := ensureCertMounted(context.Background())
+			ensureFunc := ensureCertMounted(time.Now())
+			got, _ := ensureFunc(context.Background())
 			if tc.wantExist != got {
 				t.Errorf("Unexpected value from ensureCertMounted: \n(want: %v, got: %v)\n", tc.wantExist, got)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
To avoid the below error the cert-generator should wait for the certs to be mounted inside the container:

```shell
{"level":"error","ts":"2023-08-05T18:14:44Z","logger":"entrypoint","msg":"Unable to run the manager","error":"open /tmp/cert/tls.crt: no such file or directory","stacktrace":"main.main\n\t/go/src/github.com/kubeflow/katib/cmd/katib-controller/v1beta1/main.go:164\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250"}
```

Currently, the cert-generator immediately sends data to the `certsReady` channel once the certs are generated.
However, since completed to generate certs doesn't mean the mounted secret is updated with certs, the cert-generator should wait for the mounted secret to be updated by kubelet.

ref: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
