### PR TITLE
Install typing-extensions v4.10.0 to fix Python test error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ prepare-pytest:
 	# The sqlalchemy on which optuna depends requires typing-extensions>=4.6.0.
 	# REF: https://github.com/kubeflow/katib/pull/2251
 	# TODO (tenzen-y): Once we upgrade libraries depended on typing-extensions==4.5.0, we can remove this line.
-	pip install typing-extensions==4.6.3
+	pip install typing-extensions==4.10.0
 
 prepare-pytest-testdata:
 ifeq ("$(wildcard $(TEST_TENSORFLOW_EVENT_FILE_PATH))", "")

--- a/Makefile
+++ b/Makefile
@@ -160,8 +160,8 @@ prepare-pytest:
 	pip install --prefer-binary -r cmd/suggestion/pbt/v1beta1/requirements.txt
 	pip install --prefer-binary -r cmd/earlystopping/medianstop/v1beta1/requirements.txt
 	pip install --prefer-binary -r cmd/metricscollector/v1beta1/tfevent-metricscollector/requirements.txt
-	# The sqlalchemy on which optuna depends requires typing-extensions>=4.6.0.
-	# REF: https://github.com/kubeflow/katib/pull/2251
+	# `TypeIs` was introduced in typing-extensions 4.10.0, and torch 2.6.0 requires typing-extensions>=4.10.0.
+	# REF: https://github.com/kubeflow/katib/pull/2504
 	# TODO (tenzen-y): Once we upgrade libraries depended on typing-extensions==4.5.0, we can remove this line.
 	pip install typing-extensions==4.10.0
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to install typing-extensions v4.10.0 or newer to resolve the following CI error:
```
from typing_extensions import TypeIs as _TypeIs
E   ImportError: cannot import name 'TypeIs' from 'typing_extensions'
```
The root cause is that `TypeIs` was introduced in version 4.10.0 according to the typing-extensions documentation, and torch 2.6.0 requires typing-extensions>=4.10.0, 

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #2503

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
