### PR TITLE
Set experiment names at a max of 40 characters. 

### DIFF
--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -82,10 +82,11 @@ func (g *DefaultValidator) ValidateExperiment(instance, oldInst *experimentsv1be
 	var allErrs field.ErrorList
 
 	namingConvention, _ := regexp.Compile("^[a-z]([-a-z0-9]*[a-z0-9])?")
-	if !namingConvention.MatchString(instance.Name) {
+	if !namingConvention.MatchString(instance.Name) || len(instance.Name) > 40 {
 		msg := "name must consist of lower case alphanumeric characters or '-'," +
 			" start with an alphabetic character, and end with an alphanumeric character" +
-			" (e.g. 'my-name', or 'abc-123', regex used for validation is '^[a-z]([-a-z0-9]*[a-z0-9])?)'"
+			" (e.g. 'my-name', or 'abc-123', regex used for validation is '^[a-z]([-a-z0-9]*[a-z0-9])?)'" +
+			" and may not be larger than 40 characters. "
 
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("name"), instance.Name, msg))
 	}

--- a/pkg/webhook/v1beta1/experiment/validator/validator_test.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator_test.go
@@ -86,6 +86,17 @@ func TestValidateExperiment(t *testing.T) {
 			},
 			testDescription: "Name is invalid",
 		},
+		{
+			instance: func() *experimentsv1beta1.Experiment {
+				i := newFakeInstance()
+				i.Name = "test-manymanymanyextracharactersthatgobeyondlimit"
+				return i
+			}(),
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("metadata").Child("name"), "", ""),
+			},
+			testDescription: "Name is invalid",
+		},
 		// Objective
 		{
 			instance: func() *experimentsv1beta1.Experiment {


### PR DESCRIPTION
**What this PR does / why we need it**:
As of now, the suggestion service does not start if the concatenation of algorithm and experiment name are more than 63 characters. The experiment gets created successfully on the dashboard, but never runs. This PR directly rejects all experiments with names longer than 40 characters. 

**Which issue(s) this PR fixes**:
Fixes #2454 

**Checklist:**
- [ X ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing

**Previous Behavior:**
Would successfully allow the experiment to be submitted, and would also create the experiment. However, the suggestion service would crash silently with no error output.

**New Behavior:**
Throws the following error message:
```
Error from server: error when creating "../experiments/test.yaml": admission webhook "validator.experiment.katib.kubeflow.org" denied the request: metadata.name: Invalid value: "testveryveryverylargenamefillercharactersmorefillerspaces": name must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name', or 'abc-123', regex used for validation is '^[a-z]([-a-z0-9]*[a-z0-9])?)' and may not be larger than 40 characters.
```