### PR TITLE
feat(sdk): support volume mount in tune API

### DIFF
--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -532,6 +532,8 @@ class KatibClient(object):
             if storage_per_trial:
                 if isinstance(storage_per_trial, dict):
                     storage_per_trial = [storage_per_trial]
+                elif not isinstance(storage_per_trial, list):
+                    raise ValueError("storage_per_trial must be a list of dictionaries")
                 for storage in storage_per_trial:
                     volume = None
                     if isinstance(storage["volume"], client.V1Volume):

--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client_test.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client_test.py
@@ -405,6 +405,50 @@ test_tune_data = [
         ValueError,
     ),
     (
+        "invalid storage_per_trial - type mismatch",
+        {
+            "name": "tune_test",
+            "objective": lambda x: print(f"a={x}"),
+            "parameters": {"a": katib.search.int(min=10, max=100)},
+            "storage_per_trial": "invalid",
+        },
+        ValueError,
+    ),
+    (
+        "invalid storage_per_trial - volume has no name",
+        {
+            "name": "tune_test",
+            "objective": lambda x: print(f"a={x}"),
+            "parameters": {"a": katib.search.int(min=10, max=100)},
+            "storage_per_trial": [
+                {
+                    "volume": {
+                        # do not provide name
+                        "type": "pvc",
+                    }
+                }
+            ],
+        },
+        ValueError,
+    ),
+    (
+        "invalid storage_per_trial - volume has no type",
+        {
+            "name": "tune_test",
+            "objective": lambda x: print(f"a={x}"),
+            "parameters": {"a": katib.search.int(min=10, max=100)},
+            "storage_per_trial": [
+                {
+                    "volume": {
+                        "name": "test-pvc",
+                        # do not provide type
+                    }
+                }
+            ],
+        },
+        ValueError,
+    ),
+    (
         "invalid model_provider_parameters",
         {
             "name": "tune_test",


### PR DESCRIPTION
**What this PR does / why we need it**:

As discussed on #2247 , providing a clean and simple way for specifying volume mount in `tune` API of katib Python SDK will enhance develop experience.

This PR adds `storage_per_trial` argument to `KatibClient.tune()` method. 

## Design

The `storage_per_trial` argument is designed to have the following type:

```python
List[TypedDict({
    "volume": client.V1Volume,
    "mount_path": client.V1VolumeMount,
})]
```

To simplify the usage, there are some enhancements:

1. User can omit the outer list wrapper if there is only one storage to be mount. This optimization change the type of `storage_per_trial` to: `Union[TuneStoragePerTrial, List[TuneStoragePerTrial]]`
2. User can specify a `dict` instead of a `client.V1Volume` object when the storage config is simple:
    ```python
    {
         "name": "volume-name",  # Required: Name of the volume
         "type": "pvc|secret|config_map|empty_dir",  # Required: Volume type
         # Optional fields based on type:
         # For PVC:
         "claim_name": "pvc-name",
         "read_only": False,
         # For Secret:
         "secret_name": "secret-name", 
         "items": [...],
         "default_mode": 0644,
         "optional": False,
         # For ConfigMap:
         "config_map_name": "config-name",
         "items": [...],
         "default_mode": 0644,
         "optional": False,
         # For EmptyDir:
         "medium": None,
         "size_limit": None
     }
    ```
3. User can specify `mount_path` with a `str` instead of `client.V1VolumeMount`

## Example Usage

```
storage_per_trial = [
    {
        "volume": {
            "name": "data",
            "type": "pvc",
            "claim_name": "my-data-pvc"
        },
        "mount_path": "/data"
    },
    {
        "volume": {
            "name": "config",
            "type": "config_map",
            "config_map_name": "model-config"
        },
        "mount_path": "/etc/config"
    }
]
```

<details>
<summary>Full Example</summary>


```python
import kubeflow.katib as katib
from kubernetes import client
import json
import base64

VOLUME_NAME = "katib-secret-volume"
SECRET_NAME = "katib-secret-test"

# create the secret (for testing purposes, optional)
secret = client.V1Secret(
    metadata=client.V1ObjectMeta(name=SECRET_NAME),
    data={
        "credentials.json": base64.b64encode(
            json.dumps({"username": "admin", "password": "password"}).encode()
        ).decode()
    },
)
# client.CoreV1Api().create_namespaced_secret(namespace="kubeflow", body=secret)


def objective(parameters):
    import os

    result = 4 * int(parameters["x"]) - float(parameters["y"]) ** 2
    # The result will be negative if the secret is mounted successfully
    if os.path.exists("/secret/credentials.json"):
        result *= -1
    print(f"result={result}")


parameters = {
    "x": katib.search.int(min=10, max=20),
    "y": katib.search.double(min=0.1, max=0.2),
}


katib_client = katib.KatibClient(namespace="kubeflow")

storage_per_trial = {
    "volume": {
        "name": VOLUME_NAME,
        "type": "secret",
        "secret_name": SECRET_NAME,
    },
    "mount_path": "/secret",
}

name = "katib-experiment-secret"
katib_client.tune(
    name=name,
    parameters=parameters,
    objective=objective,
    objective_metric_name="result",
    max_trial_count=12,
    resources_per_trial={"cpu": "2"},
    storage_per_trial=storage_per_trial,
)

katib_client.wait_for_experiment_condition(name=name)
print(katib_client.get_optimal_hyperparameters(name=name))
```

</details>

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #2247 

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
- [x] Support mounting volume
- [x] Documenting usage of `storage_per_trial`
