### PR TITLE
Add environment variable option to set postgres ssl mode

### DIFF
--- a/pkg/db/v1beta1/common/const.go
+++ b/pkg/db/v1beta1/common/const.go
@@ -41,11 +41,13 @@ const (
 	PostgreSQLDBHostEnvName = "KATIB_POSTGRESQL_DB_HOST"
 	PostgreSQLDBPortEnvName = "KATIB_POSTGRESQL_DB_PORT"
 	PostgreSQLDatabase      = "KATIB_POSTGRESQL_DB_DATABASE"
+	PostgreSSLMode          = "KATIB_POSTGRESQL_SSL_MODE"
 
 	DefaultPostgreSQLUser     = "katib"
 	DefaultPostgreSQLDatabase = "katib"
 	DefaultPostgreSQLHost     = "katib-postgres"
 	DefaultPostgreSQLPort     = "5432"
+	DefaultPostgreSSLMode     = "disable"
 
 	SkipDbInitializationEnvName = "SKIP_DB_INITIALIZATION"
 )

--- a/pkg/db/v1beta1/postgres/postgres.go
+++ b/pkg/db/v1beta1/postgres/postgres.go
@@ -48,10 +48,12 @@ func getDbName() string {
 		common.PostgreSQLDBPortEnvName, common.DefaultPostgreSQLPort)
 	dbName := env.GetEnvOrDefault(common.PostgreSQLDatabase,
 		common.DefaultPostgreSQLDatabase)
+	sslMode := env.GetEnvOrDefault(common.PostgreSSLMode,
+		common.DefaultPostgreSSLMode)
 
 	psqlInfo := fmt.Sprintf("host=%s port=%s user=%s "+
-		"password=%s dbname=%s sslmode=disable",
-		dbHost, dbPort, dbUser, dbPass, dbName)
+		"password=%s dbname=%s sslmode=%s",
+		dbHost, dbPort, dbUser, dbPass, dbName, sslMode)
 
 	return psqlInfo
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
In postgres, `sslmode` may has [different value](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION) such as `disable`, `prefer` and `require`. But for now in [postgres.go#L52](https://github.com/kubeflow/katib/blob/master/pkg/db/v1beta1/postgres/postgres.go#L52) it only allows `disable`. So we should add an environment variable option to allow users to specify the value of `sslmode`.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes https://github.com/kubeflow/katib/issues/2244

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing

(Need to update list of [Environment Variables for Katib Components](https://www.kubeflow.org/docs/components/katib/env-variables/#katib-db-manager) on Katib DB Manager. I will create additional pull request to address the change on website.)