### PR TITLE
Add command to re-run GitHub Actions tests

### DIFF
--- a/.github/workflows/trigger-rerun-test.yaml
+++ b/.github/workflows/trigger-rerun-test.yaml
@@ -1,0 +1,16 @@
+name: Re-Run PR Tests
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rerun_pr_tests:
+    name: rerun_pr_tests
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: estroz/rerun-actions@main
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          comment_id: ${{ github.event.comment.id }}


### PR DESCRIPTION
Followup on this KFP PR: https://github.com/kubeflow/pipelines/pull/10930

I added ability to re-run failed GitHub Actions without manually re-trigger them.
That allows contributors without GitHub write access to trigger the failed actions.

The following commands are supported by this action:

`/rerun-all` - rerun all failed workflows.
`/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified.

Reference: https://github.com/estroz/rerun-actions

/assign @kubeflow/wg-training-leads @rimolive 