### PR TITLE
typo fix stale.yaml

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -36,8 +36,7 @@ jobs:
             recent activity. It will be closed if no further activity occurs. Thank you
             for your contributions.
           close-pr-message: >
-            This pull request has been automatically marked as stale because it has not had
-            recent activity. It will be closed if no further activity occurs. Thank you
-            for your contributions.
+            This pull request has been automatically closed because it has not had recent
+            activity. Please comment "/reopen" to reopen it.
           stale-pr-label: lifecycle/stale
           exempt-pr-labels: lifecycle/frozen


### PR DESCRIPTION
Message `close-pr-message` was likely a wrong copy-paste from stale.

This aligns `close-` messages.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
