### PR TITLE
[GSoC] Add New Parameter in `tune`

### DIFF
--- a/hack/gen-python-sdk/post_gen.py
+++ b/hack/gen-python-sdk/post_gen.py
@@ -41,6 +41,8 @@ def _rewrite_helper(input_file, output_file, rewrite_rules):
     if (output_file == "sdk/python/v1beta1/kubeflow/katib/__init__.py"):
         lines.append("# Import Katib API client.\n")
         lines.append("from kubeflow.katib.api.katib_client import KatibClient\n")
+        lines.append("# Import Katib report metrics functions")
+        lines.append("from kubeflow.katib.api.report_metrics import report_metrics")
         lines.append("# Import Katib helper functions.\n")
         lines.append("import kubeflow.katib.api.search as search\n")
         lines.append("# Import Katib helper constants.\n")

--- a/pkg/apis/controller/common/v1beta1/common_types.go
+++ b/pkg/apis/controller/common/v1beta1/common_types.go
@@ -220,8 +220,8 @@ const (
 	CustomCollector CollectorKind = "Custom"
 
 	// When model training source code persists metrics into persistent layer
-	// directly, metricsCollector isn't in need, and its kind is "noneCollector"
-	NoneCollector CollectorKind = "None"
+	// directly, sidecar container isn't in need, and its kind is "pushCollector"
+	PushCollector CollectorKind = "Push"
 
 	MetricsVolume = "metrics-volume"
 )

--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -60,6 +60,9 @@ const (
 	// resources list which can be used as trial template
 	ConfigTrialResources = "trial-resources"
 
+	// EnvTrialName is the env variable of Trial name
+	EnvTrialName = "KATIB_TRIAL_NAME"
+
 	// LabelExperimentName is the label of experiment name.
 	LabelExperimentName = "katib.kubeflow.org/experiment"
 	// LabelSuggestionName is the label of suggestion name.

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -489,7 +489,7 @@ func (g *DefaultValidator) validateMetricsCollector(inst *experimentsv1beta1.Exp
 	// TODO(hougangliu): log warning message if some field will not be used for the metricsCollector kind
 	switch mcKind {
 	case commonapiv1beta1.PushCollector, commonapiv1beta1.StdOutCollector:
-		return nil
+		return allErrs
 	case commonapiv1beta1.FileCollector:
 		if mcSpec.Source == nil || mcSpec.Source.FileSystemPath == nil ||
 			mcSpec.Source.FileSystemPath.Kind != commonapiv1beta1.FileKind || !filepath.IsAbs(mcSpec.Source.FileSystemPath.Path) {

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -488,8 +488,8 @@ func (g *DefaultValidator) validateMetricsCollector(inst *experimentsv1beta1.Exp
 	}
 	// TODO(hougangliu): log warning message if some field will not be used for the metricsCollector kind
 	switch mcKind {
-	case commonapiv1beta1.NoneCollector, commonapiv1beta1.StdOutCollector:
-		return allErrs
+	case commonapiv1beta1.PushCollector, commonapiv1beta1.StdOutCollector:
+		return nil
 	case commonapiv1beta1.FileCollector:
 		if mcSpec.Source == nil || mcSpec.Source.FileSystemPath == nil ||
 			mcSpec.Source.FileSystemPath.Kind != commonapiv1beta1.FileKind || !filepath.IsAbs(mcSpec.Source.FileSystemPath.Path) {

--- a/pkg/webhook/v1beta1/pod/inject_webhook.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook.go
@@ -147,8 +147,8 @@ func (s *SidecarInjector) Mutate(pod *v1.Pod, namespace string) (*v1.Pod, error)
 		return mutatedPod, nil
 	}
 
-	// If Metrics Collector in None, skip the mutation.
-	if trial.Spec.MetricsCollector.Collector.Kind == common.NoneCollector {
+	// If Metrics Collector is Push, skip the mutation.
+	if trial.Spec.MetricsCollector.Collector.Kind == common.PushCollector {
 		return mutatedPod, nil
 	}
 

--- a/pkg/webhook/v1beta1/pod/inject_webhook.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -139,6 +140,25 @@ func (s *SidecarInjector) Mutate(pod *v1.Pod, namespace string) (*v1.Pod, error)
 
 	// Add Katib Trial labels to the Pod metadata.
 	mutatePodMetadata(mutatedPod, trial)
+
+
+	// Pass env variable KATIB_TRIAL_NAME to training containers using fieldPath.
+	for idx := range mutatedPod.Spec.Containers {
+		if mutatedPod.Spec.Containers[idx].Env == nil {
+			mutatedPod.Spec.Containers[idx].Env = []v1.EnvVar{}
+		}
+		mutatedPod.Spec.Containers[idx].Env = append(
+			mutatedPod.Spec.Containers[idx].Env, 
+			v1.EnvVar{
+				Name: consts.EnvTrialName,
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						FieldPath: fmt.Sprintf("metadata.labels['%s']", consts.LabelTrialName),
+					},
+				},
+			},
+		)
+	}
 
 	// Do the following mutation only for the Primary pod.
 	// If PrimaryPodLabel is not set we mutate all pods which are related to Trial job.

--- a/pkg/webhook/v1beta1/pod/inject_webhook.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook.go
@@ -148,7 +148,7 @@ func (s *SidecarInjector) Mutate(pod *v1.Pod, namespace string) (*v1.Pod, error)
 			mutatedPod.Spec.Containers[index].Env = []v1.EnvVar{}
 		}
 		mutatedPod.Spec.Containers[index].Env = append(
-			mutatedPod.Spec.Containers[index].Env, 
+			mutatedPod.Spec.Containers[index].Env,
 			v1.EnvVar{
 				Name: consts.EnvTrialName,
 				ValueFrom: &v1.EnvVarSource{

--- a/pkg/webhook/v1beta1/pod/inject_webhook_test.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/gomega"
-	"google.golang.org/protobuf/testing/protocmp"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1164,7 +1163,7 @@ func TestMutatePodEnv(t *testing.T) {
 				)
 			}
 			// Compare Pod with expected pod after mutation
-			if diff := cmp.Diff(testcase.mutatedPod, testcase.pod, protocmp.Transform()); len(diff) != 0 {
+			if diff := cmp.Diff(testcase.mutatedPod, testcase.pod); len(diff) != 0 {
 				t.Errorf("Unexpected mutated result (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/webhook/v1beta1/pod/inject_webhook_test.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook_test.go
@@ -25,7 +25,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/gomega"
+	"google.golang.org/protobuf/testing/protocmp"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1065,5 +1068,105 @@ func TestMutatePodMetadata(t *testing.T) {
 		if !reflect.DeepEqual(tc.mutatedPod, tc.pod) {
 			t.Errorf("Case %v. Expected Pod %v, got %v", tc.testDescription, tc.mutatedPod, tc.pod)
 		}
+	}
+}
+
+func TestMutatePodEnv(t *testing.T) {
+	testcases := map[string]struct {
+		pod        *v1.Pod
+		trial      *trialsv1beta1.Trial
+		mutatedPod *v1.Pod
+		wantError  error
+	}{
+		"Valid case for mutating Pod's env variable": {
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "training-container",
+						},
+					},
+				},
+			},
+			trial: &trialsv1beta1.Trial{
+				Spec: trialsv1beta1.TrialSpec{
+					PrimaryContainerName: "training-container",
+				},
+			},
+			mutatedPod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "training-container",
+							Env: []v1.EnvVar{
+								{
+									Name: consts.EnvTrialName,
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: fmt.Sprintf("metadata.labels['%s']", consts.LabelTrialName),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"Mismatch for Pod name and primaryContainerName in Trial": {
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "training-container",
+						},
+					},
+				},
+			},
+			trial: &trialsv1beta1.Trial{
+				Spec: trialsv1beta1.TrialSpec{
+					PrimaryContainerName: "training-containers",
+				},
+			},
+			mutatedPod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "training-container",
+						},
+					},
+				},
+			},
+			wantError: fmt.Errorf(
+				"Unable to find primary container %v in mutated pod containers %v",
+				"training-containers",
+				[]v1.Container{
+					{
+						Name: "training-container",
+					},
+				},
+			),
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			err := mutatePodEnv(testcase.pod, testcase.trial)
+			// Compare error with expected error
+			if testcase.wantError != nil && err != nil {
+				if diff := cmp.Diff(testcase.wantError.Error(), err.Error()); len(diff) != 0 {
+					t.Errorf("Unexpected error (-want,+got):\n%s", diff)
+				}
+			} else if testcase.wantError != nil || err != nil {
+				t.Errorf(
+					"Unexpected error (-want,+got):\n%s",
+					cmp.Diff(testcase.wantError, err, cmpopts.EquateErrors()),
+				)
+			}
+			// Compare Pod with expected pod after mutation
+			if diff := cmp.Diff(testcase.mutatedPod, testcase.pod, protocmp.Transform()); len(diff) != 0 {
+				t.Errorf("Unexpected mutated result (-want,+got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -186,6 +186,7 @@ class KatibClient(object):
         retain_trials: bool = False,
         packages_to_install: List[str] = None,
         pip_index_url: str = "https://pypi.org/simple",
+        metrics_collector_config: Dict[str, Any] = {"kind": "StdOut"},
     ):
         """Create HyperParameter Tuning Katib Experiment from the objective function.
 
@@ -248,6 +249,8 @@ class KatibClient(object):
                 to the base image packages. These packages are installed before
                 executing the objective function.
             pip_index_url: The PyPI url from which to install Python packages.
+            metrics_collector_config: Specify the config of metrics collector, 
+                for example, `metrics_collector_config = {"kind": "Push"}`.
 
         Raises:
             ValueError: Function arguments have incorrect type or value.
@@ -379,6 +382,19 @@ class KatibClient(object):
                     raise ValueError(
                         f"Incorrect value for env_per_trial: {env_per_trial}"
                     )
+
+        # Add metrics collector to the Katib Experiment.
+        # Up to now, We only support parameter `kind`, of which default value is `StdOut`, to specify the kind of metrics collector. 
+        experiment.spec.metrics_collector = models.V1beta1MetricsCollectorSpec(
+            collector=models.V1beta1CollectorSpec(kind=metrics_collector_config["kind"])
+        )
+        if metrics_collector_config["kind"] == "Push":
+            trial_params.append(
+                models.V1beta1TrialParameterSpec(name="trialName", reference="${{trialSpec.Name}}")
+            )
+            env.append(
+                client.V1EnvVar(name="KATIB_TRIAL_NAME", value="${{trialParameters.trialName}}")
+            )
 
         # Create Trial specification.
         trial_spec = client.V1Job(

--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -190,6 +190,8 @@ class KatibClient(object):
     ):
         """Create HyperParameter Tuning Katib Experiment from the objective function.
 
+        Katib always passes Trial name as env variable `KATIB_TRIAL_NAME` to the training container.
+
         Args:
             name: Name for the Experiment.
             objective: Objective function that Katib uses to train the model.
@@ -389,13 +391,14 @@ class KatibClient(object):
         experiment.spec.metrics_collector = models.V1beta1MetricsCollectorSpec(
             collector=models.V1beta1CollectorSpec(kind=metrics_collector_config["kind"])
         )
-        if metrics_collector_config["kind"] == "Push":
-            trial_params.append(
-                models.V1beta1TrialParameterSpec(name="trialName", reference="${{trialSpec.Name}}")
-            )
-            env.append(
-                client.V1EnvVar(name="KATIB_TRIAL_NAME", value="${{trialParameters.trialName}}")
-            )
+
+        # Pass Trial name as env variable `KATIB_TRIAL_NAME` to the training containers.
+        trial_params.append(
+            models.V1beta1TrialParameterSpec(name="trialName", reference="${{trialSpec.Name}}")
+        )
+        env.append(
+            client.V1EnvVar(name="KATIB_TRIAL_NAME", value="${{trialParameters.trialName}}")
+        )
 
         # Create Trial specification.
         trial_spec = client.V1Job(

--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -251,6 +251,7 @@ class KatibClient(object):
             pip_index_url: The PyPI url from which to install Python packages.
             metrics_collector_config: Specify the config of metrics collector, 
                 for example, `metrics_collector_config = {"kind": "Push"}`.
+                Currently, we only support `StdOut` and `Push` metrics collector.
 
         Raises:
             ValueError: Function arguments have incorrect type or value.

--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -190,8 +190,6 @@ class KatibClient(object):
     ):
         """Create HyperParameter Tuning Katib Experiment from the objective function.
 
-        Katib always passes Trial name as env variable `KATIB_TRIAL_NAME` to the training container.
-
         Args:
             name: Name for the Experiment.
             objective: Objective function that Katib uses to train the model.
@@ -390,14 +388,6 @@ class KatibClient(object):
         # Up to now, We only support parameter `kind`, of which default value is `StdOut`, to specify the kind of metrics collector. 
         experiment.spec.metrics_collector = models.V1beta1MetricsCollectorSpec(
             collector=models.V1beta1CollectorSpec(kind=metrics_collector_config["kind"])
-        )
-
-        # Pass Trial name as env variable `KATIB_TRIAL_NAME` to the training containers.
-        trial_params.append(
-            models.V1beta1TrialParameterSpec(name="trialName", reference="${{trialSpec.Name}}")
-        )
-        env.append(
-            client.V1EnvVar(name="KATIB_TRIAL_NAME", value="${{trialParameters.trialName}}")
         )
 
         # Create Trial specification.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

I add a new parameter `metrics_collector_config` to `tune` function. Design details: https://github.com/kubeflow/katib/blob/cc95ef03cb25df3d86a1a1c20c9c69bad17fce92/docs/proposals/push-based-metrics-collection.md#add-new-parameter-in-tune


**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
