### PR TITLE
[SDK] Fix namespace label

### DIFF
--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -377,9 +377,13 @@ class KatibClient(object):
 
         namespace = namespace or self.namespace
         namespace_labels = client.CoreV1Api().read_namespace(namespace).metadata.labels
-        if 'katib.kubeflow.org/metrics-collector-injection' not in namespace_labels:
-            namespace_labels['katib.kubeflow.org/metrics-collector-injection'] = 'enabled'
-            client.CoreV1Api().patch_namespace(namespace, {'metadata': {'labels': namespace_labels}})
+        if "katib.kubeflow.org/metrics-collector-injection" not in namespace_labels:
+            namespace_labels["katib.kubeflow.org/metrics-collector-injection"] = (
+                "enabled"
+            )
+            client.CoreV1Api().patch_namespace(
+                namespace, {"metadata": {"labels": namespace_labels}}
+            )
 
         # Create Katib Experiment template.
         experiment = models.V1beta1Experiment(

--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -376,6 +376,10 @@ class KatibClient(object):
             raise ValueError("Please specify name for the Experiment.")
 
         namespace = namespace or self.namespace
+        namespace_labels = client.CoreV1Api().read_namespace(namespace).metadata.labels
+        if 'katib.kubeflow.org/metrics-collector-injection' not in namespace_labels:
+            namespace_labels['katib.kubeflow.org/metrics-collector-injection'] = 'enabled'
+            client.CoreV1Api().patch_namespace(namespace, {'metadata': {'labels': namespace_labels}})
 
         # Create Katib Experiment template.
         experiment = models.V1beta1Experiment(


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the error `the namespace lacks label \"katib.kubeflow.org/metrics-collector-injection: enabled\"` when using Katib SDK to create Experiment.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #2492 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
