### PR TITLE
Introduced error constants and replaced reflect with cmp

### DIFF
--- a/pkg/controller.v1beta1/experiment/manifest/generator_test.go
+++ b/pkg/controller.v1beta1/experiment/manifest/generator_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package manifest
 
 import (
-	"errors"
 	"math"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/mock/gomock"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
@@ -88,23 +88,18 @@ func TestGetRunSpecWithHP(t *testing.T) {
 		t.Errorf("ConvertObjectToUnstructured failed: %v", err)
 	}
 
-	tcs := []struct {
-		instance             *experimentsv1beta1.Experiment
-		parameterAssignments []commonapiv1beta1.ParameterAssignment
-		expectedRunSpec      *unstructured.Unstructured
-		err                  bool
-		testDescription      string
+	cases := map[string]struct {
+		instance                       *experimentsv1beta1.Experiment
+		parameterAssignments           []commonapiv1beta1.ParameterAssignment
+		wantRunSpecWithHyperParameters *unstructured.Unstructured
+		wantError                      error
 	}{
-		// Valid run
-		{
-			instance:             newFakeInstance(),
-			parameterAssignments: newFakeParameterAssignment(),
-			expectedRunSpec:      expectedRunSpec,
-			err:                  false,
-			testDescription:      "Run with valid parameters",
+		"Run with valid parameters": {
+			instance:                       newFakeInstance(),
+			parameterAssignments:           newFakeParameterAssignment(),
+			wantRunSpecWithHyperParameters: expectedRunSpec,
 		},
-		// Invalid JSON in unstructured
-		{
+		"Invalid JSON in Unstructured Trial template": {
 			instance: func() *experimentsv1beta1.Experiment {
 				i := newFakeInstance()
 				trialSpec := i.Spec.TrialTemplate.TrialSource.TrialSpec
@@ -114,22 +109,9 @@ func TestGetRunSpecWithHP(t *testing.T) {
 				return i
 			}(),
 			parameterAssignments: newFakeParameterAssignment(),
-			err:                  true,
-			testDescription:      "Invalid JSON in Trial template",
+			wantError:            errConvertUnstructuredToStringFailed,
 		},
-		// len(parameterAssignment) != len(trialParameters)
-		{
-			instance: newFakeInstance(),
-			parameterAssignments: func() []commonapiv1beta1.ParameterAssignment {
-				pa := newFakeParameterAssignment()
-				pa = pa[1:]
-				return pa
-			}(),
-			err:             true,
-			testDescription: "Number of parameter assignments is not equal to number of Trial parameters",
-		},
-		// Parameter from assignments not found in Trial parameters
-		{
+		"Non-meta parameter from TrialParameters not found in ParameterAssignment": {
 			instance: newFakeInstance(),
 			parameterAssignments: func() []commonapiv1beta1.ParameterAssignment {
 				pa := newFakeParameterAssignment()
@@ -139,23 +121,33 @@ func TestGetRunSpecWithHP(t *testing.T) {
 				}
 				return pa
 			}(),
-			err:             true,
-			testDescription: "Trial parameters don't have parameter from assignments",
+			wantError: errParamNotFoundInParameterAssignment,
+		},
+		// case in which the lengths of trial parameters and parameter assignments are different
+		"Parameter from ParameterAssignment not found in TrialParameters": {
+			instance: newFakeInstance(),
+			parameterAssignments: func() []commonapiv1beta1.ParameterAssignment {
+				pa := newFakeParameterAssignment()
+				pa = append(pa, commonapiv1beta1.ParameterAssignment{
+					Name:  "extra-name",
+					Value: "extra-value",
+				})
+				return pa
+			}(),
+			wantError: errParamNotFoundInTrialParameters,
 		},
 	}
 
-	for _, tc := range tcs {
-		actualRunSpec, err := p.GetRunSpecWithHyperParameters(tc.instance, "trial-name", "trial-namespace", tc.parameterAssignments)
-
-		if tc.err && err == nil {
-			t.Errorf("Case: %v failed. Expected err, got nil", tc.testDescription)
-		} else if !tc.err {
-			if err != nil {
-				t.Errorf("Case: %v failed. Expected nil, got %v", tc.testDescription, err)
-			} else if !reflect.DeepEqual(tc.expectedRunSpec, actualRunSpec) {
-				t.Errorf("Case: %v failed. Expected %v\n got %v", tc.testDescription, tc.expectedRunSpec.Object, actualRunSpec.Object)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := p.GetRunSpecWithHyperParameters(tc.instance, "trial-name", "trial-namespace", tc.parameterAssignments)
+			if diff := cmp.Diff(tc.wantError, err, cmpopts.EquateErrors()); len(diff) != 0 {
+				t.Errorf("Unexpected error from GetRunSpecWithHyperParameters (-want,+got):\n%s", diff)
 			}
-		}
+			if diff := cmp.Diff(tc.wantRunSpecWithHyperParameters, got); len(diff) != 0 {
+				t.Errorf("Unexpected run spec from GetRunSpecWithHyperParameters (-want,+got):\n%s", diff)
+			}
+		})
 	}
 }
 
@@ -208,7 +200,7 @@ spec:
 		map[string]string{templatePath: trialSpec}, nil)
 
 	invalidConfigMapName := c.EXPECT().GetConfigMap(gomock.Any(), gomock.Any()).Return(
-		nil, errors.New("Unable to get ConfigMap"))
+		nil, errConfigMapNotFound)
 
 	validGetConfigMap3 := c.EXPECT().GetConfigMap(gomock.Any(), gomock.Any()).Return(
 		map[string]string{templatePath: trialSpec}, nil)
@@ -244,19 +236,18 @@ spec:
             - "--momentum=0.9"`
 
 	expectedRunSpec, err := util.ConvertStringToUnstructured(expectedStr)
-	if err != nil {
-		t.Errorf("ConvertStringToUnstructured failed: %v", err)
+	if diff := cmp.Diff(nil, err, cmpopts.EquateErrors()); len(diff) != 0 {
+		t.Errorf("ConvertStringToUnstructured failed (-want,+got):\n%s", diff)
 	}
 
-	tcs := []struct {
-		instance             *experimentsv1beta1.Experiment
-		parameterAssignments []commonapiv1beta1.ParameterAssignment
-		err                  bool
-		testDescription      string
+	cases := map[string]struct {
+		instance                       *experimentsv1beta1.Experiment
+		parameterAssignments           []commonapiv1beta1.ParameterAssignment
+		wantRunSpecWithHyperParameters *unstructured.Unstructured
+		wantError                      error
 	}{
-		// Valid run
 		// validGetConfigMap1 case
-		{
+		"Run with valid parameters": {
 			instance: func() *experimentsv1beta1.Experiment {
 				i := newFakeInstance()
 				i.Spec.TrialTemplate.TrialSource = experimentsv1beta1.TrialSource{
@@ -268,13 +259,11 @@ spec:
 				}
 				return i
 			}(),
-			parameterAssignments: newFakeParameterAssignment(),
-			err:                  false,
-			testDescription:      "Run with valid parameters",
+			parameterAssignments:           newFakeParameterAssignment(),
+			wantRunSpecWithHyperParameters: expectedRunSpec,
 		},
-		// Invalid ConfigMap name
 		// invalidConfigMapName case
-		{
+		"Invalid ConfigMap name": {
 			instance: func() *experimentsv1beta1.Experiment {
 				i := newFakeInstance()
 				i.Spec.TrialTemplate.TrialSource = experimentsv1beta1.TrialSource{
@@ -285,12 +274,10 @@ spec:
 				return i
 			}(),
 			parameterAssignments: newFakeParameterAssignment(),
-			err:                  true,
-			testDescription:      "Invalid ConfigMap name",
+			wantError:            errConfigMapNotFound,
 		},
-		// Invalid template path in ConfigMap name
 		// validGetConfigMap3 case
-		{
+		"Invalid template path in ConfigMap name": {
 			instance: func() *experimentsv1beta1.Experiment {
 				i := newFakeInstance()
 				i.Spec.TrialTemplate.TrialSource = experimentsv1beta1.TrialSource{
@@ -303,14 +290,12 @@ spec:
 				return i
 			}(),
 			parameterAssignments: newFakeParameterAssignment(),
-			err:                  true,
-			testDescription:      "Invalid template path in ConfigMap",
+			wantError:            errTrialTemplateNotFound,
 		},
-		// Invalid Trial template spec in ConfigMap
+		// invalidTemplate case
 		// Trial template is a string in ConfigMap
 		// Because of that, user can specify not valid unstructured template
-		// invalidTemplate case
-		{
+		"Invalid trial spec in ConfigMap": {
 			instance: func() *experimentsv1beta1.Experiment {
 				i := newFakeInstance()
 				i.Spec.TrialTemplate.TrialSource = experimentsv1beta1.TrialSource{
@@ -323,22 +308,20 @@ spec:
 				return i
 			}(),
 			parameterAssignments: newFakeParameterAssignment(),
-			err:                  true,
-			testDescription:      "Invalid Trial spec in ConfigMap",
+			wantError:            errConvertStringToUnstructuredFailed,
 		},
 	}
 
-	for _, tc := range tcs {
-		actualRunSpec, err := p.GetRunSpecWithHyperParameters(tc.instance, "trial-name", "trial-namespace", tc.parameterAssignments)
-		if tc.err && err == nil {
-			t.Errorf("Case: %v failed. Expected err, got nil", tc.testDescription)
-		} else if !tc.err {
-			if err != nil {
-				t.Errorf("Case: %v failed. Expected nil, got %v", tc.testDescription, err)
-			} else if !reflect.DeepEqual(expectedRunSpec, actualRunSpec) {
-				t.Errorf("Case: %v failed. Expected %v\n got %v", tc.testDescription, expectedRunSpec.Object, actualRunSpec.Object)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := p.GetRunSpecWithHyperParameters(tc.instance, "trial-name", "trial-namespace", tc.parameterAssignments)
+			if diff := cmp.Diff(tc.wantError, err, cmpopts.EquateErrors()); len(diff) != 0 {
+				t.Errorf("Unexpected error from GetRunSpecWithHyperParameters (-want,+got):\n%s", diff)
 			}
-		}
+			if diff := cmp.Diff(tc.wantRunSpecWithHyperParameters, got); len(diff) != 0 {
+				t.Errorf("Unexpected run spec from GetRunSpecWithHyperParameters (-want,+got):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/pkg/webhook/v1beta1/pod/utils.go
+++ b/pkg/webhook/v1beta1/pod/utils.go
@@ -18,6 +18,7 @@ package pod
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -34,6 +35,8 @@ import (
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 	mccommon "github.com/kubeflow/katib/pkg/metricscollector/v1beta1/common"
 )
+
+var errPrimaryContainerNotFound = errors.New("unable to find primary container in mutated pod containers")
 
 func isPrimaryPod(podLabels, primaryLabels map[string]string) bool {
 
@@ -190,8 +193,7 @@ func wrapWorkerContainer(trial *trialsv1beta1.Trial, pod *v1.Pod, namespace,
 		c.Command = command
 		c.Args = []string{argsStr}
 	} else {
-		return fmt.Errorf("Unable to find primary container %v in mutated pod containers %v",
-			trial.Spec.PrimaryContainerName, pod.Spec.Containers)
+		return fmt.Errorf("%w: primary container: %v, mutated pod containers: %v", errPrimaryContainerNotFound, trial.Spec.PrimaryContainerName, pod.Spec.Containers)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Following the suggestion https://github.com/kubeflow/katib/pull/2281#pullrequestreview-1926741952 from @tenzen-y this code change provides a more thorough comparison of errors through the introduction of error constants and the replacement of `replace.DeepEqual` with `cmp.Diff`.

In addition some of the test cases in `generator_test.go` have been revised to allow for a more thorough comparison of error messages.

Finally cosmetic changes have been applied to some of the tests in order to match the style of the code in [config_test.go](https://github.com/kubeflow/katib/pull/2281#discussion_r1519020624) that compares error constants.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes https://github.com/kubeflow/katib/issues/2268

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
