### PR TITLE
stop running e2etest when katib not available

### DIFF
--- a/test/e2e/v1beta1/scripts/gh-actions/run-e2e-tune-api.sh
+++ b/test/e2e/v1beta1/scripts/gh-actions/run-e2e-tune-api.sh
@@ -34,7 +34,7 @@ kubectl get pvc -n kubeflow
 echo "Available CRDs"
 kubectl get crd
 
-# check if the katib pods are running
+# check if the katib pods are running.
 if ! kubectl get pods -n kubeflow | grep -q "katib-controller"; then
     echo "katib is not available. Exiting test."
     exit 1 

--- a/test/e2e/v1beta1/scripts/gh-actions/run-e2e-tune-api.sh
+++ b/test/e2e/v1beta1/scripts/gh-actions/run-e2e-tune-api.sh
@@ -34,5 +34,11 @@ kubectl get pvc -n kubeflow
 echo "Available CRDs"
 kubectl get crd
 
+# check if the katib pods are running
+if ! kubectl get pods -n kubeflow | grep -q "katib-controller"; then
+    echo "katib is not available. Exiting test."
+    exit 1 
+fi
+
 python run-e2e-tune-api.py --namespace default \
 --verbose || (kubectl get pods -n kubeflow && exit 1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This Changes affect to the e2e test.
Previous behavior : when we run e2e test it continue testing even if the Katib is not available 
Current behavior : now if the Katib is not available it will stop testing and if the katib is available only then it move further.

Fixes #2513 

