### PR TITLE
Bug Fix: Resolved “value used before assignment” issue in get_trial_s…

### DIFF
--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -665,9 +665,9 @@ class KatibClient(object):
                     "--dataset_dir",
                     VOLUME_PATH_DATASET,
                     "--lora_config",
-                    f"'{lora_config}'",
+                    lora_config,
                     "--training_parameters",
-                    f"'{training_args}'",
+                    training_args,
                 ],
                 volume_mounts=[STORAGE_INITIALIZER_VOLUME_MOUNT],
                 resources=(

--- a/sdk/python/v1beta1/kubeflow/katib/utils/utils.py
+++ b/sdk/python/v1beta1/kubeflow/katib/utils/utils.py
@@ -192,7 +192,7 @@ def get_trial_substitutions_from_trainer(
     parameters: Union["TrainingArguments", "LoraConfig"],  # noqa: F821
     experiment_params: List[models.V1beta1ParameterSpec],
     trial_params: List[models.V1beta1TrialParameterSpec],
-) -> Dict[str, str]:
+) -> str:
     from peft import LoraConfig  # noqa: F401
     from transformers import TrainingArguments  # noqa: F401
 
@@ -208,9 +208,7 @@ def get_trial_substitutions_from_trainer(
             continue
 
         if isinstance(p_value, models.V1beta1ParameterSpec):
-            old_attr = getattr(parameters, p_name, None)
-            if old_attr is not None:
-                value = f"${{trialParameters.{p_name}}}"
+            value = f"${{trialParameters.{p_name}}}"
             setattr(parameters, p_name, value)
             p_value.name = p_name
             experiment_params.append(p_value)
@@ -219,12 +217,13 @@ def get_trial_substitutions_from_trainer(
             )
         elif p_value is not None:
             old_attr = getattr(parameters, p_name, None)
-            if old_attr is not None:
-                if isinstance(p_value, dict):
-                    # Update the existing dictionary without nesting
-                    value = copy.deepcopy(p_value)
-                else:
-                    value = type(old_attr)(p_value)
+            if isinstance(p_value, dict):
+                # Update the existing dictionary without nesting
+                value = copy.deepcopy(p_value)
+            elif old_attr is not None:
+                value = type(old_attr)(p_value)
+            else:
+                value = p_value
             setattr(parameters, p_name, value)
 
     if isinstance(parameters, TrainingArguments):


### PR DESCRIPTION
…ubstitutions_from_trainer.

→ Removed the conditional so the value is always set before use.

Type Fix: Corrected return type annotation to str instead of Dict[str, str].

Bug Fix: Fixed JSON argument handling in container args where single quotes were incorrectly added. → JSON strings are now passed directly without additional quoting.

These changes collectively resolve the JSON parsing errors observed during LLM fine-tuning and ensure cleaner, consistent behavior in trial generation.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
