### PR TITLE
Remove code generation from release script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,14 +115,12 @@ push-latest: generate
 	bash scripts/v1beta1/push.sh $(KATIB_REGISTRY) $(COMMIT)
 
 # Build and push Katib images for the given tag.
-push-tag: generate
+push-tag:
 ifeq ($(TAG),)
 	$(error TAG must be set. Usage: make push-tag TAG=<release-tag>)
 endif
 	bash scripts/v1beta1/build.sh $(KATIB_REGISTRY) $(TAG) $(CPU_ARCH)
-	bash scripts/v1beta1/build.sh $(KATIB_REGISTRY) $(COMMIT) $(CPU_ARCH)
 	bash scripts/v1beta1/push.sh $(KATIB_REGISTRY) $(TAG)
-	bash scripts/v1beta1/push.sh $(KATIB_REGISTRY) $(COMMIT)
 
 # Release a new version of Katib.
 release:

--- a/scripts/v1beta1/release.sh
+++ b/scripts/v1beta1/release.sh
@@ -79,8 +79,6 @@ if [[ ${sdk_version} == *"-rc."* ]]; then
   sdk_version=${sdk_version//-rc./rc}
 fi
 echo -e "\nPublishing Katib Python SDK, version: ${sdk_version}\n"
-# Run generate script.
-make generate
 
 # Change version in setup.py
 cd sdk/python/v1beta1


### PR DESCRIPTION
I removed the code generation from our release script.

Currently, we have to clone Katib repo to the `$GOPATH/src/github.com/kubeflow/katib` to correctly run Go code generation. However, in the release script we clone the Katib repo to the [temp directory](https://github.com/kubeflow/katib/blob/0947169ab114dfe71f5492b0d094d4c2054052a9/scripts/v1beta1/release.sh#L43-L47) to avoid un-sync Git history.

We don't need to run `make generate` in our release script, since we have [the code generation check](https://github.com/andreyvelich/katib/blob/0947169ab114dfe71f5492b0d094d4c2054052a9/hack/verify-generated-codes.sh#L24) for each PR.

Also, we don't need to publish images with COMMIT tag during the release.

/assign @tenzen-y @johnugeorge 

