### PR TITLE
chore: add unit testcases for files in Text format.

### DIFF
--- a/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
+++ b/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
@@ -28,6 +28,22 @@ import (
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 )
 
+const (
+	invalidFileName   = "invalid"
+	invalidFileFormat = "invalid"
+
+	validJSONTestFile            = "good.json"
+	invalidFormatJSONTestFile    = "invalid-format.json"
+	invalidTimestampJSONTestFile = "invalid-timestamp.json"
+	missingMetricJSONTestFile    = "missing-objective-metric.json"
+
+	validTEXTTestFile            = "good.log"
+	invalidValueTEXTTestFile     = "invalid-value.log"
+	invalidFormatTEXTTestFile    = "invalid-format.log"
+	invalidTimestampTEXTTestFile = "invalid-timestamp.log"
+	missingMetricTEXTTestFile    = "missing-objective-metric.log"
+)
+
 var (
 	testJsonDataPath = filepath.Join("testdata", "JSON")
 	testTextDataPath = filepath.Join("testdata", "TEXT")
@@ -52,7 +68,7 @@ func TestCollectObservationLog(t *testing.T) {
 		expected   *v1beta1.ObservationLog
 	}{
 		"Positive case for logs in JSON format": {
-			filePath:   filepath.Join(testJsonDataPath, "good.json"),
+			filePath:   filepath.Join(testJsonDataPath, validJSONTestFile),
 			metrics:    []string{"acc", "loss"},
 			fileFormat: commonv1beta1.JsonFormat,
 			expected: &v1beta1.ObservationLog{
@@ -96,7 +112,7 @@ func TestCollectObservationLog(t *testing.T) {
 			},
 		},
 		"Positive case for logs in TEXT format": {
-			filePath:   filepath.Join(testTextDataPath, "good.log"),
+			filePath:   filepath.Join(testTextDataPath, validTEXTTestFile),
 			metrics:    []string{"accuracy", "loss"},
 			filters:    []string{"{metricName: ([\\w|-]+), metricValue: ((-?\\d+)(\\.\\d+)?)}"},
 			fileFormat: commonv1beta1.TextFormat,
@@ -162,7 +178,7 @@ func TestCollectObservationLog(t *testing.T) {
 			},
 		},
 		"Invalid case for logs in TEXT format": {
-			filePath:   filepath.Join(testTextDataPath, "invalid-value.log"),
+			filePath:   filepath.Join(testTextDataPath, invalidValueTEXTTestFile),
 			filters:    []string{"{metricName: ([\\w|-]+), metricValue: ((-?\\d+)(\\.\\d+)?)}"},
 			metrics:    []string{"accuracy", "loss"},
 			fileFormat: commonv1beta1.TextFormat,
@@ -179,21 +195,21 @@ func TestCollectObservationLog(t *testing.T) {
 			},
 		},
 		"Invalid file name": {
-			filePath: "invalid",
+			filePath: invalidFileName,
 			err:      true,
 		},
 		"Invalid file format": {
-			filePath:   filepath.Join(testTextDataPath, "good.log"),
-			fileFormat: "invalid",
+			filePath:   filepath.Join(testTextDataPath, validTEXTTestFile),
+			fileFormat: invalidFileFormat,
 			err:        true,
 		},
 		"Invalid formatted file for logs in JSON format": {
-			filePath:   filepath.Join(testJsonDataPath, "invalid-format.json"),
+			filePath:   filepath.Join(testJsonDataPath, invalidFormatJSONTestFile),
 			fileFormat: commonv1beta1.JsonFormat,
 			err:        true,
 		},
 		"Invalid formatted file for logs in TEXT format": {
-			filePath:   filepath.Join(testTextDataPath, "invalid-format.log"),
+			filePath:   filepath.Join(testTextDataPath, invalidFormatTEXTTestFile),
 			filters:    []string{"{metricName: ([\\w|-]+), metricValue: ((-?\\d+)(\\.\\d+)?)}"},
 			metrics:    []string{"accuracy", "loss"},
 			fileFormat: commonv1beta1.TextFormat,
@@ -210,7 +226,7 @@ func TestCollectObservationLog(t *testing.T) {
 			},
 		},
 		"Invalid timestamp for logs in JSON format": {
-			filePath:   filepath.Join(testJsonDataPath, "invalid-timestamp.json"),
+			filePath:   filepath.Join(testJsonDataPath, invalidTimestampJSONTestFile),
 			fileFormat: commonv1beta1.JsonFormat,
 			metrics:    []string{"acc", "loss"},
 			expected: &v1beta1.ObservationLog{
@@ -233,7 +249,7 @@ func TestCollectObservationLog(t *testing.T) {
 			},
 		},
 		"Invalid timestamp for logs in TEXT format": {
-			filePath:   filepath.Join(testTextDataPath, "invalid-timestamp.log"),
+			filePath:   filepath.Join(testTextDataPath, invalidTimestampTEXTTestFile),
 			metrics:    []string{"accuracy", "loss"},
 			filters:    []string{"{metricName: ([\\w|-]+), metricValue: ((-?\\d+)(\\.\\d+)?)}"},
 			fileFormat: commonv1beta1.TextFormat,
@@ -257,7 +273,7 @@ func TestCollectObservationLog(t *testing.T) {
 			},
 		},
 		"Missing objective metric in JSON training logs": {
-			filePath:   filepath.Join(testJsonDataPath, "missing-objective-metric.json"),
+			filePath:   filepath.Join(testJsonDataPath, missingMetricJSONTestFile),
 			fileFormat: commonv1beta1.JsonFormat,
 			metrics:    []string{"acc", "loss"},
 			expected: &v1beta1.ObservationLog{
@@ -273,7 +289,7 @@ func TestCollectObservationLog(t *testing.T) {
 			},
 		},
 		"Missing objective metric in TEXT training logs": {
-			filePath:   filepath.Join(testTextDataPath, "missing-objective-metric.log"),
+			filePath:   filepath.Join(testTextDataPath, missingMetricTEXTTestFile),
 			fileFormat: commonv1beta1.TextFormat,
 			metrics:    []string{"accuracy", "loss"},
 			expected: &v1beta1.ObservationLog{
@@ -316,7 +332,7 @@ func generateJSONTestFiles() error {
 		data     string
 	}{
 		{
-			fileName: "good.json",
+			fileName: validJSONTestFile,
 			data: `{"checkpoint_path": "", "global_step": "0", "loss": "0.22082142531871796", "timestamp": 1638422847.28721, "trial": "0"}
 {"acc": "0.9349666833877563", "checkpoint_path": "", "global_step": "0", "timestamp": 1638422847.287801, "trial": "0"}
 {"checkpoint_path": "", "global_step": "1", "loss": "0.1414974331855774", "timestamp": "2021-12-02T14:27:50.000035161Z", "trial": "0"}
@@ -325,18 +341,18 @@ func generateJSONTestFiles() error {
 `,
 		},
 		{
-			fileName: "invalid-format.json",
+			fileName: invalidFormatJSONTestFile,
 			data: `"checkpoint_path": "", "global_step": "0", "loss": "0.22082142531871796", "timestamp": 1638422847.28721, "trial": "0"
 {"acc": "0.9349666833877563", "checkpoint_path": "", "global_step": "0", "timestamp": 1638422847.287801, "trial": "0
 `,
 		},
 		{
-			fileName: "invalid-timestamp.json",
+			fileName: invalidTimestampJSONTestFile,
 			data: `{"checkpoint_path": "", "global_step": "0", "loss": "0.22082142531871796", "timestamp": "invalid", "trial": "0"}
 {"acc": "0.9349666833877563", "checkpoint_path": "", "global_step": "0", "timestamp": 1638422847, "trial": "0"}
 `,
 		}, {
-			fileName: "missing-objective-metric.json",
+			fileName: missingMetricJSONTestFile,
 			data: `{"checkpoint_path": "", "global_step": "0", "loss": "0.22082142531871796", "timestamp": 1638422847.28721, "trial": "0"}
 {"checkpoint_path": "", "global_step": "1", "loss": "0.1414974331855774", "timestamp": "2021-12-02T14:27:50.000035161+09:00", "trial": "0"}
 {"checkpoint_path": "", "global_step": "2", "loss": "0.10683439671993256", "trial": "0"}`,
@@ -365,7 +381,7 @@ func generateTEXTTestFiles() error {
 		data     string
 	}{
 		{
-			fileName: "good.log",
+			fileName: validTEXTTestFile,
 			data: `2024-03-04T17:55:08Z INFO     {metricName: accuracy, metricValue: 0.8078};{metricName: loss, metricValue: 0.5183}
 2024-03-04T17:55:08Z INFO     {metricName: accuracy, metricValue: 0.6752}
 2024-03-04T17:55:08Z INFO     {metricName: loss, metricValue: 0.3634}
@@ -375,24 +391,24 @@ func generateTEXTTestFiles() error {
 {metricName: loss, metricValue: 0.8671}`,
 		},
 		{
-			fileName: "invalid-value.log",
+			fileName: invalidValueTEXTTestFile,
 			data: `2024-03-04T17:55:08Z INFO     {metricName: accuracy, metricValue: .333}
 2024-03-04T17:55:08Z INFO     {metricName: accuracy, metricValue: -.333}
 2024-03-04T17:55:08Z INFO     {metricName: accuracy, metricValue: - 345.333}
 2024-03-04T17:55:08Z INFO     {metricName: accuracy, metricValue: 888.}`,
 		},
 		{
-			fileName: "invalid-format.log",
+			fileName: invalidFormatTEXTTestFile,
 			data: `2024-03-04T17:55:08Z INFO     {metricName: accuracy, metricValue: 0.6752
 2024-03-04T17:55:08Z INFO     {metricName: loss, metricValue: 0.3634}`,
 		},
 		{
-			fileName: "invalid-timestamp.log",
+			fileName: invalidTimestampTEXTTestFile,
 			data: `2024-03-04T17:55:08Z INFO     {metricName: accuracy, metricValue: 0.6752}
 invalid INFO     {metricName: loss, metricValue: 0.3634}`,
 		},
 		{
-			fileName: "missing-objective-metric.log",
+			fileName: missingMetricTEXTTestFile,
 			data: `2024-03-04T17:55:08Z INFO     {metricName: loss, metricValue: 0.3634}
 2024-03-04T17:55:08Z INFO     {metricName: loss, metricValue: 0.8671}`,
 		},

--- a/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
+++ b/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
@@ -34,12 +34,11 @@ var (
 )
 
 func TestCollectObservationLog(t *testing.T) {
-	if err := generateJsonTestFiles(); err != nil {
+	if err := generateJSONTestFiles(); err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(filepath.Dir(testJsonDataPath))
-
-	if err := generateTextTestFiles(); err != nil {
+	if err := generateTEXTTestFiles(); err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(filepath.Dir(testTextDataPath))
@@ -267,7 +266,7 @@ func TestCollectObservationLog(t *testing.T) {
 	}
 }
 
-func generateJsonTestFiles() error {
+func generateJSONTestFiles() error {
 	if _, err := os.Stat(testJsonDataPath); err != nil {
 		if err = os.MkdirAll(testJsonDataPath, 0700); err != nil {
 			return err
@@ -316,7 +315,7 @@ func generateJsonTestFiles() error {
 	return nil
 }
 
-func generateTextTestFiles() error {
+func generateTEXTTestFiles() error {
 	if _, err := os.Stat(testTextDataPath); err != nil {
 		if err = os.MkdirAll(testTextDataPath, 0700); err != nil {
 			return err

--- a/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
+++ b/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
@@ -258,8 +258,8 @@ func TestCollectObservationLog(t *testing.T) {
 			if (err != nil) != test.err {
 				t.Errorf("\nGOT: \n%v\nWANT: %v\n", err, test.err)
 			} else {
-				if diff := cmp.Diff(actual, test.expected); diff != "" {
-					t.Errorf("Expected %v\n got %v\ndiff: %v", test.expected, actual, diff)
+				if diff := cmp.Diff(test.expected, actual); diff != "" {
+					t.Errorf("Unexpected parsed result (-want,+got):\n%s", diff)
 				}
 			}
 		})
@@ -356,6 +356,5 @@ invalid INFO     {metricName: loss, metricValue: 0.3634}`,
 			return err
 		}
 	}
-
 	return nil
 }

--- a/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
+++ b/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
@@ -174,19 +174,19 @@ func TestCollectTextObservationLog(t *testing.T) {
 	}
 	defer os.RemoveAll(filepath.Dir(testTextDataPath))
 
-	testCases := map[string]struct{
-		filePath    string
-		metrics     []string
-		filters     []string
-		fileFormat  commonv1beta1.FileFormat
-		err         bool
-		expected    *v1beta1.ObservationLog
+	testCases := map[string]struct {
+		filePath   string
+		metrics    []string
+		filters    []string
+		fileFormat commonv1beta1.FileFormat
+		err        bool
+		expected   *v1beta1.ObservationLog
 	}{
 		"Positive case for logs in TEXT format": {
-			filePath: 	 filepath.Join(testTextDataPath, "good.log"),
-			metrics: 	 []string{"accuracy", "loss"},
-			filters: 	 []string{"{metricName: ([\\w|-]+), metricValue: ((-?\\d+)(\\.\\d+)?)}"},
-			fileFormat:  commonv1beta1.TextFormat,
+			filePath:   filepath.Join(testTextDataPath, "good.log"),
+			metrics:    []string{"accuracy", "loss"},
+			filters:    []string{"{metricName: ([\\w|-]+), metricValue: ((-?\\d+)(\\.\\d+)?)}"},
+			fileFormat: commonv1beta1.TextFormat,
 			expected: &v1beta1.ObservationLog{
 				MetricLogs: []*v1beta1.MetricLog{
 					{
@@ -228,19 +228,19 @@ func TestCollectTextObservationLog(t *testing.T) {
 			},
 		},
 		"Invalid file name": {
-			filePath:    "invalid",
-			err:         true,
+			filePath: "invalid",
+			err:      true,
 		},
 		"Invalid file format": {
-			filePath:    filepath.Join(testTextDataPath, "good.log"),
-			fileFormat:  "invalid",
-			err:         true,
+			filePath:   filepath.Join(testTextDataPath, "good.log"),
+			fileFormat: "invalid",
+			err:        true,
 		},
 		"Invalid timestamp for logs in TEXT format": {
-			filePath:    filepath.Join(testTextDataPath, "invalid-timestamp.log"),
-			metrics:     []string{"accuracy", "loss"},
-			filters:     []string{"{metricName: ([\\w|-]+), metricValue: ((-?\\d+)(\\.\\d+)?)}"},
-			fileFormat:  commonv1beta1.TextFormat,
+			filePath:   filepath.Join(testTextDataPath, "invalid-timestamp.log"),
+			metrics:    []string{"accuracy", "loss"},
+			filters:    []string{"{metricName: ([\\w|-]+), metricValue: ((-?\\d+)(\\.\\d+)?)}"},
+			fileFormat: commonv1beta1.TextFormat,
 			expected: &v1beta1.ObservationLog{
 				MetricLogs: []*v1beta1.MetricLog{
 					{
@@ -261,9 +261,9 @@ func TestCollectTextObservationLog(t *testing.T) {
 			},
 		},
 		"Missing objective metric in training logs": {
-			filePath:    filepath.Join(testTextDataPath, "missing-objective-metric.log"),
-			fileFormat:  commonv1beta1.TextFormat,
-			metrics:     []string{"accuracy", "loss"},
+			filePath:   filepath.Join(testTextDataPath, "missing-objective-metric.log"),
+			fileFormat: commonv1beta1.TextFormat,
+			metrics:    []string{"accuracy", "loss"},
 			expected: &v1beta1.ObservationLog{
 				MetricLogs: []*v1beta1.MetricLog{
 					{

--- a/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
+++ b/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
@@ -29,9 +29,6 @@ import (
 )
 
 const (
-	invalidFileName   = "invalid"
-	invalidFileFormat = "invalid"
-
 	validJSONTestFile            = "good.json"
 	invalidFormatJSONTestFile    = "invalid-format.json"
 	invalidTimestampJSONTestFile = "invalid-timestamp.json"
@@ -197,12 +194,12 @@ func TestCollectObservationLog(t *testing.T) {
 			},
 		},
 		"Invalid file name": {
-			filePath: invalidFileName,
+			filePath: "invalid",
 			err:      true,
 		},
 		"Invalid file format": {
 			filePath:   filepath.Join(testTextDataPath, validTEXTTestFile),
-			fileFormat: invalidFileFormat,
+			fileFormat: "invalid",
 			err:        true,
 		},
 		"Invalid formatted file for logs in JSON format": {

--- a/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
+++ b/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
@@ -131,10 +131,48 @@ func TestCollectObservationLog(t *testing.T) {
 						},
 					},
 					{
+						TimeStamp: "2024-03-04T17:55:08Z",
+						Metric: &v1beta1.Metric{
+							Name:  "accuracy",
+							Value: "100",
+						},
+					},
+					{
+						TimeStamp: "2024-03-04T17:55:08Z",
+						Metric: &v1beta1.Metric{
+							Name:  "accuracy",
+							Value: "888.333",
+						},
+					},
+					{
+						TimeStamp: "2024-03-04T17:55:08Z",
+						Metric: &v1beta1.Metric{
+							Name:  "accuracy",
+							Value: "-0.4759",
+						},
+					},
+					{
 						TimeStamp: time.Time{}.UTC().Format(time.RFC3339),
 						Metric: &v1beta1.Metric{
 							Name:  "loss",
 							Value: "0.8671",
+						},
+					},
+				},
+			},
+		},
+		"Invalid case for logs in TEXT format": {
+			filePath:   filepath.Join(testTextDataPath, "invalid-value.log"),
+			filters:    []string{"{metricName: ([\\w|-]+), metricValue: ((-?\\d+)(\\.\\d+)?)}"},
+			metrics:    []string{"accuracy", "loss"},
+			fileFormat: commonv1beta1.TextFormat,
+			expected: &v1beta1.ObservationLog{
+				MetricLogs: []*v1beta1.MetricLog{
+					{
+						TimeStamp: time.Time{}.UTC().Format(time.RFC3339),
+						Metric: &v1beta1.Metric{
+							Name:  "accuracy",
+							Value: consts.UnavailableMetricValue,
 						},
 					},
 				},
@@ -331,7 +369,17 @@ func generateTEXTTestFiles() error {
 			data: `2024-03-04T17:55:08Z INFO     {metricName: accuracy, metricValue: 0.8078};{metricName: loss, metricValue: 0.5183}
 2024-03-04T17:55:08Z INFO     {metricName: accuracy, metricValue: 0.6752}
 2024-03-04T17:55:08Z INFO     {metricName: loss, metricValue: 0.3634}
+2024-03-04T17:55:08Z INFO     {metricName: accuracy, metricValue: 100}
+2024-03-04T17:55:08Z INFO     {metricName: accuracy, metricValue: 888.333}
+2024-03-04T17:55:08Z INFO     {metricName: accuracy, metricValue: -0.4759}
 {metricName: loss, metricValue: 0.8671}`,
+		},
+		{
+			fileName: "invalid-value.log",
+			data: `2024-03-04T17:55:08Z INFO     {metricName: accuracy, metricValue: .333}
+2024-03-04T17:55:08Z INFO     {metricName: accuracy, metricValue: -.333}
+2024-03-04T17:55:08Z INFO     {metricName: accuracy, metricValue: - 345.333}
+2024-03-04T17:55:08Z INFO     {metricName: accuracy, metricValue: 888.}`,
 		},
 		{
 			fileName: "invalid-format.log",

--- a/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
+++ b/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
@@ -42,8 +42,9 @@ const (
 )
 
 var (
-	testJsonDataPath = filepath.Join("testdata", "JSON")
-	testTextDataPath = filepath.Join("testdata", "TEXT")
+	testDir          = "testdata"
+	testJsonDataPath = filepath.Join(testDir, "JSON")
+	testTextDataPath = filepath.Join(testDir, "TEXT")
 )
 
 func TestCollectObservationLog(t *testing.T) {
@@ -56,7 +57,7 @@ func TestCollectObservationLog(t *testing.T) {
 	if err := generateTEXTTestFiles(); err != nil {
 		t.Fatal(err)
 	}
-	defer deleteTestDirs()
+	defer os.RemoveAll(testDir)
 
 	testCases := map[string]struct {
 		filePath   string
@@ -332,18 +333,6 @@ func generateTestDirs() error {
 		if err = os.MkdirAll(testTextDataPath, 0700); err != nil {
 			return err
 		}
-	}
-
-	return nil
-}
-
-func deleteTestDirs() error {
-	if err := os.RemoveAll(filepath.Dir(testJsonDataPath)); err != nil {
-		return err
-	}
-
-	if err := os.RemoveAll(filepath.Dir(testTextDataPath)); err != nil {
-		return err
 	}
 
 	return nil

--- a/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
+++ b/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
@@ -50,14 +50,16 @@ var (
 )
 
 func TestCollectObservationLog(t *testing.T) {
+	if err := generateTestDirs(); err != nil {
+		t.Fatal(err)
+	}
 	if err := generateJSONTestFiles(); err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(filepath.Dir(testJsonDataPath))
 	if err := generateTEXTTestFiles(); err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(filepath.Dir(testTextDataPath))
+	defer deleteTestDirs()
 
 	testCases := map[string]struct {
 		filePath   string
@@ -320,13 +322,37 @@ func TestCollectObservationLog(t *testing.T) {
 	}
 }
 
-func generateJSONTestFiles() error {
+func generateTestDirs() error {
+	// Generate JSON files' dir
 	if _, err := os.Stat(testJsonDataPath); err != nil {
 		if err = os.MkdirAll(testJsonDataPath, 0700); err != nil {
 			return err
 		}
 	}
 
+	// Generate TEXT files' dir
+	if _, err := os.Stat(testTextDataPath); err != nil {
+		if err = os.MkdirAll(testTextDataPath, 0700); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deleteTestDirs() error {
+	if err := os.RemoveAll(filepath.Dir(testJsonDataPath)); err != nil {
+		return err
+	}
+
+	if err := os.RemoveAll(filepath.Dir(testTextDataPath)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func generateJSONTestFiles() error {
 	testData := []struct {
 		fileName string
 		data     string
@@ -370,12 +396,6 @@ func generateJSONTestFiles() error {
 }
 
 func generateTEXTTestFiles() error {
-	if _, err := os.Stat(testTextDataPath); err != nil {
-		if err = os.MkdirAll(testTextDataPath, 0700); err != nil {
-			return err
-		}
-	}
-
 	testData := []struct {
 		fileName string
 		data     string
@@ -420,5 +440,6 @@ invalid INFO     {metricName: loss, metricValue: 0.3634}`,
 			return err
 		}
 	}
+
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Add unit test cases for files in Text format in `file-metricscollector_test.go`, including:
1. "Positive case for logs in TEXT format" test case
2. "Invalid file name" test case
3. "Invalid file format" test case
4. "Invalid timestamp for logs in TEXT format" test case
5. "Missing objective metric in training logs" test case

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #1756 

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
