### PR TITLE
Add KATIB_EXPERIMENT_NAME to pod env.

### DIFF
--- a/pkg/controller.v1beta1/consts/const.go
+++ b/pkg/controller.v1beta1/consts/const.go
@@ -62,6 +62,8 @@ const (
 
 	// EnvTrialName is the env variable of Trial name
 	EnvTrialName = "KATIB_TRIAL_NAME"
+	// EnvExperimentName is the env variable of Experiment name
+	EnvExperimentName = "KATIB_EXPERIMENT_NAME"
 
 	// LabelExperimentName is the label of experiment name.
 	LabelExperimentName = "katib.kubeflow.org/experiment"

--- a/pkg/webhook/v1beta1/pod/inject_webhook_test.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook_test.go
@@ -1094,6 +1094,14 @@ func TestMutatePodEnv(t *testing.T) {
 										},
 									},
 								},
+								{
+									Name: consts.EnvExperimentName,
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: fmt.Sprintf("metadata.labels['%s']", consts.LabelExperimentName),
+										},
+									},
+								},
 							},
 						},
 					},

--- a/pkg/webhook/v1beta1/pod/utils.go
+++ b/pkg/webhook/v1beta1/pod/utils.go
@@ -313,7 +313,7 @@ func mutatePodEnv(pod *v1.Pod, trial *trialsv1beta1.Trial) error {
 		)
 		return nil
 	} else {
-		return fmt.Errorf("unable to find primary container %v in mutated pod containers %v",
+		return fmt.Errorf("Unable to find primary container %v in mutated pod containers %v",
 			trial.Spec.PrimaryContainerName, pod.Spec.Containers)
 	}
 }

--- a/pkg/webhook/v1beta1/pod/utils.go
+++ b/pkg/webhook/v1beta1/pod/utils.go
@@ -291,7 +291,7 @@ func mutatePodEnv(pod *v1.Pod, trial *trialsv1beta1.Trial) error {
 			pod.Spec.Containers[index].Env = []v1.EnvVar{}
 		}
 
-		// Pass env variable KATIB_TRIAL_NAME to the primary container using fieldPath
+		// Pass env variable KATIB_TRIAL_NAME and KATIB_EXPERIMENT_NAME to the primary container using fieldPath
 		pod.Spec.Containers[index].Env = append(
 			pod.Spec.Containers[index].Env,
 			v1.EnvVar{
@@ -302,10 +302,18 @@ func mutatePodEnv(pod *v1.Pod, trial *trialsv1beta1.Trial) error {
 					},
 				},
 			},
+			v1.EnvVar{
+				Name: consts.EnvExperimentName,
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						FieldPath: fmt.Sprintf("metadata.labels['%s']", consts.LabelExperimentName),
+					},
+				},
+			},
 		)
 		return nil
 	} else {
-		return fmt.Errorf("Unable to find primary container %v in mutated pod containers %v",
+		return fmt.Errorf("unable to find primary container %v in mutated pod containers %v",
 			trial.Spec.PrimaryContainerName, pod.Spec.Containers)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Users sometimes may need experiment metadata for their customized applications like: https://github.com/kubeflow/katib/issues/2473

As we discussed in https://github.com/kubeflow/katib/issues/2390, we can get namespace of experiment from: 

```
/var/run/secrets/kubernetes.io/serviceaccount/namespace
```

So we only need to pass experiment name as `KATIB_EXPERIMENT_NAME` to the Pod Env just like `KATIB_TRIAL_NAME`:)

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #2473
Also related to: https://github.com/kubeflow/katib/issues/2390

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing

/cc @kubeflow/wg-automl-leads @mickvangelderen @helenxie-bit @tariq-hasan 
