### PR TITLE
Bump Katib Python SDK to 0.16.0 version

### DIFF
--- a/sdk/python/v1beta1/setup.py
+++ b/sdk/python/v1beta1/setup.py
@@ -38,7 +38,7 @@ if os.path.exists(katib_grpc_api_file):
 
 setuptools.setup(
     name="kubeflow-katib",
-    version="0.16.0rc1",
+    version="0.16.0",
     author="Kubeflow Authors",
     author_email="premnath.vel@gmail.com",
     license="Apache License Version 2.0",


### PR DESCRIPTION
Updating Katib Python SDK to the latest version.

/assign @johnugeorge @tenzen-y