### PR TITLE
chore: supporting the listen-address parameter on db-manager

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,9 +88,10 @@ Below is a list of command-line flags accepted by Katib controller:
 
 Below is a list of command-line flags accepted by Katib DB Manager:
 
-| Name            | Type          | Default | Description                                             |
-| --------------- | ------------- | ------- | ------------------------------------------------------- |
-| connect-timeout | time.Duration | 60s     | Timeout before calling error during database connection |
+| Name            | Type          | Default      | Description                                                         |
+| --------------- | ------------- | -------------| ------------------------------------------------------------------- |
+| connect-timeout | time.Duration | 60s          | Timeout before calling error during database connection             |
+| listen-address  | string        | 0.0.0.0:6789 | The network interface or IP address to receive incoming connections |
 
 ## Katib admission webhooks
 

--- a/cmd/db-manager/v1beta1/main.go
+++ b/cmd/db-manager/v1beta1/main.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	port                  = "0.0.0.0:6789"
+	defaultListenAddress  = "0.0.0.0:6789"
 	defaultConnectTimeout = time.Second * 60
 )
 
@@ -90,7 +90,9 @@ func (s *server) Check(ctx context.Context, in *health_pb.HealthCheckRequest) (*
 
 func main() {
 	var connectTimeout time.Duration
+	var listenAddress string
 	flag.DurationVar(&connectTimeout, "connect-timeout", defaultConnectTimeout, "Timeout before calling error during database connection. (e.g. 120s)")
+	flag.StringVar(&listenAddress, "listen-address", defaultListenAddress, "The network interface or IP address to receive incoming connections. (e.g. 0.0.0.0:6789)")
 	flag.Parse()
 
 	var err error
@@ -104,13 +106,13 @@ func main() {
 		klog.Fatalf("Failed to open db connection: %v", err)
 	}
 	dbIf.DBInit()
-	listener, err := net.Listen("tcp", port)
+	listener, err := net.Listen("tcp", listenAddress)
 	if err != nil {
 		klog.Fatalf("Failed to listen: %v", err)
 	}
 
 	size := 1<<31 - 1
-	klog.Infof("Start Katib manager: %s", port)
+	klog.Infof("Start Katib manager: %s", listenAddress)
 	s := grpc.NewServer(grpc.MaxRecvMsgSize(size), grpc.MaxSendMsgSize(size))
 	api_pb.RegisterDBManagerServer(s, &server{})
 	health_pb.RegisterHealthServer(s, &server{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: I would like to be able to pass a different listen-address to handle other ports or even ipv6.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
