### PR TITLE
Fix Optuna Validation for CMA-ES

### DIFF
--- a/cmd/suggestion/optuna/v1beta1/requirements.txt
+++ b/cmd/suggestion/optuna/v1beta1/requirements.txt
@@ -1,4 +1,4 @@
 grpcio>=1.41.1
 protobuf>=3.19.5, <=3.20.3
 googleapis-common-protos==1.53.0
-optuna>=3.0.0
+optuna==3.3.0

--- a/test/unit/v1beta1/suggestion/test_optuna_service.py
+++ b/test/unit/v1beta1/suggestion/test_optuna_service.py
@@ -244,7 +244,22 @@ class TestOptuna:
                 "cmaes",
                 {"restart_strategy": "ipop", "sigma": "0.1", "random_state": "10"},
                 20,
-                [],
+                [
+                    {
+                        "name": "param-1",
+                        "type": api_pb2.INT,
+                        "feasible_space": api_pb2.FeasibleSpace(
+                            max="5", min="1", list=[]
+                        ),
+                    },
+                    {
+                        "name": "param-2",
+                        "type": api_pb2.INT,
+                        "feasible_space": api_pb2.FeasibleSpace(
+                            max="10", min="9", list=[]
+                        ),
+                    },
+                ],
                 grpc.StatusCode.OK,
             ],
             # [CMAES] Invalid parameter name
@@ -252,7 +267,22 @@ class TestOptuna:
                 "cmaes",
                 {"invalid": "invalid", "sigma": "0.1"},
                 100,
-                [],
+                [
+                    {
+                        "name": "param-1",
+                        "type": api_pb2.INT,
+                        "feasible_space": api_pb2.FeasibleSpace(
+                            max="5", min="1", list=[]
+                        ),
+                    },
+                    {
+                        "name": "param-2",
+                        "type": api_pb2.INT,
+                        "feasible_space": api_pb2.FeasibleSpace(
+                            max="10", min="9", list=[]
+                        ),
+                    },
+                ],
                 grpc.StatusCode.INVALID_ARGUMENT,
             ],
             # [CMAES] Invalid restart_strategy
@@ -260,7 +290,22 @@ class TestOptuna:
                 "cmaes",
                 {"restart_strategy": "invalid", "sigma": "0.1"},
                 15,
-                [],
+                [
+                    {
+                        "name": "param-1",
+                        "type": api_pb2.INT,
+                        "feasible_space": api_pb2.FeasibleSpace(
+                            max="5", min="1", list=[]
+                        ),
+                    },
+                    {
+                        "name": "param-2",
+                        "type": api_pb2.INT,
+                        "feasible_space": api_pb2.FeasibleSpace(
+                            max="10", min="9", list=[]
+                        ),
+                    },
+                ],
                 grpc.StatusCode.INVALID_ARGUMENT,
             ],
             # [CMAES] Invalid sigma
@@ -268,7 +313,22 @@ class TestOptuna:
                 "cmaes",
                 {"restart_strategy": "None", "sigma": "-10"},
                 55,
-                [],
+                [
+                    {
+                        "name": "param-1",
+                        "type": api_pb2.INT,
+                        "feasible_space": api_pb2.FeasibleSpace(
+                            max="5", min="1", list=[]
+                        ),
+                    },
+                    {
+                        "name": "param-2",
+                        "type": api_pb2.INT,
+                        "feasible_space": api_pb2.FeasibleSpace(
+                            max="10", min="9", list=[]
+                        ),
+                    },
+                ],
                 grpc.StatusCode.INVALID_ARGUMENT,
             ],
             # [CMAES] Invalid random_state
@@ -276,7 +336,22 @@ class TestOptuna:
                 "cmaes",
                 {"sigma": "0.2", "random_state": "-20"},
                 25,
-                [],
+                [
+                    {
+                        "name": "param-1",
+                        "type": api_pb2.INT,
+                        "feasible_space": api_pb2.FeasibleSpace(
+                            max="5", min="1", list=[]
+                        ),
+                    },
+                    {
+                        "name": "param-2",
+                        "type": api_pb2.INT,
+                        "feasible_space": api_pb2.FeasibleSpace(
+                            max="10", min="9", list=[]
+                        ),
+                    },
+                ],
                 grpc.StatusCode.INVALID_ARGUMENT,
             ],
             # [CMAES] Invalid number of parameters
@@ -296,7 +371,28 @@ class TestOptuna:
                 grpc.StatusCode.INVALID_ARGUMENT,
             ],
             # [RANDOM] Valid Case
-            ["random", {"random_state": "10"}, 23, [], grpc.StatusCode.OK],
+            [
+                "random",
+                {"random_state": "10"},
+                23,
+                [
+                    {
+                        "name": "param-1",
+                        "type": api_pb2.INT,
+                        "feasible_space": api_pb2.FeasibleSpace(
+                            max="5", min="1", list=[]
+                        ),
+                    },
+                    {
+                        "name": "param-2",
+                        "type": api_pb2.INT,
+                        "feasible_space": api_pb2.FeasibleSpace(
+                            max="10", min="9", list=[]
+                        ),
+                    },
+                ],
+                grpc.StatusCode.OK,
+            ],
             # [RANDOM] Invalid parameter name
             [
                 "random",

--- a/test/unit/v1beta1/suggestion/test_optuna_service.py
+++ b/test/unit/v1beta1/suggestion/test_optuna_service.py
@@ -24,19 +24,31 @@ import utils
 
 class TestOptuna:
     def setup_method(self):
-        services = {
-            api_pb2.DESCRIPTOR.services_by_name['Suggestion']: OptunaService(
-            )
-        }
+        services = {api_pb2.DESCRIPTOR.services_by_name["Suggestion"]: OptunaService()}
 
         self.test_server = grpc_testing.server_from_dictionary(
-            services, grpc_testing.strict_real_time())
+            services, grpc_testing.strict_real_time()
+        )
 
     @pytest.mark.parametrize(
         ["algorithm_name", "algorithm_settings"],
         [
-            ["tpe", {"n_startup_trials": "20", "n_ei_candidates": "10", "random_state": "71"}],
-            ["multivariate-tpe", {"n_startup_trials": "20", "n_ei_candidates": "10", "random_state": "71"}],
+            [
+                "tpe",
+                {
+                    "n_startup_trials": "20",
+                    "n_ei_candidates": "10",
+                    "random_state": "71",
+                },
+            ],
+            [
+                "multivariate-tpe",
+                {
+                    "n_startup_trials": "20",
+                    "n_ei_candidates": "10",
+                    "random_state": "71",
+                },
+            ],
             ["cmaes", {"restart_strategy": "ipop", "sigma": "2", "random_state": "71"}],
             ["random", {"random_state": "71"}],
             ["grid", {"random_state": "71"}],
@@ -49,45 +61,44 @@ class TestOptuna:
                 algorithm=api_pb2.AlgorithmSpec(
                     algorithm_name=algorithm_name,
                     algorithm_settings=[
-                        api_pb2.AlgorithmSetting(
-                            name=name,
-                            value=value
-                        ) for name, value in algorithm_settings.items()
+                        api_pb2.AlgorithmSetting(name=name, value=value)
+                        for name, value in algorithm_settings.items()
                     ],
                 ),
-                objective=api_pb2.ObjectiveSpec(
-                    type=api_pb2.MAXIMIZE,
-                    goal=0.9
-                ),
+                objective=api_pb2.ObjectiveSpec(type=api_pb2.MAXIMIZE, goal=0.9),
                 parameter_specs=api_pb2.ExperimentSpec.ParameterSpecs(
                     parameters=[
                         api_pb2.ParameterSpec(
                             name="param-1",
                             parameter_type=api_pb2.INT,
                             feasible_space=api_pb2.FeasibleSpace(
-                                max="5", min="1", list=[]),
+                                max="5", min="1", list=[]
+                            ),
                         ),
                         api_pb2.ParameterSpec(
                             name="param-2",
                             parameter_type=api_pb2.CATEGORICAL,
                             feasible_space=api_pb2.FeasibleSpace(
-                                max=None, min=None, list=["cat1", "cat2", "cat3"])
+                                max=None, min=None, list=["cat1", "cat2", "cat3"]
+                            ),
                         ),
                         api_pb2.ParameterSpec(
                             name="param-3",
                             parameter_type=api_pb2.DISCRETE,
                             feasible_space=api_pb2.FeasibleSpace(
-                                max=None, min=None, list=["3", "2", "6"])
+                                max=None, min=None, list=["3", "2", "6"]
+                            ),
                         ),
                         api_pb2.ParameterSpec(
                             name="param-4",
                             parameter_type=api_pb2.DOUBLE,
                             feasible_space=api_pb2.FeasibleSpace(
-                                max="5", min="1", step="1", list=[])
-                        )
+                                max="5", min="1", step="1", list=[]
+                            ),
+                        ),
                     ]
-                )
-            )
+                ),
+            ),
         )
 
         # Run the first suggestion with no previous trials in the request
@@ -98,11 +109,15 @@ class TestOptuna:
         )
 
         get_suggestion = self.test_server.invoke_unary_unary(
-            method_descriptor=(api_pb2.DESCRIPTOR
-                               .services_by_name['Suggestion']
-                               .methods_by_name['GetSuggestions']),
+            method_descriptor=(
+                api_pb2.DESCRIPTOR.services_by_name["Suggestion"].methods_by_name[
+                    "GetSuggestions"
+                ]
+            ),
             invocation_metadata={},
-            request=request, timeout=1)
+            request=request,
+            timeout=1,
+        )
 
         response, metadata, code, details = get_suggestion.termination()
         assert code == grpc.StatusCode.OK
@@ -116,27 +131,21 @@ class TestOptuna:
                     objective=api_pb2.ObjectiveSpec(
                         type=api_pb2.MAXIMIZE,
                         objective_metric_name="metric-2",
-                        goal=0.9
+                        goal=0.9,
                     ),
                     parameter_assignments=api_pb2.TrialSpec.ParameterAssignments(
                         assignments=response.parameter_assignments[0].assignments
-                    )
+                    ),
                 ),
                 status=api_pb2.TrialStatus(
                     condition=api_pb2.TrialStatus.TrialConditionType.SUCCEEDED,
                     observation=api_pb2.Observation(
                         metrics=[
-                            api_pb2.Metric(
-                                name="metric-1",
-                                value="435"
-                            ),
-                            api_pb2.Metric(
-                                name="metric-2",
-                                value="5643"
-                            ),
+                            api_pb2.Metric(name="metric-1", value="435"),
+                            api_pb2.Metric(name="metric-2", value="5643"),
                         ]
-                    )
-                )
+                    ),
+                ),
             ),
             api_pb2.Trial(
                 name="test-234hs",
@@ -144,28 +153,22 @@ class TestOptuna:
                     objective=api_pb2.ObjectiveSpec(
                         type=api_pb2.MAXIMIZE,
                         objective_metric_name="metric-2",
-                        goal=0.9
+                        goal=0.9,
                     ),
                     parameter_assignments=api_pb2.TrialSpec.ParameterAssignments(
                         assignments=response.parameter_assignments[1].assignments
-                    )
+                    ),
                 ),
                 status=api_pb2.TrialStatus(
                     condition=api_pb2.TrialStatus.TrialConditionType.SUCCEEDED,
                     observation=api_pb2.Observation(
                         metrics=[
-                            api_pb2.Metric(
-                                name="metric-1",
-                                value="123"
-                            ),
-                            api_pb2.Metric(
-                                name="metric-2",
-                                value="3028"
-                            ),
+                            api_pb2.Metric(name="metric-1", value="123"),
+                            api_pb2.Metric(name="metric-2", value="3028"),
                         ]
-                    )
-                )
-            )
+                    ),
+                ),
+            ),
         ]
 
         request = api_pb2.GetSuggestionsRequest(
@@ -175,95 +178,212 @@ class TestOptuna:
         )
 
         get_suggestion = self.test_server.invoke_unary_unary(
-            method_descriptor=(api_pb2.DESCRIPTOR
-                               .services_by_name['Suggestion']
-                               .methods_by_name['GetSuggestions']),
+            method_descriptor=(
+                api_pb2.DESCRIPTOR.services_by_name["Suggestion"].methods_by_name[
+                    "GetSuggestions"
+                ]
+            ),
             invocation_metadata={},
-            request=request, timeout=1)
+            request=request,
+            timeout=1,
+        )
 
         response, metadata, code, details = get_suggestion.termination()
         assert code == grpc.StatusCode.OK
         assert 2 == len(response.parameter_assignments)
 
     @pytest.mark.parametrize(
-        ["algorithm_name", "algorithm_settings", "max_trial_count", "parameters", "result"],
+        [
+            "algorithm_name",
+            "algorithm_settings",
+            "max_trial_count",
+            "parameters",
+            "result",
+        ],
         [
             # Invalid algorithm name
             ["invalid", {}, 1, [], grpc.StatusCode.INVALID_ARGUMENT],
-
             # [TPE] Valid case
-            ["tpe", {"n_startup_trials": "5", "n_ei_candidates": "24", "random_state": "1"}, 100, [],
-             grpc.StatusCode.OK],
+            [
+                "tpe",
+                {"n_startup_trials": "5", "n_ei_candidates": "24", "random_state": "1"},
+                100,
+                [],
+                grpc.StatusCode.OK,
+            ],
             # [TPE] Invalid parameter name
             ["tpe", {"invalid": "5"}, 100, [], grpc.StatusCode.INVALID_ARGUMENT],
             # [TPE] Invalid n_startup_trials
-            ["tpe", {"n_startup_trials": "-1"}, 100, [], grpc.StatusCode.INVALID_ARGUMENT],
+            [
+                "tpe",
+                {"n_startup_trials": "-1"},
+                100,
+                [],
+                grpc.StatusCode.INVALID_ARGUMENT,
+            ],
             # [TPE] Invalid n_ei_candidate
-            ["tpe", {"n_ei_candidate": "-1"}, 100, [], grpc.StatusCode.INVALID_ARGUMENT],
+            [
+                "tpe",
+                {"n_ei_candidate": "-1"},
+                100,
+                [],
+                grpc.StatusCode.INVALID_ARGUMENT,
+            ],
             # [TPE] Invalid random_state
             ["tpe", {"random_state": "-1"}, 100, [], grpc.StatusCode.INVALID_ARGUMENT],
-
             # [Multivariate-TPE] Valid case
-            ["multivariate-tpe", {"n_startup_trials": "5", "n_ei_candidates": "24", "random_state": "1"}, 100, [],
-             grpc.StatusCode.OK],
-
+            [
+                "multivariate-tpe",
+                {"n_startup_trials": "5", "n_ei_candidates": "24", "random_state": "1"},
+                100,
+                [],
+                grpc.StatusCode.OK,
+            ],
             # [CMAES] Valid case
-            ["cmaes", {"restart_strategy": "ipop", "sigma": "0.1", "random_state": "10"}, 20, [], grpc.StatusCode.OK],
+            [
+                "cmaes",
+                {"restart_strategy": "ipop", "sigma": "0.1", "random_state": "10"},
+                20,
+                [],
+                grpc.StatusCode.OK,
+            ],
             # [CMAES] Invalid parameter name
-            ["cmaes", {"invalid": "invalid", "sigma": "0.1"}, 100, [], grpc.StatusCode.INVALID_ARGUMENT],
+            [
+                "cmaes",
+                {"invalid": "invalid", "sigma": "0.1"},
+                100,
+                [],
+                grpc.StatusCode.INVALID_ARGUMENT,
+            ],
             # [CMAES] Invalid restart_strategy
-            ["cmaes", {"restart_strategy": "invalid", "sigma": "0.1"}, 15, [], grpc.StatusCode.INVALID_ARGUMENT],
+            [
+                "cmaes",
+                {"restart_strategy": "invalid", "sigma": "0.1"},
+                15,
+                [],
+                grpc.StatusCode.INVALID_ARGUMENT,
+            ],
             # [CMAES] Invalid sigma
-            ["cmaes", {"restart_strategy": "None", "sigma": "-10"}, 55, [], grpc.StatusCode.INVALID_ARGUMENT],
+            [
+                "cmaes",
+                {"restart_strategy": "None", "sigma": "-10"},
+                55,
+                [],
+                grpc.StatusCode.INVALID_ARGUMENT,
+            ],
             # [CMAES] Invalid random_state
-            ["cmaes", {"sigma": "0.2", "random_state": "-20"}, 25, [], grpc.StatusCode.INVALID_ARGUMENT],
+            [
+                "cmaes",
+                {"sigma": "0.2", "random_state": "-20"},
+                25,
+                [],
+                grpc.StatusCode.INVALID_ARGUMENT,
+            ],
             # [CMAES] Invalid number of parameters
-            ["cmaes", {"sigma": "0.2"}, 5, [], grpc.StatusCode.INVALID_ARGUMENT],
-
+            [
+                "cmaes",
+                {"sigma": "0.2"},
+                5,
+                [
+                    {
+                        "name": "param-1",
+                        "type": api_pb2.INT,
+                        "feasible_space": api_pb2.FeasibleSpace(
+                            max="5", min="1", list=[]
+                        ),
+                    }
+                ],
+                grpc.StatusCode.INVALID_ARGUMENT,
+            ],
             # [RANDOM] Valid Case
             ["random", {"random_state": "10"}, 23, [], grpc.StatusCode.OK],
             # [RANDOM] Invalid parameter name
-            ["random", {"invalid": "invalid"}, 33, [], grpc.StatusCode.INVALID_ARGUMENT],
+            [
+                "random",
+                {"invalid": "invalid"},
+                33,
+                [],
+                grpc.StatusCode.INVALID_ARGUMENT,
+            ],
             # [RANDOM] Invalid random_state
-            ["random", {"random_state": "-1"}, 33, [], grpc.StatusCode.INVALID_ARGUMENT],
-
+            [
+                "random",
+                {"random_state": "-1"},
+                33,
+                [],
+                grpc.StatusCode.INVALID_ARGUMENT,
+            ],
             # [GRID] Valid Case
-            ["grid", {"random_state": "10"}, 5,
-             [{"name": "param-1",
-               "type": api_pb2.INT,
-               "feasible_space": api_pb2.FeasibleSpace(max="5", min="1", list=[])},
-              ], grpc.StatusCode.OK],
+            [
+                "grid",
+                {"random_state": "10"},
+                5,
+                [
+                    {
+                        "name": "param-1",
+                        "type": api_pb2.INT,
+                        "feasible_space": api_pb2.FeasibleSpace(
+                            max="5", min="1", list=[]
+                        ),
+                    },
+                ],
+                grpc.StatusCode.OK,
+            ],
             # [GRID] Invalid parameter name
             ["grid", {"invalid": "invalid"}, 33, [], grpc.StatusCode.INVALID_ARGUMENT],
             # [GRID] Invalid random_state
             ["grid", {"random_state": "-1"}, 10, [], grpc.StatusCode.INVALID_ARGUMENT],
             # [GRID] Invalid feasible_space
-            ["grid", {"random_state": "1"}, 26,
-             [{"name": "param-1",
-               "type": api_pb2.DOUBLE,
-               "feasible_space": api_pb2.FeasibleSpace(max="5", min="1", list=[])},
-              ], grpc.StatusCode.INVALID_ARGUMENT],
+            [
+                "grid",
+                {"random_state": "1"},
+                26,
+                [
+                    {
+                        "name": "param-1",
+                        "type": api_pb2.DOUBLE,
+                        "feasible_space": api_pb2.FeasibleSpace(
+                            max="5", min="1", list=[]
+                        ),
+                    },
+                ],
+                grpc.StatusCode.INVALID_ARGUMENT,
+            ],
             # [GRID] Invalid max_trial_count
-            ["grid", {"random_state": "1"}, 26,
-             [{"name": "param-1",
-               "type": api_pb2.INT,
-               "feasible_space": api_pb2.FeasibleSpace(max="5", min="1", list=[])},
-              {"name": "param-2",
-               "type": api_pb2.DOUBLE,
-               "feasible_space": api_pb2.FeasibleSpace(max="5", min="1", step="1", list=[])},
-              ], grpc.StatusCode.INVALID_ARGUMENT],
+            [
+                "grid",
+                {"random_state": "1"},
+                26,
+                [
+                    {
+                        "name": "param-1",
+                        "type": api_pb2.INT,
+                        "feasible_space": api_pb2.FeasibleSpace(
+                            max="5", min="1", list=[]
+                        ),
+                    },
+                    {
+                        "name": "param-2",
+                        "type": api_pb2.DOUBLE,
+                        "feasible_space": api_pb2.FeasibleSpace(
+                            max="5", min="1", step="1", list=[]
+                        ),
+                    },
+                ],
+                grpc.StatusCode.INVALID_ARGUMENT,
+            ],
         ],
     )
-    def test_validate_algorithm_settings(self, algorithm_name, algorithm_settings, max_trial_count, parameters, result):
+    def test_validate_algorithm_settings(
+        self, algorithm_name, algorithm_settings, max_trial_count, parameters, result
+    ):
         experiment_spec = api_pb2.ExperimentSpec(
             max_trial_count=max_trial_count,
             algorithm=api_pb2.AlgorithmSpec(
                 algorithm_name=algorithm_name,
                 algorithm_settings=[
-                    api_pb2.AlgorithmSetting(
-                        name=name,
-                        value=value
-                    ) for name, value in algorithm_settings.items()
+                    api_pb2.AlgorithmSetting(name=name, value=value)
+                    for name, value in algorithm_settings.items()
                 ],
             ),
             parameter_specs=api_pb2.ExperimentSpec.ParameterSpecs(
@@ -272,13 +392,14 @@ class TestOptuna:
                         name=param["name"],
                         parameter_type=param["type"],
                         feasible_space=param["feasible_space"],
-                    ) for param in parameters
+                    )
+                    for param in parameters
                 ]
-            )
+            ),
         )
         _, _, code, _ = utils.call_validate(self.test_server, experiment_spec)
         assert code == result
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Since Optuna recently moved `cmaes` to optional dependencies, our CI is failing: https://github.com/optuna/optuna/pull/4901.
I bumped Optuna to 3.3.0 version to unblock it, we can keep specific version of Optuna for now to avoid such errors.
If we need to relax the version, we can discuss the long-term plan on how to identify such errors in advance.

Also, I noticed that we have incorrect validation for `cmaes` in Optuna service.
We need to check that Search Space has more than 2 dimensional continues parameters instead of checking Algorithm Settings, similar to Goptuna: https://github.com/kubeflow/katib/blob/master/pkg/suggestion/v1beta1/goptuna/service.go#L188-L196


/assign @tenzen-y @johnugeorge @c-bata @shipengcheng1230