### PR TITLE
DB: Add environment variable option to skip DB table creationˆ

### DIFF
--- a/pkg/db/v1beta1/common/const.go
+++ b/pkg/db/v1beta1/common/const.go
@@ -46,4 +46,6 @@ const (
 	DefaultPostgreSQLDatabase = "katib"
 	DefaultPostgreSQLHost     = "katib-postgres"
 	DefaultPostgreSQLPort     = "5432"
+
+	SkipDbMigrationEnvName = "SKIP_DB_MIGRATION"
 )

--- a/pkg/db/v1beta1/common/const.go
+++ b/pkg/db/v1beta1/common/const.go
@@ -47,5 +47,5 @@ const (
 	DefaultPostgreSQLHost     = "katib-postgres"
 	DefaultPostgreSQLPort     = "5432"
 
-	SkipDbMigrationEnvName = "SKIP_DB_MIGRATION"
+	SkipDbInitializationEnvName = "SKIP_DB_INITIALIZATION"
 )

--- a/pkg/db/v1beta1/mysql/init.go
+++ b/pkg/db/v1beta1/mysql/init.go
@@ -25,9 +25,9 @@ import (
 
 func (d *dbConn) DBInit() {
 	db := d.db
-	skipDbMigration := env.GetBoolEnvOrDefault(common.SkipDbMigrationEnvName, false)
+	skipDbInitialization := env.GetEnvOrDefault(common.SkipDbInitializationEnvName, "false")
 
-	if !skipDbMigration {
+	if skipDbInitialization == "false" {
 		klog.Info("Initializing v1beta1 DB schema")
 
 		_, err := db.Exec(`CREATE TABLE IF NOT EXISTS observation_logs

--- a/pkg/db/v1beta1/mysql/init.go
+++ b/pkg/db/v1beta1/mysql/init.go
@@ -18,22 +18,34 @@ package mysql
 
 import (
 	"fmt"
-
+	"github.com/kubeflow/katib/pkg/db/v1beta1/common"
+	"github.com/kubeflow/katib/pkg/util/v1beta1/env"
 	"k8s.io/klog"
 )
 
 func (d *dbConn) DBInit() {
 	db := d.db
-	klog.Info("Initializing v1beta1 DB schema")
+	skipDbMigration := env.GetBoolEnvOrDefault(common.SkipDbMigrationEnvName, false)
 
-	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS observation_logs
+	if !skipDbMigration {
+		klog.Info("Initializing v1beta1 DB schema")
+
+		_, err := db.Exec(`CREATE TABLE IF NOT EXISTS observation_logs
 		(trial_name VARCHAR(255) NOT NULL,
 		id INT AUTO_INCREMENT PRIMARY KEY,
 		time DATETIME(6),
 		metric_name VARCHAR(255) NOT NULL,
 		value TEXT NOT NULL)`)
-	if err != nil {
-		klog.Fatalf("Error creating observation_logs table: %v", err)
+		if err != nil {
+			klog.Fatalf("Error creating observation_logs table: %v", err)
+		}
+	} else {
+		klog.Info("Skipping v1beta1 DB schema initialization.")
+
+		_, err := db.Query(`SELECT trial_name, id, time, metric_name, value FROM observation_logs LIMIT 1`)
+		if err != nil {
+			klog.Fatalf("Error validating observation_logs table: %v", err)
+		}
 	}
 }
 

--- a/pkg/db/v1beta1/mysql/init.go
+++ b/pkg/db/v1beta1/mysql/init.go
@@ -18,9 +18,11 @@ package mysql
 
 import (
 	"fmt"
+
+	"k8s.io/klog"
+
 	"github.com/kubeflow/katib/pkg/db/v1beta1/common"
 	"github.com/kubeflow/katib/pkg/util/v1beta1/env"
-	"k8s.io/klog"
 )
 
 func (d *dbConn) DBInit() {

--- a/pkg/db/v1beta1/postgres/init.go
+++ b/pkg/db/v1beta1/postgres/init.go
@@ -26,9 +26,9 @@ import (
 
 func (d *dbConn) DBInit() {
 	db := d.db
-	skipDbMigration := env.GetBoolEnvOrDefault(common.SkipDbMigrationEnvName, false)
+	skipDbInitialization := env.GetEnvOrDefault(common.SkipDbInitializationEnvName, "false")
 
-	if !skipDbMigration {
+	if skipDbInitialization == "false" {
 		klog.Info("Initializing v1beta1 DB schema")
 
 		_, err := db.Exec(`CREATE TABLE IF NOT EXISTS observation_logs

--- a/pkg/db/v1beta1/postgres/init.go
+++ b/pkg/db/v1beta1/postgres/init.go
@@ -18,10 +18,11 @@ package postgres
 
 import (
 	"fmt"
-	"github.com/kubeflow/katib/pkg/db/v1beta1/common"
-	"github.com/kubeflow/katib/pkg/util/v1beta1/env"
 
 	"k8s.io/klog"
+
+	"github.com/kubeflow/katib/pkg/db/v1beta1/common"
+	"github.com/kubeflow/katib/pkg/util/v1beta1/env"
 )
 
 func (d *dbConn) DBInit() {

--- a/pkg/db/v1beta1/postgres/init.go
+++ b/pkg/db/v1beta1/postgres/init.go
@@ -18,22 +18,35 @@ package postgres
 
 import (
 	"fmt"
+	"github.com/kubeflow/katib/pkg/db/v1beta1/common"
+	"github.com/kubeflow/katib/pkg/util/v1beta1/env"
 
 	"k8s.io/klog"
 )
 
 func (d *dbConn) DBInit() {
 	db := d.db
-	klog.Info("Initializing v1beta1 DB schema")
+	skipDbMigration := env.GetBoolEnvOrDefault(common.SkipDbMigrationEnvName, false)
 
-	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS observation_logs
+	if !skipDbMigration {
+		klog.Info("Initializing v1beta1 DB schema")
+
+		_, err := db.Exec(`CREATE TABLE IF NOT EXISTS observation_logs
 		(trial_name VARCHAR(255) NOT NULL,
 		id serial PRIMARY KEY,
 		time TIMESTAMP(6),
 		metric_name VARCHAR(255) NOT NULL,
 		value TEXT NOT NULL)`)
-	if err != nil {
-		klog.Fatalf("Error creating observation_logs table: %v", err)
+		if err != nil {
+			klog.Fatalf("Error creating observation_logs table: %v", err)
+		}
+	} else {
+		klog.Info("Skipping v1beta1 DB schema initialization.")
+
+		_, err := db.Query(`SELECT trial_name, id, time, metric_name, value FROM observation_logs LIMIT 1`)
+		if err != nil {
+			klog.Fatalf("Error validating observation_logs table: %v", err)
+		}
 	}
 }
 

--- a/pkg/util/v1beta1/env/env.go
+++ b/pkg/util/v1beta1/env/env.go
@@ -16,11 +16,26 @@ limitations under the License.
 
 package env
 
-import "os"
+import (
+	"k8s.io/klog"
+	"os"
+	"strconv"
+)
 
 func GetEnvOrDefault(key string, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
+	}
+	return fallback
+}
+
+func GetBoolEnvOrDefault(key string, fallback bool) bool {
+	if value, ok := os.LookupEnv(key); ok {
+		parsedValue, err := strconv.ParseBool(value)
+		if err != nil {
+			klog.Fatalf("Failed converting %s env to bool", key)
+		}
+		return parsedValue
 	}
 	return fallback
 }

--- a/pkg/util/v1beta1/env/env.go
+++ b/pkg/util/v1beta1/env/env.go
@@ -17,25 +17,12 @@ limitations under the License.
 package env
 
 import (
-	"k8s.io/klog"
 	"os"
-	"strconv"
 )
 
 func GetEnvOrDefault(key string, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
-	}
-	return fallback
-}
-
-func GetBoolEnvOrDefault(key string, fallback bool) bool {
-	if value, ok := os.LookupEnv(key); ok {
-		parsedValue, err := strconv.ParseBool(value)
-		if err != nil {
-			klog.Fatalf("Failed converting %s env to bool", key)
-		}
-		return parsedValue
 	}
 	return fallback
 }

--- a/pkg/util/v1beta1/env/env_test.go
+++ b/pkg/util/v1beta1/env/env_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package env
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
@@ -33,5 +34,22 @@ func TestGetEnvWithDefault(t *testing.T) {
 	v = GetEnvOrDefault(key, "")
 	if v != expected {
 		t.Errorf("Expected %s, got %s", expected, v)
+	}
+}
+
+func TestGetBoolEnvWithDefault(t *testing.T) {
+	expected := false
+	key := "TEST"
+	v := GetBoolEnvOrDefault(key, expected)
+	if v != expected {
+		t.Errorf("Expected %t, got %t", expected, v)
+	}
+
+	expected = true
+	envValue := fmt.Sprintf("%t", expected)
+	os.Setenv(key, envValue)
+	v = GetBoolEnvOrDefault(key, false)
+	if v != expected {
+		t.Errorf("Expected %t, got %t", expected, v)
 	}
 }

--- a/pkg/util/v1beta1/env/env_test.go
+++ b/pkg/util/v1beta1/env/env_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package env
 
 import (
-	"fmt"
 	"os"
 	"testing"
 )
@@ -34,22 +33,5 @@ func TestGetEnvWithDefault(t *testing.T) {
 	v = GetEnvOrDefault(key, "")
 	if v != expected {
 		t.Errorf("Expected %s, got %s", expected, v)
-	}
-}
-
-func TestGetBoolEnvWithDefault(t *testing.T) {
-	expected := false
-	key := "TEST"
-	v := GetBoolEnvOrDefault(key, expected)
-	if v != expected {
-		t.Errorf("Expected %t, got %t", expected, v)
-	}
-
-	expected = true
-	envValue := fmt.Sprintf("%t", expected)
-	os.Setenv(key, envValue)
-	v = GetBoolEnvOrDefault(key, false)
-	if v != expected {
-		t.Errorf("Expected %t, got %t", expected, v)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Currently, DB Manager automatically tries to create `observation_logs` table on startup using `CREATE TABLE IF NOT EXISTS` clause. However, this part does not work when DB user does not have enough privilege to create table if DB schema creation is handled by manual admin process.

To address this, we have hard-forked the repository and built our own image after commenting out table creation part so far. Since I guess there might be similar need to skip table creation from other than us, I've added an environment variable option to skip table creation along with simple logic to validate `observation_logs` table structure with `SELECT` statement.

([ml-metadata allows](https://github.com/google/ml-metadata/blob/master/ml_metadata/proto/metadata_store.proto#L648) this with option in protobuf text format.)

**Which issue(s) this PR fixes**

None. I've create pull request directly.

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing

(Need to update list of [Environment Variables for Katib Components](https://www.kubeflow.org/docs/components/katib/env-variables/#katib-db-manager) on Katib DB Manager. I will create additional pull request to address the change on website.)

FYI. I've created an issue for Pipelines(https://github.com/kubeflow/pipelines/issues/10265) where similar improvement could be possible

