### PR TITLE
fix: clean up UTs for file metrics collector

### DIFF
--- a/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector.go
+++ b/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector.go
@@ -18,6 +18,7 @@ package sidecarmetricscollector
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -34,20 +35,27 @@ import (
 	"github.com/kubeflow/katib/pkg/metricscollector/v1beta1/common"
 )
 
+var (
+	ErrFileFormat = fmt.Errorf("format must be set %v or %v", commonv1beta1.TextFormat, commonv1beta1.JsonFormat)
+	ErrOpenFile   = errors.New("failed to open the file")
+	ErrReadFile   = errors.New("failed to read the file")
+	ErrParseJson  = errors.New("failed to parse the json object")
+)
+
 func CollectObservationLog(fileName string, metrics []string, filters []string, fileFormat commonv1beta1.FileFormat) (*v1beta1.ObservationLog, error) {
 	// we should check fileFormat first in case of opening an invalid file
 	if fileFormat != commonv1beta1.JsonFormat && fileFormat != commonv1beta1.TextFormat {
-		return nil, fmt.Errorf("format must be set %v or %v", commonv1beta1.TextFormat, commonv1beta1.JsonFormat)
+		return nil, ErrFileFormat
 	}
-	
+
 	file, err := os.Open(fileName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrOpenFile, err.Error())
 	}
 	defer file.Close()
 	content, err := io.ReadAll(file)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", ErrReadFile, err.Error())
 	}
 	logs := string(content)
 
@@ -125,7 +133,7 @@ func parseLogsInJsonFormat(logs []string, metrics []string) (*v1beta1.Observatio
 		}
 		var jsonObj map[string]interface{}
 		if err := json.Unmarshal([]byte(logline), &jsonObj); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %s", ErrParseJson, err.Error())
 		}
 
 		timestamp := time.Time{}.UTC().Format(time.RFC3339)

--- a/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector.go
+++ b/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector.go
@@ -35,6 +35,11 @@ import (
 )
 
 func CollectObservationLog(fileName string, metrics []string, filters []string, fileFormat commonv1beta1.FileFormat) (*v1beta1.ObservationLog, error) {
+	// we should check fileFormat first in case of opening an invalid file
+	if fileFormat != commonv1beta1.JsonFormat && fileFormat != commonv1beta1.TextFormat {
+		return nil, fmt.Errorf("format must be set %v or %v", commonv1beta1.TextFormat, commonv1beta1.JsonFormat)
+	}
+	
 	file, err := os.Open(fileName)
 	if err != nil {
 		return nil, err
@@ -52,7 +57,7 @@ func CollectObservationLog(fileName string, metrics []string, filters []string, 
 	case commonv1beta1.JsonFormat:
 		return parseLogsInJsonFormat(strings.Split(logs, "\n"), metrics)
 	}
-	return nil, fmt.Errorf("format must be set %v or %v", commonv1beta1.TextFormat, commonv1beta1.JsonFormat)
+	return nil, nil
 }
 
 func parseLogsInTextFormat(logs []string, metrics []string, filters []string) (*v1beta1.ObservationLog, error) {

--- a/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector.go
+++ b/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector.go
@@ -36,26 +36,26 @@ import (
 )
 
 var (
-	ErrFileFormat = fmt.Errorf("format must be set %v or %v", commonv1beta1.TextFormat, commonv1beta1.JsonFormat)
-	ErrOpenFile   = errors.New("failed to open the file")
-	ErrReadFile   = errors.New("failed to read the file")
-	ErrParseJson  = errors.New("failed to parse the json object")
+	errFileFormat = fmt.Errorf("format must be set %v or %v", commonv1beta1.TextFormat, commonv1beta1.JsonFormat)
+	errOpenFile   = errors.New("failed to open the file")
+	errReadFile   = errors.New("failed to read the file")
+	errParseJson  = errors.New("failed to parse the json object")
 )
 
 func CollectObservationLog(fileName string, metrics []string, filters []string, fileFormat commonv1beta1.FileFormat) (*v1beta1.ObservationLog, error) {
 	// we should check fileFormat first in case of opening an invalid file
 	if fileFormat != commonv1beta1.JsonFormat && fileFormat != commonv1beta1.TextFormat {
-		return nil, ErrFileFormat
+		return nil, errFileFormat
 	}
 
 	file, err := os.Open(fileName)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrOpenFile, err.Error())
+		return nil, fmt.Errorf("%w: %s", errOpenFile, err.Error())
 	}
 	defer file.Close()
 	content, err := io.ReadAll(file)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrReadFile, err.Error())
+		return nil, fmt.Errorf("%w: %s", errReadFile, err.Error())
 	}
 	logs := string(content)
 
@@ -64,8 +64,9 @@ func CollectObservationLog(fileName string, metrics []string, filters []string, 
 		return parseLogsInTextFormat(strings.Split(logs, "\n"), metrics, filters)
 	case commonv1beta1.JsonFormat:
 		return parseLogsInJsonFormat(strings.Split(logs, "\n"), metrics)
+	default:
+		return nil, nil
 	}
-	return nil, nil
 }
 
 func parseLogsInTextFormat(logs []string, metrics []string, filters []string) (*v1beta1.ObservationLog, error) {
@@ -133,7 +134,7 @@ func parseLogsInJsonFormat(logs []string, metrics []string) (*v1beta1.Observatio
 		}
 		var jsonObj map[string]interface{}
 		if err := json.Unmarshal([]byte(logline), &jsonObj); err != nil {
-			return nil, fmt.Errorf("%w: %s", ErrParseJson, err.Error())
+			return nil, fmt.Errorf("%w: %s", errParseJson, err.Error())
 		}
 
 		timestamp := time.Time{}.UTC().Format(time.RFC3339)

--- a/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
+++ b/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
@@ -185,19 +185,19 @@ func TestCollectObservationLog(t *testing.T) {
 		"Invalid file name": {
 			fileName:   "invalid",
 			fileFormat: commonv1beta1.JsonFormat,
-			wantError:  ErrOpenFile,
+			wantError:  errOpenFile,
 		},
 		"Invalid file format": {
 			fileName:   "good.log",
 			fileFormat: "invalid",
-			wantError:  ErrFileFormat,
+			wantError:  errFileFormat,
 		},
 		"Invalid formatted file for logs in JSON format": {
 			fileName: "invalid-format.json",
 			testData: `"checkpoint_path": "", "global_step": "0", "loss": "0.22082142531871796", "timestamp": 1638422847.28721, "trial": "0"
 {"acc": "0.9349666833877563", "checkpoint_path": "", "global_step": "0", "timestamp": 1638422847.287801, "trial": "0`,
 			fileFormat: commonv1beta1.JsonFormat,
-			wantError:  ErrParseJson,
+			wantError:  errParseJson,
 		},
 		"Invalid formatted file for logs in TEXT format": {
 			fileName: "invalid-format.log",
@@ -313,7 +313,7 @@ invalid INFO     {metricName: loss, metricValue: 0.3634}`,
 		t.Run(name, func(t *testing.T) {
 			if test.testData != "" {
 				if err := os.WriteFile(filepath.Join(tmpDir, test.fileName), []byte(test.testData), 0600); err != nil {
-					t.Fatal(err)
+					t.Fatalf("failed to write test data: %v", err)
 				}
 			}
 			actual, err := CollectObservationLog(filepath.Join(tmpDir, test.fileName), test.metrics, test.filters, test.fileFormat)

--- a/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
+++ b/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
@@ -41,23 +41,14 @@ const (
 	missingMetricTEXTTestFile    = "missing-objective-metric.log"
 )
 
-var (
-	testDir          = "testdata"
-	testJsonDataPath = filepath.Join(testDir, "JSON")
-	testTextDataPath = filepath.Join(testDir, "TEXT")
-)
-
 func TestCollectObservationLog(t *testing.T) {
-	if err := generateTestDirs(); err != nil {
+	testJsonDataPath, testTextDataPath := t.TempDir(), t.TempDir()
+	if err := generateJSONTestFiles(testJsonDataPath); err != nil {
 		t.Fatal(err)
 	}
-	if err := generateJSONTestFiles(); err != nil {
+	if err := generateTEXTTestFiles(testTextDataPath); err != nil {
 		t.Fatal(err)
 	}
-	if err := generateTEXTTestFiles(); err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(testDir)
 
 	testCases := map[string]struct {
 		filePath   string
@@ -320,25 +311,7 @@ func TestCollectObservationLog(t *testing.T) {
 	}
 }
 
-func generateTestDirs() error {
-	// Generate JSON files' dir
-	if _, err := os.Stat(testJsonDataPath); err != nil {
-		if err = os.MkdirAll(testJsonDataPath, 0700); err != nil {
-			return err
-		}
-	}
-
-	// Generate TEXT files' dir
-	if _, err := os.Stat(testTextDataPath); err != nil {
-		if err = os.MkdirAll(testTextDataPath, 0700); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func generateJSONTestFiles() error {
+func generateJSONTestFiles(tmpDir string) error {
 	testData := []struct {
 		fileName string
 		data     string
@@ -372,7 +345,7 @@ func generateJSONTestFiles() error {
 	}
 
 	for _, td := range testData {
-		filePath := filepath.Join(testJsonDataPath, td.fileName)
+		filePath := filepath.Join(tmpDir, td.fileName)
 		if err := os.WriteFile(filePath, []byte(td.data), 0600); err != nil {
 			return err
 		}
@@ -381,7 +354,7 @@ func generateJSONTestFiles() error {
 	return nil
 }
 
-func generateTEXTTestFiles() error {
+func generateTEXTTestFiles(tmpDir string) error {
 	testData := []struct {
 		fileName string
 		data     string
@@ -421,7 +394,7 @@ invalid INFO     {metricName: loss, metricValue: 0.3634}`,
 	}
 
 	for _, td := range testData {
-		filePath := filepath.Join(testTextDataPath, td.fileName)
+		filePath := filepath.Join(tmpDir, td.fileName)
 		if err := os.WriteFile(filePath, []byte(td.data), 0600); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Current error comparison in file-metricscollector_test.go is based on a boolean rather than the error content  To make test cases more detailed and accurate, we should expose and compare errors. 

And also @tenzen-y suggested that `t.TempDir` should be used for generating test directory. So I replace static directories with `t.TempDir`.

Related discussion: https://github.com/kubeflow/katib/issues/1756#issuecomment-1983711306 https://github.com/kubeflow/katib/pull/2274#discussion_r1521725542

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #1756 

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
