### PR TITLE
Upgrade grpcio version to v1.64.1

### DIFF
--- a/cmd/earlystopping/medianstop/v1beta1/requirements.txt
+++ b/cmd/earlystopping/medianstop/v1beta1/requirements.txt
@@ -1,4 +1,4 @@
-grpcio>=1.41.1
+grpcio>=1.64.1
 protobuf>=4.21.12,<5
 googleapis-common-protos==1.6.0
 kubernetes==22.6.0

--- a/cmd/metricscollector/v1beta1/tfevent-metricscollector/requirements.txt
+++ b/cmd/metricscollector/v1beta1/tfevent-metricscollector/requirements.txt
@@ -1,6 +1,6 @@
 psutil==5.9.4
 rfc3339>=6.2
-grpcio>=1.41.1
+grpcio>=1.64.1
 googleapis-common-protos==1.6.0
 tensorflow==2.16.1
 protobuf>=4.21.12,<5

--- a/cmd/suggestion/hyperband/v1beta1/requirements.txt
+++ b/cmd/suggestion/hyperband/v1beta1/requirements.txt
@@ -1,4 +1,4 @@
-grpcio>=1.41.1
+grpcio>=1.64.1
 cloudpickle==0.5.6
 numpy>=1.25.2
 scikit-learn>=0.24.0

--- a/cmd/suggestion/hyperopt/v1beta1/requirements.txt
+++ b/cmd/suggestion/hyperopt/v1beta1/requirements.txt
@@ -1,4 +1,4 @@
-grpcio>=1.41.1
+grpcio>=1.64.1
 cloudpickle==0.5.6
 numpy>=1.25.2
 scikit-learn>=0.24.0

--- a/cmd/suggestion/nas/darts/v1beta1/requirements.txt
+++ b/cmd/suggestion/nas/darts/v1beta1/requirements.txt
@@ -1,4 +1,4 @@
-grpcio>=1.41.1
+grpcio>=1.64.1
 protobuf>=4.21.12,<5
 googleapis-common-protos==1.6.0
 cython>=0.29.24

--- a/cmd/suggestion/nas/enas/v1beta1/requirements.txt
+++ b/cmd/suggestion/nas/enas/v1beta1/requirements.txt
@@ -1,4 +1,4 @@
-grpcio>=1.41.1
+grpcio>=1.64.1
 googleapis-common-protos==1.6.0
 cython>=0.29.24
 tensorflow==2.16.1

--- a/cmd/suggestion/optuna/v1beta1/requirements.txt
+++ b/cmd/suggestion/optuna/v1beta1/requirements.txt
@@ -1,4 +1,4 @@
-grpcio>=1.41.1
+grpcio>=1.64.1
 protobuf>=4.21.12,<5
 googleapis-common-protos==1.53.0
 optuna==3.3.0

--- a/cmd/suggestion/pbt/v1beta1/requirements.txt
+++ b/cmd/suggestion/pbt/v1beta1/requirements.txt
@@ -1,4 +1,4 @@
-grpcio>=1.41.1
+grpcio>=1.64.1
 protobuf>=4.21.12,<5
 googleapis-common-protos==1.53.0
 numpy==1.25.2

--- a/cmd/suggestion/skopt/v1beta1/requirements.txt
+++ b/cmd/suggestion/skopt/v1beta1/requirements.txt
@@ -1,4 +1,4 @@
-grpcio>=1.41.1
+grpcio>=1.64.1
 cloudpickle==0.5.6
 # This is a workaround to avoid the following error.
 # AttributeError: module 'numpy' has no attribute 'int'

--- a/sdk/python/v1beta1/setup.py
+++ b/sdk/python/v1beta1/setup.py
@@ -23,7 +23,7 @@ REQUIRES = [
     "setuptools>=21.0.0",
     "urllib3>=1.15.1",
     "kubernetes>=27.2.0",
-    "grpcio>=1.41.1",
+    "grpcio>=1.64.1",
     "protobuf>=4.21.12,<5",
 ]
 

--- a/test/unit/v1beta1/requirements.txt
+++ b/test/unit/v1beta1/requirements.txt
@@ -1,2 +1,2 @@
-grpcio-testing==1.41.1
+grpcio-testing==1.64.1
 pytest==7.2.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

After #2344 got merged, our python grpc client is generated by `buf.build/grpc/python:v1.64.1`. However, our Python SDK still uses `grpcio>=1.41.1`, resulting in some errors like #2427.

This is due to the update of [grpcio packge](https://github.com/grpc/grpc/releases/tag/v1.64.0) (the corresponding PR is https://github.com/grpc/grpc/pull/36371). In v1.64.0, grpcio introduced a parameter `__register_method` to `unary_unary`, which would be called by grpc client  in:

https://github.com/kubeflow/katib/blob/eb8af4d50266b51c77ea895585ff535c8e9137f9/pkg/apis/manager/v1beta1/python/api_pb2_grpc.py#L19-L23

And in `tensorflow/tensorflow:2.13.0`, the `grpcio` version is `v1.56.0` while in `tensorflow/tensorflow:2.17.0` the version is `v1.64.1`. So the error occurred in `tensorflow/tensorflow:2.13.0`, but not in `tensorflow/tensorflow:2.17.0`.

Given the fact that `grpcio` version is outdated, I upgrade the `grpcio` version to `v1.64.1`

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #2427

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing

/cc @kubeflow/wg-automl-leads @helenxie-bit @tariq-hasan 
