### PR TITLE
Automated cherry pick of #2207: Remove a katib-webhook-cert Secret from components

### DIFF
--- a/manifests/v1beta1/components/webhook/kustomization.yaml
+++ b/manifests/v1beta1/components/webhook/kustomization.yaml
@@ -4,4 +4,3 @@ kind: Kustomization
 
 resources:
   - webhooks.yaml
-  - secret.yaml

--- a/manifests/v1beta1/components/webhook/secret.yaml
+++ b/manifests/v1beta1/components/webhook/secret.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: katib-webhook-cert

--- a/manifests/v1beta1/installs/katib-external-db/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-external-db/kustomization.yaml
@@ -32,6 +32,10 @@ secretGenerator:
   - name: katib-mysql-secrets
     envs:
       - secrets.env
+  # Secret for webhooks certs.
+  - name: katib-webhook-cert
+    options:
+      disableNameSuffixHash: true
 configMapGenerator:
   - name: katib-config
     behavior: create

--- a/manifests/v1beta1/installs/katib-standalone-postgres/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-standalone-postgres/kustomization.yaml
@@ -41,3 +41,8 @@ configMapGenerator:
       - katib-config.yaml
     options:
       disableNameSuffixHash: true
+# Secret for webhooks certs.
+secretGenerator:
+  - name: katib-webhook-cert
+    options:
+      disableNameSuffixHash: true

--- a/manifests/v1beta1/installs/katib-standalone/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-standalone/kustomization.yaml
@@ -34,3 +34,8 @@ configMapGenerator:
       - katib-config.yaml
     options:
       disableNameSuffixHash: true
+# Secret for webhooks certs.
+secretGenerator:
+  - name: katib-webhook-cert
+    options:
+      disableNameSuffixHash: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Cherry-pick of https://github.com/kubeflow/katib/pull/2207 on release-0.16.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
