### PR TITLE
[SDK] fix issue with serialization of LoraConfig

### DIFF
--- a/sdk/python/v1beta1/kubeflow/katib/utils/utils.py
+++ b/sdk/python/v1beta1/kubeflow/katib/utils/utils.py
@@ -188,8 +188,9 @@ def get_trial_substitutions_from_trainer(
     if isinstance(parameters, TrainingArguments):
         parameters_dict = parameters.to_dict()
     else:
-        parameters_dict = parameters.__dict__
-
+        parameters_dict = (
+            parameters.to_dict() if hasattr(parameters, "to_dict") else vars(parameters)
+        )
     for p_name, p_value in parameters_dict.items():
         if not hasattr(parameters, p_name):
             logger.warning(f"Training parameter {p_name} is not supported.")
@@ -218,7 +219,11 @@ def get_trial_substitutions_from_trainer(
     if isinstance(parameters, TrainingArguments):
         parameters = json.dumps(parameters.to_dict())
     else:
-        parameters = json.dumps(parameters.__dict__, cls=SetEncoder)
+        parameters = (
+            json.dumps(parameters.to_dict(), cls=SetEncoder)
+            if hasattr(parameters, "to_dict")
+            else json.dumps(vars(parameters), cls=SetEncoder)
+        )
 
     return parameters
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Improve JSON serialization to fix issue occuring when following https://www.kubeflow.org/docs/components/katib/user-guides/llm-hp-optimization/, among other guides. Currently, running the example code with the latest versions of katib sdk  peft and transformers, would result in an error of `TypeError: Object of type LoraRuntimeConfig is not JSON serializable`. Now, it will correctly use .to_dict when available, and __dict__ otherwise for non TrainingArgument types


