### PR TITLE
Remove default caBundle value

### DIFF
--- a/manifests/v1beta1/components/webhook/webhooks.yaml
+++ b/manifests/v1beta1/components/webhook/webhooks.yaml
@@ -9,7 +9,6 @@ webhooks:
     admissionReviewVersions:
       - v1
     clientConfig:
-      caBundle: Cg==
       service:
         name: katib-controller
         namespace: kubeflow
@@ -35,7 +34,6 @@ webhooks:
     admissionReviewVersions:
       - v1
     clientConfig:
-      caBundle: Cg==
       service:
         name: katib-controller
         namespace: kubeflow
@@ -55,7 +53,6 @@ webhooks:
     admissionReviewVersions:
       - v1
     clientConfig:
-      caBundle: Cg==
       service:
         name: katib-controller
         namespace: kubeflow


### PR DESCRIPTION
**What this PR does / why we need it**:
caBundle hasn't been a required key since k8s v1.13
Removing it makes it simpler to deploy katib with terraform.

**Which issue(s) this PR fixes**:
Fixes #2367

**Checklist:**
- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
