### PR TITLE
Ignore cache exporting errors in the image building workflows

### DIFF
--- a/.github/workflows/template-publish-image/action.yaml
+++ b/.github/workflows/template-publish-image/action.yaml
@@ -58,5 +58,5 @@ runs:
         push: ${{ inputs.push }}
         tags: ${{ steps.meta.outputs.tags }}
         cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-to: type=gha,mode=max,ignore-error=true
         platforms: ${{ inputs.platforms }}


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to manually rerun CI jobs due to cache exporting errors:
```
#33 exporting to GitHub Actions Cache
#33 preparing build cache for export
#33 writing layer sha256:043014c17c0e213c5220cb1c47f39ba308ecad3e3d912504a1f69cc0689bdcdd
#33 preparing build cache for export 865.0s done
#33 writing layer sha256:043014c17c0e213c5220cb1c47f39ba308ecad3e3d912504a1f69cc0689bdcdd 600.1s done
#33 ERROR: error writing layer blob: maximum timeout reached
```
We can ignore this with `ignore-error=true`, following [this guide](https://docs.docker.com/build/cache/backends/gha/#synopsis). Same work is done in https://github.com/kubeflow/training-operator/pull/2336

**Which issue(s) this PR fixes** :
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
