### PR TITLE
fix(controller): Fix RBAC to create TrainJobs

### DIFF
--- a/manifests/v1beta1/components/controller/rbac.yaml
+++ b/manifests/v1beta1/components/controller/rbac.yaml
@@ -107,6 +107,7 @@ rules:
       - "get"
       - "list"
       - "watch"
+      - "delete"
   - apiGroups:
       - kubeflow.org
     resources:


### PR DESCRIPTION
Katib's Trial controller should have access to create and delete TrainJobs.


/assign @Electronic-Waste @johnugeorge @kubeflow/kubeflow-sdk-team @kubeflow/kubeflow-trainer-team 