### PR TITLE
Bump Katib Python SDK to 0.18.0rc0 version

### DIFF
--- a/sdk/python/v1beta1/setup.py
+++ b/sdk/python/v1beta1/setup.py
@@ -56,7 +56,7 @@ if os.path.exists(katib_grpc_svc_file):
 
 setuptools.setup(
     name="kubeflow-katib",
-    version="0.17.0",
+    version="0.18.0rc0",
     author="Kubeflow Authors",
     author_email="premnath.vel@gmail.com",
     license="Apache License Version 2.0",


### PR DESCRIPTION
Part of: https://github.com/kubeflow/katib/issues/2386.

Updating SDK version to the latest release.

/assign @kubeflow/wg-training-leads @Electronic-Waste @helenxie-bit 