### PR TITLE
Install typing-extensions v4.6.3 for Optuna

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,10 @@ prepare-pytest:
 	pip install --prefer-binary -r cmd/suggestion/pbt/v1beta1/requirements.txt
 	pip install --prefer-binary -r cmd/earlystopping/medianstop/v1beta1/requirements.txt
 	pip install --prefer-binary -r cmd/metricscollector/v1beta1/tfevent-metricscollector/requirements.txt
+	# The sqlalchemy on which optuna depends requires typing-extensions>=4.6.0.
+	# REF: https://github.com/kubeflow/katib/pull/2251
+	# TODO (tenzen-y): Once we upgrade libraries depended on typing-extensions==4.5.0, we can remove this line.
+	pip install typing-extensions==4.6.3
 
 prepare-pytest-testdata:
 ifeq ("$(wildcard $(TEST_TENSORFLOW_EVENT_FILE_PATH))", "")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
We need to install typing-extensions v4.6.0 or newer to resolve the following CI error:

> E   ImportError: cannot import name 'TypeAliasType' from 'typing_extensions' (/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/typing_extensions.py)

https://github.com/kubeflow/katib/actions/runs/7400396607/job/20133921603?pr=2250#step:4:594

The root cause is that the sqlalchemy on which the optuna depends requires typing-extensions v4.6.0 or newer:

Optuna dependencies: https://github.com/optuna/optuna/blob/v3.3.0/pyproject.toml#L40

sqlalchemy dependencies: https://github.com/sqlalchemy/sqlalchemy/blob/4871a2f72f5f0e514fe81a8caa17a14f9fc51300/setup.cfg#L38-L39

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
