### PR TITLE
doc(example): fix the broken link.

### DIFF
--- a/examples/v1beta1/kubeflow-pipelines/README.md
+++ b/examples/v1beta1/kubeflow-pipelines/README.md
@@ -18,7 +18,7 @@ You have to install the following Python SDK to run these examples:
 The Notebooks examples run Pipelines in multi-user mode and your Kubeflow Notebook
 must have the appropriate `PodDefault` with the `pipelines.kubeflow.org` audience.
 
-Please follow [this guide](https://www.kubeflow.org/docs/components/pipelines/sdk/connect-api/#multi-user-mode)
+Please follow [this guide](https://www.kubeflow.org/docs/components/pipelines/operator-guides/multi-user/)
 to give an access Kubeflow Notebook to run Kubeflow Pipelines.
 
 ## List of Examples

--- a/examples/v1beta1/kubeflow-pipelines/README.md
+++ b/examples/v1beta1/kubeflow-pipelines/README.md
@@ -15,10 +15,9 @@ You have to install the following Python SDK to run these examples:
 
 ## Multi-User Pipelines Setup
 
-The Notebooks examples run Pipelines in multi-user mode and your Kubeflow Notebook
-must have the appropriate `PodDefault` with the `pipelines.kubeflow.org` audience.
+The Notebooks examples run Pipelines in multi-user mode and your Kubeflow Notebook must authenticate the Pipeline SDK.
 
-Please follow [this guide](https://www.kubeflow.org/docs/components/pipelines/operator-guides/multi-user/)
+Please follow [this guide](https://www.kubeflow.org/docs/components/pipelines/user-guides/core-functions/connect-api/)
 to give an access Kubeflow Notebook to run Kubeflow Pipelines.
 
 ## List of Examples


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/docs/developer-guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

As @yehudit1987 discussed with me in the Slack, there is a missing guide link in the environment setting section : https://github.com/kubeflow/katib/blob/master/examples/v1beta1/kubeflow-pipelines/README.md#multi-user-pipelines-setup 

We decided to fix it to make the guide accessible to new-comers.

cc👀 @yehudit1987 @kubeflow/wg-automl-leads 

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
