### PR TITLE
Immediately close the certsReady channel if the cert-generator is disabled

### DIFF
--- a/cmd/katib-controller/v1beta1/main.go
+++ b/cmd/katib-controller/v1beta1/main.go
@@ -141,7 +141,7 @@ func main() {
 			log.Error(err, "Failed to set up cert-generator")
 		}
 	} else {
-		certsReady <- struct{}{}
+		close(certsReady)
 	}
 
 	// The setupControllers will register controllers to the manager


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
