### PR TITLE
Skip to inject the metrics-collector pods to the katib controller

### DIFF
--- a/manifests/v1beta1/components/controller/controller.yaml
+++ b/manifests/v1beta1/components/controller/controller.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         katib.kubeflow.org/component: controller
+        katib.kubeflow.org/metrics-collector-injection: disabled
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"

--- a/manifests/v1beta1/components/webhook/webhooks.yaml
+++ b/manifests/v1beta1/components/webhook/webhooks.yaml
@@ -63,6 +63,16 @@ webhooks:
     namespaceSelector:
       matchLabels:
         katib.kubeflow.org/metrics-collector-injection: enabled
+    # Once the AdmissionWebhookMatchConditions feature gate is enabled by default, we should switch to control based on userInfo.
+    # REF:
+    # - AdmissionWebhookMatchConditions: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchconditions
+    # - Tracking issue: https://github.com/kubeflow/katib/issues/2206
+    objectSelector:
+      matchExpressions:
+        - key: katib.kubeflow.org/metrics-collector-injection
+          operator: NotIn
+          values:
+            - disabled
     rules:
       - apiGroups:
           - ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I introduced the label to skip injecting the metrics-collector to the katib system components.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #2069

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
