### PR TITLE
Sort experiments by descending creation date by default in katib-ui

### DIFF
--- a/pkg/ui/v1beta1/frontend/cypress/e2e/index-page.cy.ts
+++ b/pkg/ui/v1beta1/frontend/cypress/e2e/index-page.cy.ts
@@ -37,7 +37,9 @@ describe('Index page', () => {
     // Experiment objects are sorted alphabetically by name
     // We sort them by startTime in descending
     const sortedExperiments = [...experiments].sort((a, b) => {
-      return b.startTime.getTime() - a.startTime.getTime();
+      const timeA = new Date(a.startTime).getTime();
+      const timeB = new Date(b.startTime).getTime();
+      return timeB - timeA;
     });
     
     // Table is sorted by startTime in descending order

--- a/pkg/ui/v1beta1/frontend/cypress/e2e/index-page.cy.ts
+++ b/pkg/ui/v1beta1/frontend/cypress/e2e/index-page.cy.ts
@@ -33,10 +33,16 @@ describe('Index page', () => {
 
     let i = 0;
     const experiments = this.experimentsRequest;
-    // Table is sorted by Name in ascending order by default
-    // and experiment objects are also sorted alphabetically by name
+
+    // Experiment objects are sorted alphabetically by name
+    // We sort them by startTime in descending
+    const sortedExperiments = [...experiments].sort((a, b) => {
+      return b.startTime.getTime() - a.startTime.getTime();
+    });
+    
+    // Table is sorted by startTime in descending order
     cy.get(`[data-cy-resource-table-row="Name"]`).each(element => {
-      expect(element).to.contain(experiments[i].name);
+      expect(element).to.contain(sortedExperiments[i].name);
       i++;
     });
   });

--- a/pkg/ui/v1beta1/frontend/src/app/pages/experiments/config.ts
+++ b/pkg/ui/v1beta1/frontend/src/app/pages/experiments/config.ts
@@ -95,4 +95,6 @@ export const experimentsTableConfig: TableConfig = {
       ]),
     },
   ],
+  sortByColumn: 'age',
+  sortDirection: 'desc',
 };


### PR DESCRIPTION

**What this PR does / why we need it**:
Showing experiments from newest to oldest by default instead of sorting them by name. 
Now the experiments are initially shown as follows:
<img width="1269" alt="2025-01-21 17 02 21" src="https://github.com/user-attachments/assets/453a8a52-4aad-42f5-bbba-357eb61ebba8" />


**Which issue(s) this PR fixes** :
Fixes #2475 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
