### PR TITLE
Update Ubuntu to 22.04 for E2E Tests

### DIFF
--- a/.github/workflows/build-and-publish-images.yaml
+++ b/.github/workflows/build-and-publish-images.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
   build-and-publish:
     name: Publish Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/e2e-test-darts-cifar10.yaml
+++ b/.github/workflows/e2e-test-darts-cifar10.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-test-enas-cifar10.yaml
+++ b/.github/workflows/e2e-test-enas-cifar10.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-test-mxnet-mnist.yaml
+++ b/.github/workflows/e2e-test-mxnet-mnist.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-test-pytorch-mnist.yaml
+++ b/.github/workflows/e2e-test-pytorch-mnist.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-test-simple-pbt.yaml
+++ b/.github/workflows/e2e-test-simple-pbt.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-test-tf-mnist-with-summaries.yaml
+++ b/.github/workflows/e2e-test-tf-mnist-with-summaries.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-test-ui-random-search-postgres.yaml
+++ b/.github/workflows/e2e-test-ui-random-search-postgres.yaml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   generatetests:
     name: Generate And Format Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       GOPATH: ${{ github.workspace }}/go
     defaults:
@@ -34,7 +34,7 @@ jobs:
 
   unittests:
     name: Unit Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       GOPATH: ${{ github.workspace }}/go
     defaults:

--- a/.github/workflows/test-lint.yaml
+++ b/.github/workflows/test-lint.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out code

--- a/.github/workflows/test-node.yaml
+++ b/.github/workflows/test-node.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   test:
     name: Code format and lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out code
@@ -35,7 +35,7 @@ jobs:
 
   frontend-unit-tests:
     name: Frontend Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out code

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out code

--- a/examples/v1beta1/trial-images/mxnet-mnist/install-arm-performance-libraries.sh
+++ b/examples/v1beta1/trial-images/mxnet-mnist/install-arm-performance-libraries.sh
@@ -19,17 +19,17 @@ set -o nounset
 set -o pipefail
 cd "$(dirname "$0")"
 
-# Download Arm Performance Libraries for Ubuntu 20.04
+# Download Arm Performance Libraries for Ubuntu 22.04
 # Ref: https://developer.arm.com/downloads/-/arm-performance-libraries
-echo "Downloading Arm Performance Libraries for Ubuntu 20.04..."
+echo "Downloading Arm Performance Libraries for Ubuntu 22.04..."
 wget -qO - \
-  "https://developer.arm.com/-/media/Files/downloads/hpc/arm-performance-libraries/22-0-2/Ubuntu20.04/arm-performance-libraries_22.0.2_Ubuntu-20.04_gcc-11.2.tar?rev=577d3dbcff7847b9af57399b2978f9a6&revision=577d3dbc-ff78-47b9-af57-399b2978f9a6" \
+  "https://developer.arm.com/-/media/Files/downloads/hpc/arm-performance-libraries/23-04-1/ubuntu-22/arm-performance-libraries_23.04.1_Ubuntu-22.04_gcc-11.3.tar?rev=207c1f7aaa16400e94eb9a980494a6eb&revision=207c1f7a-aa16-400e-94eb-9a980494a6eb" \
   | tar -xf -
 
 # Install Arm Performance Libraries
-echo "Installing Arm Performance Libraries for Ubuntu 20.04..."
-./arm-performance-libraries_22.0.2_Ubuntu-20.04/arm-performance-libraries_22.0.2_Ubuntu-20.04.sh -a
+echo "Installing Arm Performance Libraries for Ubuntu 22.04..."
+./arm-performance-libraries_23.04.1_Ubuntu-22.04/arm-performance-libraries_23.04.1_Ubuntu-22.04.sh -a
 
 # Clean up
 echo "Removing installer..."
-rm -rf ./arm-performance-libraries_22.0.2_Ubuntu-20.04
+rm -rf ./arm-performance-libraries_23.04.1_Ubuntu-22.04


### PR DESCRIPTION
I updated Ubuntu version to `22.04` for our E2E tests to fix errors.
For more context follow this thread: https://github.com/kubeflow/katib/pull/2153#discussion_r1304485202

/assign @tenzen-y @johnugeorge 