### PR TITLE
[SDK] Raise more human-readable name conflict exception

### DIFF
--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -105,7 +105,11 @@ class KatibClient(object):
             raise TimeoutError(
                 f"Timeout to create Katib Experiment: {namespace}/{experiment.metadata.name}"
             )
-        except Exception:
+        except Exception as e:
+            if hasattr(e, "status") and e.status == 409:
+                raise Exception(
+                    f"A Katib Experiment with the name {namespace}/{experiment.metadata.name} already exists."
+                )
             raise RuntimeError(
                 f"Failed to create Katib Experiment: {namespace}/{experiment.metadata.name}"
             )


### PR DESCRIPTION
**What this PR does / why we need it**:
If you call `KatibClient.tune` using an experiment name that already exists, you get a giant traceback with the relevant / helpful message not being at the bottom. We had a user struggle to debug this on their own.

This PR simply raises a more helpful exception in the event of a 409 (name conflict) response from the API.

**Checklist:**
- [x] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
