### PR TITLE
FIX secrets and mysql app selector for kubeflow install

### DIFF
--- a/manifests/v1beta1/installs/katib-cert-manager/certificate.yaml
+++ b/manifests/v1beta1/installs/katib-cert-manager/certificate.yaml
@@ -5,10 +5,10 @@ metadata:
   name: katib-webhook-cert
 spec:
   isCA: true
-  commonName: $(KATIB_SERVICE_NAME).$(KATIB_NAMESPACE).svc
+  commonName: KATIB_SERVICE_NAME_PLACEHOLDER.KATIB_NAMESPACE_PLACEHOLDER.svc
   dnsNames:
-    - $(KATIB_SERVICE_NAME).$(KATIB_NAMESPACE).svc
-    - $(KATIB_SERVICE_NAME).$(KATIB_NAMESPACE).svc.cluster.local
+    - KATIB_SERVICE_NAME_PLACEHOLDER.KATIB_NAMESPACE_PLACEHOLDER.svc
+    - KATIB_SERVICE_NAME_PLACEHOLDER.KATIB_NAMESPACE_PLACEHOLDER.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: katib-selfsigned-issuer

--- a/manifests/v1beta1/installs/katib-cert-manager/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-cert-manager/kustomization.yaml
@@ -30,32 +30,115 @@ images:
     newName: docker.io/kubeflowkatib/katib-ui
     newTag: latest
 
-patchesStrategicMerge:
-  - patches/katib-cert-injection.yaml
-
-vars:
-  - fieldref:
-      fieldPath: metadata.namespace
-    name: KATIB_NAMESPACE
-    objref:
-      apiVersion: v1
-      kind: Service
-      name: katib-controller
-  - fieldref:
-      fieldPath: metadata.name
-    name: KATIB_SERVICE_NAME
-    objref:
-      apiVersion: v1
-      kind: Service
-      name: katib-controller
-  - name: KATIB_CERT_NAME
-    objref:
-      kind: Certificate
+patches:
+- path: patches/katib-cert-injection.yaml
+replacements:
+- source:
+    fieldPath: metadata.namespace
+    kind: Service
+    name: katib-controller
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.commonName
+    options:
+      delimiter: .
+      index: 1
+    select:
       group: cert-manager.io
-      version: v1
+      kind: Certificate
       name: katib-webhook-cert
-    fieldref:
-      fieldpath: metadata.name
+      version: v1
+  - fieldPaths:
+    - spec.dnsNames.0
+    options:
+      delimiter: .
+      index: 1
+    select:
+      group: cert-manager.io
+      kind: Certificate
+      name: katib-webhook-cert
+      version: v1
+  - fieldPaths:
+    - spec.dnsNames.1
+    options:
+      delimiter: .
+      index: 1
+    select:
+      group: cert-manager.io
+      kind: Certificate
+      name: katib-webhook-cert
+      version: v1
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: katib.kubeflow.org
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      kind: MutatingWebhookConfiguration
+      name: katib.kubeflow.org
+- source:
+    fieldPath: metadata.name
+    kind: Service
+    name: katib-controller
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.commonName
+    options:
+      delimiter: .
+    select:
+      group: cert-manager.io
+      kind: Certificate
+      name: katib-webhook-cert
+      version: v1
+  - fieldPaths:
+    - spec.dnsNames.0
+    options:
+      delimiter: .
+    select:
+      group: cert-manager.io
+      kind: Certificate
+      name: katib-webhook-cert
+      version: v1
+  - fieldPaths:
+    - spec.dnsNames.1
+    options:
+      delimiter: .
+    select:
+      group: cert-manager.io
+      kind: Certificate
+      name: katib-webhook-cert
+      version: v1
+- source:
+    fieldPath: metadata.name
+    kind: Certificate
+    name: katib-webhook-cert
+  targets:
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      kind: ValidatingWebhookConfiguration
+      name: katib.kubeflow.org
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+    select:
+      kind: MutatingWebhookConfiguration
+      name: katib.kubeflow.org
 
 configurations:
   - params.yaml

--- a/manifests/v1beta1/installs/katib-cert-manager/patches/katib-cert-injection.yaml
+++ b/manifests/v1beta1/installs/katib-cert-manager/patches/katib-cert-injection.yaml
@@ -4,11 +4,11 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: katib.kubeflow.org
   annotations:
-    cert-manager.io/inject-ca-from: $(KATIB_NAMESPACE)/$(KATIB_CERT_NAME)
+    cert-manager.io/inject-ca-from: KATIB_NAMESPACE_PLACEHOLDER/KATIB_CERT_NAME_PLACEHOLDER
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: katib.kubeflow.org
   annotations:
-    cert-manager.io/inject-ca-from: $(KATIB_NAMESPACE)/$(KATIB_CERT_NAME)
+    cert-manager.io/inject-ca-from: KATIB_NAMESPACE_PLACEHOLDER/KATIB_CERT_NAME_PLACEHOLDER

--- a/manifests/v1beta1/installs/katib-external-db/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-external-db/kustomization.yaml
@@ -25,8 +25,8 @@ images:
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
     newTag: latest
-patchesStrategicMerge:
-  - patches/db-manager.yaml
+patches:
+- path: patches/db-manager.yaml
 # Modify katib-mysql-secrets with parameters for the DB.
 secretGenerator:
   - name: katib-mysql-secrets

--- a/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
@@ -42,6 +42,17 @@ patches:
       kind: Deployment
       name: katib-ui
     path: patches/istio-sidecar-injection.yaml
+  # Use mysql secrets, since katib-mysql is not used, only the already existing mysql
+  - target:
+      kind: Deployment
+      name: katib-db-manager
+    path: patches/katib-db-manager-env.yaml
+  # Fix select the app mysql
+  - target:
+      kind: Service
+      name: katib-mysql
+      namespace: kubeflow
+    path: patches/katib-mysql-service-select-app.yaml
 
 vars:
   - fieldref:

--- a/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/kustomization.yaml
@@ -11,18 +11,16 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: latest
+    newTag: v0.17.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: latest
+    newTag: v0.17.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: latest
-
-patchesStrategicMerge:
-  - patches/remove-namespace.yaml
+    newTag: v0.17.0
 
 patches:
+  - path: patches/remove-namespace.yaml
   # Extend RBAC permission list of katib-ui so it can
   # create SubjectAccessReview resources.
   - target:
@@ -54,14 +52,24 @@ patches:
       namespace: kubeflow
     path: patches/katib-mysql-service-select-app.yaml
 
-vars:
-  - fieldref:
-      fieldPath: metadata.namespace
-    name: KATIB_UI_NAMESPACE
-    objref:
-      apiVersion: apps/v1
-      kind: Deployment
+replacements:
+- source:
+    fieldPath: metadata.namespace
+    group: apps
+    kind: Deployment
+    name: katib-ui
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.http.0.route.0.destination.host
+    options:
+      delimiter: .
+      index: 1
+    select:
+      group: networking.istio.io
+      kind: VirtualService
       name: katib-ui
+      version: v1alpha3
 
 configurations:
   - params.yaml

--- a/manifests/v1beta1/installs/katib-with-kubeflow/patches/katib-db-manager-env.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/patches/katib-db-manager-env.yaml
@@ -1,0 +1,16 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/0/env
+  value:
+    - name: DB_NAME
+      value: mysql
+    - name: DB_USER
+      valueFrom:
+        secretKeyRef:
+          key: username
+          name: mysql-secret
+    - name: DB_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          key: password
+          name: mysql-secret

--- a/manifests/v1beta1/installs/katib-with-kubeflow/patches/katib-mysql-service-select-app.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/patches/katib-mysql-service-select-app.yaml
@@ -1,0 +1,5 @@
+---
+- op: replace
+  path: /spec/selector
+  value:
+    app: mysql

--- a/manifests/v1beta1/installs/katib-with-kubeflow/ui-virtual-service.yaml
+++ b/manifests/v1beta1/installs/katib-with-kubeflow/ui-virtual-service.yaml
@@ -16,6 +16,6 @@ spec:
         uri: /katib/
       route:
         - destination:
-            host: katib-ui.$(KATIB_UI_NAMESPACE).svc.cluster.local
+            host: katib-ui.KATIB_UI_NAMESPACE_PLACEHOLDER.svc.cluster.local
             port:
               number: 80


### PR DESCRIPTION
This is the original [PR (with linked issue)](https://github.com/kubeflow/manifests/pull/2981) that originated these changes.

FOR REVIEWERS: the first commit is the relevant one, the second is fixing deprecation warnings from patcheStrategicMerge and vars.