### PR TITLE
Fix Scikit-Learn Version for Skopt Tests

### DIFF
--- a/cmd/suggestion/skopt/v1beta1/requirements.txt
+++ b/cmd/suggestion/skopt/v1beta1/requirements.txt
@@ -4,7 +4,7 @@ cloudpickle==0.5.6
 # AttributeError: module 'numpy' has no attribute 'int'
 # See more: https://github.com/numpy/numpy/pull/22607
 numpy==1.23.5
-scikit-learn>=0.24.0
+scikit-learn>=0.24.0, <=1.3.0
 scipy>=1.5.4
 forestci==0.3
 protobuf>=3.19.5, <=3.20.3


### PR DESCRIPTION
This should fix our CI for skopt suggestion. We are getting this error in the most recent `sckit-learn` version:
```
E   ImportError: cannot import name 'check_pandas_support' from 'sklearn.utils' 
(/Users/avelichk/miniconda3/envs/katib-ci/lib/python3.9/site-packages/sklearn/utils/__init__.py)
```

Eventually, we should deprecate skopt in favour of `GPSampler` from Optuna: https://github.com/kubeflow/katib/issues/2280#issuecomment-1993658378 for bayesian optimization in Katib.

cc @contramundum53 

/assign @kubeflow/wg-training-leads 