### PR TITLE
Begin enabling pre-commit hooks

### DIFF
--- a/.github/workflows/test-lint.yaml
+++ b/.github/workflows/test-lint.yaml
@@ -23,8 +23,8 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Check YAML files
-        run: make yamllint
-
       - name: Check shell scripts
         run: make shellcheck
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-json
+  - repo: https://github.com/pycqa/isort
+    rev: 5.11.5
+    hooks:
+      - id: isort
+        name: isort
+        entry: isort --profile google
+exclude: |
+  (?x)^(
+    .*zz_generated.deepcopy.*|
+    .*pb.go|
+    pkg/apis/manager/.*pb2(?:_grpc)?.py|
+    pkg/apis/v1beta1/openapi_generated.go|
+    pkg/mock/.*|
+    pkg/client/controller/informers/externalversions/.*|
+    pkg/client/controller/applyconfiguration/.*|
+    pkg/client/controller/listers/.*|
+    pkg/client/controller/clientset/versioned/.*|
+    sdk/python/v1beta1/kubeflow/katib/configuration.py|
+    sdk/python/v1beta1/kubeflow/katib/rest.py|
+    sdk/python/v1beta1/kubeflow/katib/__init__.py|
+    sdk/python/v1beta1/kubeflow/katib/exceptions.py|
+    sdk/python/v1beta1/kubeflow/katib/api_client.py|
+    sdk/python/v1beta1/kubeflow/katib/models/.*
+  )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,13 +15,10 @@ exclude: |
   (?x)^(
     .*zz_generated.deepcopy.*|
     .*pb.go|
-    pkg/apis/manager/.*pb2(?:_grpc)?.py|
+    pkg/apis/manager/.*pb2(?:_grpc)?.py(?:i)?|
     pkg/apis/v1beta1/openapi_generated.go|
     pkg/mock/.*|
-    pkg/client/controller/informers/externalversions/.*|
-    pkg/client/controller/applyconfiguration/.*|
-    pkg/client/controller/listers/.*|
-    pkg/client/controller/clientset/versioned/.*|
+    pkg/client/controller/.*|
     sdk/python/v1beta1/kubeflow/katib/configuration.py|
     sdk/python/v1beta1/kubeflow/katib/rest.py|
     sdk/python/v1beta1/kubeflow/katib/__init__.py|

--- a/cmd/earlystopping/medianstop/v1beta1/main.py
+++ b/cmd/earlystopping/medianstop/v1beta1/main.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import grpc
-import time
+from concurrent import futures
 import logging
+import time
+
+import grpc
+
 from pkg.apis.manager.v1beta1.python import api_pb2_grpc
 from pkg.earlystopping.v1beta1.medianstop.service import MedianStopService
-from concurrent import futures
 
 _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 DEFAULT_PORT = "0.0.0.0:6788"

--- a/cmd/metricscollector/v1beta1/tfevent-metricscollector/main.py
+++ b/cmd/metricscollector/v1beta1/tfevent-metricscollector/main.py
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import grpc
 import argparse
+from logging import getLogger
+from logging import INFO
+from logging import StreamHandler
+
 import api_pb2
 import api_pb2_grpc
-from pns import WaitMainProcesses
 import const
+import grpc
+from pns import WaitMainProcesses
 from tfevent_loader import MetricsCollector
-from logging import getLogger, StreamHandler, INFO
 
 timeout_in_seconds = 60
 

--- a/cmd/suggestion/hyperband/v1beta1/main.py
+++ b/cmd/suggestion/hyperband/v1beta1/main.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import grpc
-import time
-from pkg.apis.manager.v1beta1.python import api_pb2_grpc
-from pkg.apis.manager.health.python import health_pb2_grpc
-from pkg.suggestion.v1beta1.hyperband.service import HyperbandService
 from concurrent import futures
+import time
+
+import grpc
+
+from pkg.apis.manager.health.python import health_pb2_grpc
+from pkg.apis.manager.v1beta1.python import api_pb2_grpc
+from pkg.suggestion.v1beta1.hyperband.service import HyperbandService
 
 _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 DEFAULT_PORT = "0.0.0.0:6789"

--- a/cmd/suggestion/hyperopt/v1beta1/main.py
+++ b/cmd/suggestion/hyperopt/v1beta1/main.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import grpc
-import time
-from pkg.apis.manager.v1beta1.python import api_pb2_grpc
-from pkg.apis.manager.health.python import health_pb2_grpc
-from pkg.suggestion.v1beta1.hyperopt.service import HyperoptService
 from concurrent import futures
+import time
+
+import grpc
+
+from pkg.apis.manager.health.python import health_pb2_grpc
+from pkg.apis.manager.v1beta1.python import api_pb2_grpc
+from pkg.suggestion.v1beta1.hyperopt.service import HyperoptService
 
 _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 DEFAULT_PORT = "0.0.0.0:6789"

--- a/cmd/suggestion/nas/darts/v1beta1/main.py
+++ b/cmd/suggestion/nas/darts/v1beta1/main.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import grpc
 from concurrent import futures
 import time
-from pkg.apis.manager.v1beta1.python import api_pb2_grpc
-from pkg.apis.manager.health.python import health_pb2_grpc
-from pkg.suggestion.v1beta1.nas.darts.service import DartsService
 
+import grpc
+
+from pkg.apis.manager.health.python import health_pb2_grpc
+from pkg.apis.manager.v1beta1.python import api_pb2_grpc
+from pkg.suggestion.v1beta1.nas.darts.service import DartsService
 
 _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 DEFAULT_PORT = "0.0.0.0:6789"

--- a/cmd/suggestion/nas/enas/v1beta1/main.py
+++ b/cmd/suggestion/nas/enas/v1beta1/main.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import grpc
 from concurrent import futures
 import time
 
-from pkg.apis.manager.v1beta1.python import api_pb2_grpc
-from pkg.apis.manager.health.python import health_pb2_grpc
-from pkg.suggestion.v1beta1.nas.enas.service import EnasService
+import grpc
 
+from pkg.apis.manager.health.python import health_pb2_grpc
+from pkg.apis.manager.v1beta1.python import api_pb2_grpc
+from pkg.suggestion.v1beta1.nas.enas.service import EnasService
 
 _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 DEFAULT_PORT = "0.0.0.0:6789"

--- a/cmd/suggestion/optuna/v1beta1/main.py
+++ b/cmd/suggestion/optuna/v1beta1/main.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import grpc
-import time
-from pkg.apis.manager.v1beta1.python import api_pb2_grpc
-from pkg.apis.manager.health.python import health_pb2_grpc
-from pkg.suggestion.v1beta1.optuna.service import OptunaService
 from concurrent import futures
+import time
+
+import grpc
+
+from pkg.apis.manager.health.python import health_pb2_grpc
+from pkg.apis.manager.v1beta1.python import api_pb2_grpc
+from pkg.suggestion.v1beta1.optuna.service import OptunaService
 
 _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 DEFAULT_PORT = "0.0.0.0:6789"

--- a/cmd/suggestion/pbt/v1beta1/main.py
+++ b/cmd/suggestion/pbt/v1beta1/main.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import grpc
-import time
-from pkg.apis.manager.v1beta1.python import api_pb2_grpc
-from pkg.apis.manager.health.python import health_pb2_grpc
-from pkg.suggestion.v1beta1.pbt.service import PbtService
 from concurrent import futures
+import time
+
+import grpc
+
+from pkg.apis.manager.health.python import health_pb2_grpc
+from pkg.apis.manager.v1beta1.python import api_pb2_grpc
+from pkg.suggestion.v1beta1.pbt.service import PbtService
 
 _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 DEFAULT_PORT = "0.0.0.0:6789"

--- a/cmd/suggestion/skopt/v1beta1/main.py
+++ b/cmd/suggestion/skopt/v1beta1/main.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import grpc
-import time
-from pkg.apis.manager.v1beta1.python import api_pb2_grpc
-from pkg.apis.manager.health.python import health_pb2_grpc
-from pkg.suggestion.v1beta1.skopt.service import SkoptService
 from concurrent import futures
+import time
+
+import grpc
+
+from pkg.apis.manager.health.python import health_pb2_grpc
+from pkg.apis.manager.v1beta1.python import api_pb2_grpc
+from pkg.suggestion.v1beta1.skopt.service import SkoptService
 
 _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 DEFAULT_PORT = "0.0.0.0:6789"

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -18,6 +18,7 @@ see the following user guides:
 - [Java](https://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html) (8 or later)
 - [Python](https://www.python.org/) (3.11 or later)
 - [kustomize](https://kustomize.io/) (4.0.5 or later)
+- [pre-commit](https://pre-commit.com/)
 
 ## Build from source code
 
@@ -150,3 +151,21 @@ Please see [Katib UI README](../pkg/ui/v1beta1).
 ## Design proposals
 
 Please see [proposals](./proposals).
+
+## Code Style
+
+### pre-commit
+
+Make sure to install [pre-commit](https://pre-commit.com/) (`pip install
+pre-commit`) and run `pre-commit install` from the root of the repository at
+least once before creating git commits.
+
+The pre-commit [hooks](../.pre-commit-config.yaml) ensure code quality and
+consistency. They are executed in CI. PRs that fail to comply with the hooks
+will not be able to pass the corresponding CI gate. The hooks are only executed
+against staged files unless you run `pre-commit run --all`, in which case,
+they'll be executed against every file in the repository.
+
+Specific programmatically generated files listed in the `exclude` field in
+[.pre-commit-config.yaml](../.pre-commit-config.yaml) are deliberately excluded
+from the hooks. 

--- a/docs/release/changelog.py
+++ b/docs/release/changelog.py
@@ -1,5 +1,6 @@
-from github import Github
 import argparse
+
+from github import Github
 
 REPO_NAME = "kubeflow/katib"
 CHANGELOG_FILE = "CHANGELOG.md"

--- a/examples/v1beta1/kubeflow-pipelines/mpi-job-horovod.py
+++ b/examples/v1beta1/kubeflow-pipelines/mpi-job-horovod.py
@@ -27,18 +27,17 @@
 # Follow this guide to install MPIJob on your cluster: https://www.kubeflow.org/docs/components/training/mpi/
 
 import kfp
-import kfp.dsl as dsl
 from kfp import components
-
+import kfp.dsl as dsl
 from kubeflow.katib import ApiClient
-from kubeflow.katib import V1beta1ExperimentSpec
-from kubeflow.katib import V1beta1AlgorithmSpec
 from kubeflow.katib import V1beta1AlgorithmSetting
+from kubeflow.katib import V1beta1AlgorithmSpec
+from kubeflow.katib import V1beta1ExperimentSpec
+from kubeflow.katib import V1beta1FeasibleSpace
 from kubeflow.katib import V1beta1ObjectiveSpec
 from kubeflow.katib import V1beta1ParameterSpec
-from kubeflow.katib import V1beta1FeasibleSpace
-from kubeflow.katib import V1beta1TrialTemplate
 from kubeflow.katib import V1beta1TrialParameterSpec
+from kubeflow.katib import V1beta1TrialTemplate
 
 
 @dsl.pipeline(

--- a/examples/v1beta1/trial-images/darts-cnn-cifar10/architect.py
+++ b/examples/v1beta1/trial-images/darts-cnn-cifar10/architect.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import torch
 import copy
+
+import torch
 
 
 class Architect():

--- a/examples/v1beta1/trial-images/darts-cnn-cifar10/model.py
+++ b/examples/v1beta1/trial-images/darts-cnn-cifar10/model.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from operations import FactorizedReduce
+from operations import MixedOp
+from operations import StdConv
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from operations import FactorizedReduce, StdConv, MixedOp
 
 
 class Cell(nn.Module):

--- a/examples/v1beta1/trial-images/darts-cnn-cifar10/operations.py
+++ b/examples/v1beta1/trial-images/darts-cnn-cifar10/operations.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import torch.nn as nn
 import torch
+import torch.nn as nn
 
 OPS = {
     'none': lambda channels, stride: Zero(stride),

--- a/examples/v1beta1/trial-images/darts-cnn-cifar10/run_trial.py
+++ b/examples/v1beta1/trial-images/darts-cnn-cifar10/run_trial.py
@@ -13,17 +13,16 @@
 # limitations under the License.
 
 
-import torch.nn as nn
-
-import torch
 import argparse
 import json
-import numpy as np
 
-from model import NetworkCNN
 from architect import Architect
-import utils
+from model import NetworkCNN
+import numpy as np
 from search_space import SearchSpace
+import torch
+import torch.nn as nn
+import utils
 
 
 def main():

--- a/examples/v1beta1/trial-images/darts-cnn-cifar10/search_space.py
+++ b/examples/v1beta1/trial-images/darts-cnn-cifar10/search_space.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections import namedtuple
+
 import torch
 
 

--- a/examples/v1beta1/trial-images/enas-cnn-cifar10/ModelConstructor.py
+++ b/examples/v1beta1/trial-images/enas-cnn-cifar10/ModelConstructor.py
@@ -12,13 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-from keras.models import Model
-from keras import backend as K
 import json
-from keras.layers import Input, Conv2D, ZeroPadding2D, concatenate, MaxPooling2D, \
-    AveragePooling2D, Dense, Activation, BatchNormalization, GlobalAveragePooling2D, Dropout
-from op_library import concat, conv, sp_conv, dw_conv, reduction
+
+from keras import backend as K
+from keras.layers import Activation
+from keras.layers import AveragePooling2D
+from keras.layers import BatchNormalization
+from keras.layers import concatenate
+from keras.layers import Conv2D
+from keras.layers import Dense
+from keras.layers import Dropout
+from keras.layers import GlobalAveragePooling2D
+from keras.layers import Input
+from keras.layers import MaxPooling2D
+from keras.layers import ZeroPadding2D
+from keras.models import Model
+import numpy as np
+from op_library import concat
+from op_library import conv
+from op_library import dw_conv
+from op_library import reduction
+from op_library import sp_conv
 
 
 class ModelConstructor(object):

--- a/examples/v1beta1/trial-images/enas-cnn-cifar10/RunTrial.py
+++ b/examples/v1beta1/trial-images/enas-cnn-cifar10/RunTrial.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tensorflow import keras
+import argparse
+
 from keras.datasets import cifar10
 from ModelConstructor import ModelConstructor
-from tensorflow.keras.utils import to_categorical
-from tensorflow.keras.layers import RandomFlip, RandomTranslation, Rescaling
+from tensorflow import keras
 import tensorflow as tf
-import argparse
+from tensorflow.keras.layers import RandomFlip
+from tensorflow.keras.layers import RandomTranslation
+from tensorflow.keras.layers import Rescaling
+from tensorflow.keras.utils import to_categorical
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='TrainingContainer')

--- a/examples/v1beta1/trial-images/enas-cnn-cifar10/op_library.py
+++ b/examples/v1beta1/trial-images/enas-cnn-cifar10/op_library.py
@@ -12,11 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 from keras import backend as K
-from keras.layers import Input, Conv2D, ZeroPadding2D, concatenate, MaxPooling2D, \
-    AveragePooling2D, Dense, Activation, BatchNormalization, GlobalAveragePooling2D, \
-    SeparableConv2D, DepthwiseConv2D
+from keras.layers import Activation
+from keras.layers import AveragePooling2D
+from keras.layers import BatchNormalization
+from keras.layers import concatenate
+from keras.layers import Conv2D
+from keras.layers import Dense
+from keras.layers import DepthwiseConv2D
+from keras.layers import GlobalAveragePooling2D
+from keras.layers import Input
+from keras.layers import MaxPooling2D
+from keras.layers import SeparableConv2D
+from keras.layers import ZeroPadding2D
+import numpy as np
 
 
 def concat(inputs):

--- a/examples/v1beta1/trial-images/pytorch-mnist/mnist.py
+++ b/examples/v1beta1/trial-images/pytorch-mnist/mnist.py
@@ -19,12 +19,13 @@ import logging
 import os
 
 import hypertune
-from torchvision import datasets, transforms
 import torch
 import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
+from torchvision import datasets
+from torchvision import transforms
 
 WORLD_SIZE = int(os.environ.get("WORLD_SIZE", 1))
 

--- a/examples/v1beta1/trial-images/simple-pbt/pbt_test.py
+++ b/examples/v1beta1/trial-images/simple-pbt/pbt_test.py
@@ -17,11 +17,12 @@
 # limitations under the License.
 
 import argparse
-import numpy as np
 import os
 import pickle
 import random
 import time
+
+import numpy as np
 
 # Ensure job runs for at least this long (secs) to allow metrics collector to
 # read PID correctly before cleanup

--- a/examples/v1beta1/trial-images/tf-mnist-with-summaries/mnist.py
+++ b/examples/v1beta1/trial-images/tf-mnist-with-summaries/mnist.py
@@ -14,10 +14,12 @@
 
 import argparse
 import os
-import tensorflow as tf
 
-from tensorflow.keras.layers import Dense, Flatten, Conv2D
+import tensorflow as tf
 from tensorflow.keras import Model
+from tensorflow.keras.layers import Conv2D
+from tensorflow.keras.layers import Dense
+from tensorflow.keras.layers import Flatten
 
 
 class MyModel(Model):

--- a/pkg/apis/manager/health/python/health_pb2.pyi
+++ b/pkg/apis/manager/health/python/health_pb2.pyi
@@ -1,7 +1,10 @@
-from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from typing import ClassVar as _ClassVar
+from typing import Optional as _Optional
+from typing import Union as _Union
+
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
-from typing import ClassVar as _ClassVar, Optional as _Optional, Union as _Union
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
 
 DESCRIPTOR: _descriptor.FileDescriptor
 

--- a/pkg/apis/manager/health/python/health_pb2.pyi
+++ b/pkg/apis/manager/health/python/health_pb2.pyi
@@ -1,10 +1,7 @@
-from typing import ClassVar as _ClassVar
-from typing import Optional as _Optional
-from typing import Union as _Union
-
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
-from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from typing import ClassVar as _ClassVar, Optional as _Optional, Union as _Union
 
 DESCRIPTOR: _descriptor.FileDescriptor
 

--- a/pkg/apis/manager/v1beta1/python/api_pb2.pyi
+++ b/pkg/apis/manager/v1beta1/python/api_pb2.pyi
@@ -1,8 +1,13 @@
-from google.protobuf.internal import containers as _containers
-from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from typing import ClassVar as _ClassVar
+from typing import Iterable as _Iterable
+from typing import Mapping as _Mapping
+from typing import Optional as _Optional
+from typing import Union as _Union
+
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
-from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
+from google.protobuf.internal import containers as _containers
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
 
 DESCRIPTOR: _descriptor.FileDescriptor
 

--- a/pkg/apis/manager/v1beta1/python/api_pb2.pyi
+++ b/pkg/apis/manager/v1beta1/python/api_pb2.pyi
@@ -1,13 +1,8 @@
-from typing import ClassVar as _ClassVar
-from typing import Iterable as _Iterable
-from typing import Mapping as _Mapping
-from typing import Optional as _Optional
-from typing import Union as _Union
-
-from google.protobuf import descriptor as _descriptor
-from google.protobuf import message as _message
 from google.protobuf.internal import containers as _containers
 from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
 
 DESCRIPTOR: _descriptor.FileDescriptor
 

--- a/pkg/earlystopping/v1beta1/medianstop/service.py
+++ b/pkg/earlystopping/v1beta1/medianstop/service.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-from typing import Iterable, Optional
-from kubernetes import client, config
-import multiprocessing
 from datetime import datetime
+import logging
+import multiprocessing
+from typing import Iterable, Optional
+
 import grpc
+from kubernetes import client
+from kubernetes import config
 
 from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.apis.manager.v1beta1.python import api_pb2_grpc

--- a/pkg/metricscollector/v1beta1/common/pns.py
+++ b/pkg/metricscollector/v1beta1/common/pns.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 import os
-import psutil
 import sys
 import time
+
 import const
+import psutil
 
 
 def WaitMainProcesses(pool_interval, timout, wait_all, completed_marked_dir):

--- a/pkg/metricscollector/v1beta1/tfevent-metricscollector/tfevent_loader.py
+++ b/pkg/metricscollector/v1beta1/tfevent-metricscollector/tfevent_loader.py
@@ -21,14 +21,20 @@
 # Check TFJob example for more information:
 # https://github.com/kubeflow/katib/blob/master/examples/v1beta1/kubeflow-training-operator/tfjob-mnist-with-summaries.yaml#L16-L22
 
-import tensorflow as tf
-from tensorboard.backend.event_processing.event_accumulator import EventAccumulator, TensorEvent
-from tensorboard.backend.event_processing.tag_types import TENSORS
-import os
-import rfc3339
 from datetime import datetime
+from logging import getLogger
+from logging import INFO
+from logging import StreamHandler
+import os
+
 import api_pb2
-from logging import getLogger, StreamHandler, INFO
+import rfc3339
+from tensorboard.backend.event_processing.event_accumulator import \
+    EventAccumulator
+from tensorboard.backend.event_processing.event_accumulator import TensorEvent
+from tensorboard.backend.event_processing.tag_types import TENSORS
+import tensorflow as tf
+
 from pkg.metricscollector.v1beta1.common import const
 
 

--- a/pkg/suggestion/v1beta1/hyperband/parsing_util.py
+++ b/pkg/suggestion/v1beta1/hyperband/parsing_util.py
@@ -18,8 +18,10 @@ to/from the grpc API into the format accepted/returned by the different
 suggestion generation algorithms.
 """
 from collections.abc import Iterable
-from pkg.apis.manager.v1beta1.python import api_pb2
+
 import numpy as np
+
+from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.suggestion.v1beta1.hyperband.parameter import ParameterConfig
 
 

--- a/pkg/suggestion/v1beta1/hyperband/service.py
+++ b/pkg/suggestion/v1beta1/hyperband/service.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+from logging import DEBUG
+from logging import getLogger
+from logging import StreamHandler
 import math
 import traceback
+
 import grpc
-import logging
-from logging import getLogger, StreamHandler, DEBUG
 
 from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.apis.manager.v1beta1.python import api_pb2_grpc

--- a/pkg/suggestion/v1beta1/hyperopt/base_service.py
+++ b/pkg/suggestion/v1beta1/hyperopt/base_service.py
@@ -12,11 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import hyperopt
-import numpy as np
 import logging
 
-from pkg.suggestion.v1beta1.internal.constant import INTEGER, DOUBLE, CATEGORICAL, DISCRETE, MAX_GOAL
+import hyperopt
+import numpy as np
+
+from pkg.suggestion.v1beta1.internal.constant import CATEGORICAL
+from pkg.suggestion.v1beta1.internal.constant import DISCRETE
+from pkg.suggestion.v1beta1.internal.constant import DOUBLE
+from pkg.suggestion.v1beta1.internal.constant import INTEGER
+from pkg.suggestion.v1beta1.internal.constant import MAX_GOAL
 from pkg.suggestion.v1beta1.internal.trial import Assignment
 
 logger = logging.getLogger(__name__)

--- a/pkg/suggestion/v1beta1/hyperopt/service.py
+++ b/pkg/suggestion/v1beta1/hyperopt/service.py
@@ -13,15 +13,17 @@
 # limitations under the License.
 
 import logging
+
 import grpc
 
 from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.apis.manager.v1beta1.python import api_pb2_grpc
-
-from pkg.suggestion.v1beta1.internal.search_space import HyperParameterSearchSpace
-from pkg.suggestion.v1beta1.internal.trial import Trial, Assignment
 from pkg.suggestion.v1beta1.hyperopt.base_service import BaseHyperoptService
 from pkg.suggestion.v1beta1.internal.base_health_service import HealthServicer
+from pkg.suggestion.v1beta1.internal.search_space import \
+    HyperParameterSearchSpace
+from pkg.suggestion.v1beta1.internal.trial import Assignment
+from pkg.suggestion.v1beta1.internal.trial import Trial
 
 logger = logging.getLogger(__name__)
 

--- a/pkg/suggestion/v1beta1/internal/search_space.py
+++ b/pkg/suggestion/v1beta1/internal/search_space.py
@@ -13,10 +13,14 @@
 # limitations under the License.
 
 import logging
+
 import numpy as np
 
 from pkg.apis.manager.v1beta1.python import api_pb2 as api
-from pkg.suggestion.v1beta1.internal.constant import INTEGER, DOUBLE, CATEGORICAL, DISCRETE
+from pkg.suggestion.v1beta1.internal.constant import CATEGORICAL
+from pkg.suggestion.v1beta1.internal.constant import DISCRETE
+from pkg.suggestion.v1beta1.internal.constant import DOUBLE
+from pkg.suggestion.v1beta1.internal.constant import INTEGER
 import pkg.suggestion.v1beta1.internal.constant as constant
 
 logging.basicConfig(level=logging.DEBUG)

--- a/pkg/suggestion/v1beta1/internal/trial.py
+++ b/pkg/suggestion/v1beta1/internal/trial.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import logging
-from pkg.apis.manager.v1beta1.python import api_pb2 as api
 
+from pkg.apis.manager.v1beta1.python import api_pb2 as api
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)

--- a/pkg/suggestion/v1beta1/nas/darts/service.py
+++ b/pkg/suggestion/v1beta1/nas/darts/service.py
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-from logging import getLogger, StreamHandler, INFO
 import json
+import logging
+from logging import getLogger
+from logging import INFO
+from logging import StreamHandler
+
 import grpc
 
-from pkg.suggestion.v1beta1.internal.base_health_service import HealthServicer
 from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.apis.manager.v1beta1.python import api_pb2_grpc
+from pkg.suggestion.v1beta1.internal.base_health_service import HealthServicer
 from pkg.suggestion.v1beta1.nas.common.validation import validate_operations
 
 

--- a/pkg/suggestion/v1beta1/nas/enas/Controller.py
+++ b/pkg/suggestion/v1beta1/nas/enas/Controller.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
 import numpy as np
+import tensorflow as tf
 
 
 class Controller(object):

--- a/pkg/suggestion/v1beta1/nas/enas/Operation.py
+++ b/pkg/suggestion/v1beta1/nas/enas/Operation.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import itertools
+
 import numpy as np
+
 from pkg.apis.manager.v1beta1.python import api_pb2
 
 

--- a/pkg/suggestion/v1beta1/nas/enas/service.py
+++ b/pkg/suggestion/v1beta1/nas/enas/service.py
@@ -12,21 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-from logging import getLogger, StreamHandler, INFO
 import json
+import logging
+from logging import getLogger
+from logging import INFO
+from logging import StreamHandler
 import os
-import tensorflow as tf
+
 import grpc
+import tensorflow as tf
 
 from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.apis.manager.v1beta1.python import api_pb2_grpc
-from pkg.suggestion.v1beta1.nas.enas.Controller import Controller
-from pkg.suggestion.v1beta1.nas.enas.Operation import SearchSpace
-from pkg.suggestion.v1beta1.nas.enas.AlgorithmSettings import (
-    parseAlgorithmSettings, algorithmSettingsValidator, enableNoneSettingsList)
 from pkg.suggestion.v1beta1.internal.base_health_service import HealthServicer
 from pkg.suggestion.v1beta1.nas.common.validation import validate_operations
+from pkg.suggestion.v1beta1.nas.enas.AlgorithmSettings import \
+    algorithmSettingsValidator
+from pkg.suggestion.v1beta1.nas.enas.AlgorithmSettings import \
+    enableNoneSettingsList
+from pkg.suggestion.v1beta1.nas.enas.AlgorithmSettings import \
+    parseAlgorithmSettings
+from pkg.suggestion.v1beta1.nas.enas.Controller import Controller
+from pkg.suggestion.v1beta1.nas.enas.Operation import SearchSpace
 
 
 class EnasExperiment:

--- a/pkg/suggestion/v1beta1/optuna/base_service.py
+++ b/pkg/suggestion/v1beta1/optuna/base_service.py
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import optuna
 from collections import defaultdict
 
-from pkg.suggestion.v1beta1.internal.constant import INTEGER, DOUBLE, CATEGORICAL, DISCRETE, MAX_GOAL
+import optuna
+
+from pkg.suggestion.v1beta1.internal.constant import CATEGORICAL
+from pkg.suggestion.v1beta1.internal.constant import DISCRETE
+from pkg.suggestion.v1beta1.internal.constant import DOUBLE
+from pkg.suggestion.v1beta1.internal.constant import INTEGER
+from pkg.suggestion.v1beta1.internal.constant import MAX_GOAL
+from pkg.suggestion.v1beta1.internal.search_space import \
+    HyperParameterSearchSpace
 from pkg.suggestion.v1beta1.internal.trial import Assignment
-from pkg.suggestion.v1beta1.internal.search_space import HyperParameterSearchSpace
 
 
 class BaseOptunaService(object):

--- a/pkg/suggestion/v1beta1/optuna/service.py
+++ b/pkg/suggestion/v1beta1/optuna/service.py
@@ -12,17 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import threading
-import grpc
-import logging
 import itertools
+import logging
+import threading
+
+import grpc
 
 from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.apis.manager.v1beta1.python import api_pb2_grpc
-from pkg.suggestion.v1beta1.internal.search_space import HyperParameterSearchSpace
-from pkg.suggestion.v1beta1.internal.trial import Trial, Assignment
-from pkg.suggestion.v1beta1.optuna.base_service import BaseOptunaService
 from pkg.suggestion.v1beta1.internal.base_health_service import HealthServicer
+from pkg.suggestion.v1beta1.internal.search_space import \
+    HyperParameterSearchSpace
+from pkg.suggestion.v1beta1.internal.trial import Assignment
+from pkg.suggestion.v1beta1.internal.trial import Trial
+from pkg.suggestion.v1beta1.optuna.base_service import BaseOptunaService
 
 logger = logging.getLogger(__name__)
 

--- a/pkg/suggestion/v1beta1/pbt/service.py
+++ b/pkg/suggestion/v1beta1/pbt/service.py
@@ -12,22 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import grpc
 import logging
-import numpy as np
 import os
 import shutil
 import uuid
 
+import grpc
+import numpy as np
+
 from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.apis.manager.v1beta1.python import api_pb2_grpc
-from pkg.suggestion.v1beta1.internal.search_space import (
-    HyperParameter,
-    HyperParameterSearchSpace,
-)
-import pkg.suggestion.v1beta1.internal.constant as constant
-from pkg.suggestion.v1beta1.internal.trial import Trial, Assignment
 from pkg.suggestion.v1beta1.internal.base_health_service import HealthServicer
+import pkg.suggestion.v1beta1.internal.constant as constant
+from pkg.suggestion.v1beta1.internal.search_space import HyperParameter
+from pkg.suggestion.v1beta1.internal.search_space import \
+    HyperParameterSearchSpace
+from pkg.suggestion.v1beta1.internal.trial import Assignment
+from pkg.suggestion.v1beta1.internal.trial import Trial
 
 logger = logging.getLogger(__name__)
 

--- a/pkg/suggestion/v1beta1/skopt/base_service.py
+++ b/pkg/suggestion/v1beta1/skopt/base_service.py
@@ -14,9 +14,14 @@
 
 import datetime
 import logging
+
 import skopt
 
-from pkg.suggestion.v1beta1.internal.constant import INTEGER, DOUBLE, CATEGORICAL, DISCRETE, MAX_GOAL
+from pkg.suggestion.v1beta1.internal.constant import CATEGORICAL
+from pkg.suggestion.v1beta1.internal.constant import DISCRETE
+from pkg.suggestion.v1beta1.internal.constant import DOUBLE
+from pkg.suggestion.v1beta1.internal.constant import INTEGER
+from pkg.suggestion.v1beta1.internal.constant import MAX_GOAL
 from pkg.suggestion.v1beta1.internal.trial import Assignment
 
 logger = logging.getLogger(__name__)

--- a/pkg/suggestion/v1beta1/skopt/service.py
+++ b/pkg/suggestion/v1beta1/skopt/service.py
@@ -19,8 +19,10 @@ import grpc
 from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.apis.manager.v1beta1.python import api_pb2_grpc
 from pkg.suggestion.v1beta1.internal.base_health_service import HealthServicer
-from pkg.suggestion.v1beta1.internal.search_space import HyperParameterSearchSpace
-from pkg.suggestion.v1beta1.internal.trial import Trial, Assignment
+from pkg.suggestion.v1beta1.internal.search_space import \
+    HyperParameterSearchSpace
+from pkg.suggestion.v1beta1.internal.trial import Assignment
+from pkg.suggestion.v1beta1.internal.trial import Trial
 from pkg.suggestion.v1beta1.skopt.base_service import BaseSkoptService
 
 logger = logging.getLogger(__name__)

--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -20,13 +20,13 @@ import time
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import grpc
-import kubeflow.katib.katib_api_pb2 as katib_api_pb2
 from kubeflow.katib import models
 from kubeflow.katib.api_client import ApiClient
 from kubeflow.katib.constants import constants
+import kubeflow.katib.katib_api_pb2 as katib_api_pb2
 from kubeflow.katib.utils import utils
-from kubernetes import client, config
-
+from kubernetes import client
+from kubernetes import config
 
 logger = logging.getLogger(__name__)
 

--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client_test.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client_test.py
@@ -1,9 +1,7 @@
 import multiprocessing
 from typing import List, Optional
-from unittest.mock import patch, Mock
-
-import pytest
-from kubernetes.client import V1ObjectMeta
+from unittest.mock import Mock
+from unittest.mock import patch
 
 from kubeflow.katib import KatibClient
 from kubeflow.katib import V1beta1AlgorithmSpec
@@ -15,6 +13,8 @@ from kubeflow.katib import V1beta1ParameterSpec
 from kubeflow.katib import V1beta1TrialParameterSpec
 from kubeflow.katib import V1beta1TrialTemplate
 from kubeflow.katib.constants import constants
+from kubernetes.client import V1ObjectMeta
+import pytest
 
 TEST_RESULT_SUCCESS = "success"
 

--- a/sdk/python/v1beta1/kubeflow/katib/api/report_metrics.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/report_metrics.py
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime
+from datetime import timezone
 import os
-from datetime import datetime, timezone
 from typing import Any, Dict
 
 import grpc
-import kubeflow.katib.katib_api_pb2 as katib_api_pb2
 from kubeflow.katib.constants import constants
+import kubeflow.katib.katib_api_pb2 as katib_api_pb2
 from kubeflow.katib.utils import utils
+
 
 def report_metrics(
     metrics: Dict[str, Any],

--- a/sdk/python/v1beta1/kubeflow/katib/api/search.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/search.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kubeflow.katib import models
 from typing import List
+
+from kubeflow.katib import models
 
 
 def double(min: float, max: float, step: float = None):

--- a/sdk/python/v1beta1/kubeflow/katib/utils/utils.py
+++ b/sdk/python/v1beta1/kubeflow/katib/utils/utils.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import json
 import os
 import textwrap
-from typing import Callable, Any
-import inspect
+from typing import Any, Callable
 
 from kubeflow.katib import models
 from kubeflow.katib.constants import constants

--- a/sdk/python/v1beta1/setup.py
+++ b/sdk/python/v1beta1/setup.py
@@ -14,6 +14,7 @@
 
 import os
 import shutil
+
 import setuptools
 
 REQUIRES = [

--- a/test/e2e/v1beta1/hack/aws/argo_workflow.py
+++ b/test/e2e/v1beta1/hack/aws/argo_workflow.py
@@ -16,7 +16,6 @@
 
 from kubeflow.testing import argo_build_util
 
-
 # Main worker image to execute Workflow.
 IMAGE_WORKER = "public.ecr.aws/j1r0q0g6/kubeflow-testing:latest"
 # Kaniko image to build Katib images.

--- a/test/e2e/v1beta1/scripts/gh-actions/run-e2e-experiment.py
+++ b/test/e2e/v1beta1/scripts/gh-actions/run-e2e-experiment.py
@@ -1,11 +1,14 @@
 import argparse
-import yaml
-import time
 import logging
-from kubernetes import client
-from kubeflow.katib import ApiClient, KatibClient, models
-from kubeflow.katib.utils.utils import FakeResponse
+import time
+
+from kubeflow.katib import ApiClient
+from kubeflow.katib import KatibClient
+from kubeflow.katib import models
 from kubeflow.katib.constants import constants
+from kubeflow.katib.utils.utils import FakeResponse
+from kubernetes import client
+import yaml
 
 # Experiment timeout is 40 min.
 EXPERIMENT_TIMEOUT = 60 * 40

--- a/test/unit/v1beta1/earlystopping/test_medianstop_service.py
+++ b/test/unit/v1beta1/earlystopping/test_medianstop_service.py
@@ -12,16 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import grpc
-import grpc_testing
 import unittest
 from unittest.mock import patch
 
-from pkg.apis.manager.v1beta1.python import api_pb2
-
-from pkg.earlystopping.v1beta1.medianstop.service import MedianStopService
-
+import grpc
+import grpc_testing
 import utils
+
+from pkg.apis.manager.v1beta1.python import api_pb2
+from pkg.earlystopping.v1beta1.medianstop.service import MedianStopService
 
 
 class TestMedianStop(unittest.TestCase):

--- a/test/unit/v1beta1/metricscollector/test_tfevent_metricscollector.py
+++ b/test/unit/v1beta1/metricscollector/test_tfevent_metricscollector.py
@@ -14,6 +14,7 @@
 
 import os
 import unittest
+
 import utils
 
 

--- a/test/unit/v1beta1/metricscollector/utils.py
+++ b/test/unit/v1beta1/metricscollector/utils.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tfevent_loader import MetricsCollector
 from google.protobuf import json_format
+from tfevent_loader import MetricsCollector
 
 
 def get_metric_logs(logs_dir, metric_names):

--- a/test/unit/v1beta1/suggestion/test_darts_service.py
+++ b/test/unit/v1beta1/suggestion/test_darts_service.py
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import unittest
+
 import grpc
 import grpc_testing
-import unittest
-import json
 
 from pkg.apis.manager.v1beta1.python import api_pb2
-
-from pkg.suggestion.v1beta1.nas.darts.service import DartsService, validate_algorithm_settings
+from pkg.suggestion.v1beta1.nas.darts.service import DartsService
+from pkg.suggestion.v1beta1.nas.darts.service import \
+    validate_algorithm_settings
 
 
 class TestDarts(unittest.TestCase):

--- a/test/unit/v1beta1/suggestion/test_enas_service.py
+++ b/test/unit/v1beta1/suggestion/test_enas_service.py
@@ -14,15 +14,13 @@
 
 import os
 import shutil
+import unittest
 
 import grpc
 import grpc_testing
-import unittest
-
 import pytest
 
 from pkg.apis.manager.v1beta1.python import api_pb2
-
 from pkg.suggestion.v1beta1.nas.enas.service import EnasService
 
 

--- a/test/unit/v1beta1/suggestion/test_hyperband_service.py
+++ b/test/unit/v1beta1/suggestion/test_hyperband_service.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import grpc
-import grpc_testing
 import unittest
 
-from pkg.apis.manager.v1beta1.python import api_pb2
+import grpc
+import grpc_testing
 
+from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.suggestion.v1beta1.hyperband.service import HyperbandService
 
 

--- a/test/unit/v1beta1/suggestion/test_hyperopt_service.py
+++ b/test/unit/v1beta1/suggestion/test_hyperopt_service.py
@@ -16,11 +16,10 @@ import unittest
 
 import grpc
 import grpc_testing
+import utils
 
 from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.suggestion.v1beta1.hyperopt.service import HyperoptService
-
-import utils
 
 
 class TestHyperopt(unittest.TestCase):

--- a/test/unit/v1beta1/suggestion/test_optuna_service.py
+++ b/test/unit/v1beta1/suggestion/test_optuna_service.py
@@ -15,11 +15,10 @@
 import grpc
 import grpc_testing
 import pytest
+import utils
 
 from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.suggestion.v1beta1.optuna.service import OptunaService
-
-import utils
 
 
 class TestOptuna:

--- a/test/unit/v1beta1/suggestion/test_skopt_service.py
+++ b/test/unit/v1beta1/suggestion/test_skopt_service.py
@@ -16,11 +16,10 @@ import unittest
 
 import grpc
 import grpc_testing
+import utils
 
 from pkg.apis.manager.v1beta1.python import api_pb2
 from pkg.suggestion.v1beta1.skopt.service import SkoptService
-
-import utils
 
 
 class TestSkopt(unittest.TestCase):


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements some basic pre-commit hooks and applies them retroactively to the entire codebase. All of the changes in this PR, other than the addition of `.pre-commit-config.yaml`, were automatically generated by the isort pre-commit hook.  This pre-commit configuration is based off of Kubeflow Pipeline's to promote consistent code across the various Kubeflow repositories. The only difference is that I commented out the majority of the hooks, because if we tried to implement all of them simultaneously, the resulting PR would be enormous in size. This PR is a kind of proof of concept. If merged, I'll just progressively uncomment and enable the other pre-commit hooks (either sequentially or all once depending on preference) and execute them retroactively and submit one or more follow up PRs.

Not sure how to integrate it into katib's CI if anyone has any input on that. Highly recommend doing so. It's the only way to enforce the standards that pre-commit enables. 

**Which issue(s) this PR fixes**
Fixes # https://github.com/kubeflow/katib/issues/2187

**Checklist:**
- [x] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
