### PR TITLE
fix: remove the dependency of `protocmp` in `google.golang.org/protobuf/testing/protocmp`.

### DIFF
--- a/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
+++ b/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
@@ -27,7 +27,6 @@ import (
 	commonv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
 	v1beta1 "github.com/kubeflow/katib/pkg/apis/manager/v1beta1"
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
-	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func TestCollectObservationLog(t *testing.T) {
@@ -321,7 +320,8 @@ invalid INFO     {metricName: loss, metricValue: 0.3634}`,
 			if diff := cmp.Diff(test.wantError, err, cmpopts.EquateErrors()); len(diff) != 0 {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
 			}
-			if diff := cmp.Diff(test.expected, actual, protocmp.Transform()); len(diff) != 0 {
+			observationLogCmpOpts := cmpopts.IgnoreUnexported(v1beta1.ObservationLog{}, v1beta1.MetricLog{}, v1beta1.Metric{})
+			if diff := cmp.Diff(test.expected, actual, observationLogCmpOpts); len(diff) != 0 {
 				t.Errorf("Unexpected parsed result (-want,+got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

We removed the dependency of `protocmp` in `google.golang.org/protobuf/testing/protocmp` by ignoring the unexported fields in `v1beta1.ObservationLog`(generated by grpc).

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #2389 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
