### PR TITLE
Run Stale Action Every 5th Hour

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,7 +7,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-    - cron: "0 16 * * *"
+    - cron: "0 */5 * * *"
 
 jobs:
   stale:


### PR DESCRIPTION
Currently, Stale Actions process a few issues/PRs per run every day: https://github.com/kubeflow/katib/actions/runs/5941243672

I changed Stale action to run every 5 hour to process more stale issues/PRs.
That should help us to track more issues and don't hit GitHub REST API limits: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
Also, I changed `operations-per-run` to 60.

WDYT @tenzen-y @johnugeorge ?