### PR TITLE
Bump Katib Python SDK to 0.16.0rc0 version

### DIFF
--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -19,6 +19,16 @@ This is the instruction on how to make a new release for the Katib project.
 
 - Install `twine` to publish the SDK package: `pip install twine==3.4.1`
 
+  - Create a [PyPI Token](https://pypi.org/help/#apitoken) to publish Katib SDK.
+
+  - Add the following config to your `~/.pypirc` file:
+
+    ```
+    [pypi]
+       username = __token__
+       password = <PYPI_TOKEN>
+    ```
+
 ## Release Process
 
 ### Versioning Policy

--- a/sdk/python/v1beta1/setup.py
+++ b/sdk/python/v1beta1/setup.py
@@ -32,12 +32,13 @@ katib_grpc_api_file = "../../../pkg/apis/manager/v1beta1/python/api_pb2.py"
 # We need to always copy this file only on the SDK building stage, not on SDK installation stage.
 if os.path.exists(katib_grpc_api_file):
     shutil.copy(
-        katib_grpc_api_file, "kubeflow/katib/katib_api_pb2.py",
+        katib_grpc_api_file,
+        "kubeflow/katib/katib_api_pb2.py",
     )
 
 setuptools.setup(
     name="kubeflow-katib",
-    version="0.15.0",
+    version="0.16.0rc0",
     author="Kubeflow Authors",
     author_email="premnath.vel@gmail.com",
     license="Apache License Version 2.0",


### PR DESCRIPTION
Updating Katib Python SDK to the latest version.

Also, I updated release doc to publish SDK to PyPi.

/assign @johnugeorge @tenzen-y 