### PR TITLE
CI: Enable parallel mode for the coveralls

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -59,9 +59,19 @@ jobs:
         with:
           path-to-profile: coverage.out
           working-directory: ${{ env.GOPATH }}/src/github.com/kubeflow/katib
+          parallel: true
 
     strategy:
       fail-fast: false
       matrix:
         # Detail: `setup-envtest list`
         kubernetes-version: ["1.25.0", "1.26.1", "1.27.1"]
+
+  # notifies that all test jobs are finished.
+  finish:
+    needs: unittests
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: shogo82148/actions-goveralls@v1
+        with:
+          parallel-finished: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
We sometimes face the following error when we retry CI. So, I enabled the parallel mode to avoid the error.

```shell
bad response status from coveralls: 422
{"message":"Can't add a job to a build that is already closed. Build 8475719809 is closed. See docs.coveralls.io/parallel-builds","error":true}
Error: Error: The process '/home/runner/work/_actions/shogo82148/actions-goveralls/v1/bin/goveralls_linux_amd64' failed with exit code 1
```

https://github.com/kubeflow/katib/actions/runs/8475719809/job/23237738755?pr=2285#step:5:29

Docs: https://github.com/shogo82148/actions-goveralls?tab=readme-ov-file#parallel-job-example

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
