### PR TITLE
Fix apple silicon rosetta error when building images from the source code

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -29,6 +29,8 @@ to build multi-arch images. Check source code as follows:
 make build REGISTRY=<image-registry> TAG=<image-tag>
 ```
 
+If you are using an Apple Silicon machine and encounter the "rosetta error: bss_size overflow," go to Docker Desktop -> General and uncheck "Use Rosetta for x86_64/amd64 emulation on Apple Silicon."
+
 To use your custom images for the Katib components, modify
 [Kustomization file](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/installs/katib-standalone/kustomization.yaml)
 and [Katib Config](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/installs/katib-standalone/katib-config.yaml)


### PR DESCRIPTION
**What this PR does / why we need it**:
When building images from the source code on an Apple Silicon machine, following the `docs/developer-guide.md`, I encountered the "rosetta error: bss_size overflow". This PR adds instructions to resolve this error by disabling Rosetta emulation in Docker Desktop settings.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**
