### PR TITLE
Add istio virtualservice to katib external-db

### DIFF
--- a/manifests/v1beta1/installs/katib-external-db/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-external-db/kustomization.yaml
@@ -14,6 +14,8 @@ resources:
 - ../../components/ui/
 # Katib webhooks.
 - ../../components/webhook/
+# Kubeflow istio virtual service.
+- ui-virtual-service.yaml
 images:
 - name: ghcr.io/kubeflow/katib/katib-controller
   newName: ghcr.io/kubeflow/katib/katib-controller

--- a/manifests/v1beta1/installs/katib-external-db/ui-virtual-service.yaml
+++ b/manifests/v1beta1/installs/katib-external-db/ui-virtual-service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: katib-ui
+spec:
+  gateways:
+    - kubeflow-gateway
+  hosts:
+    - "*"
+  http:
+    - match:
+        - uri:
+            prefix: /katib/
+      rewrite:
+        uri: /katib/
+      route:
+        - destination:
+            host: katib-ui.kubeflow.svc.cluster.local
+            port:
+              number: 80


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

## Summary
Adds ui-virtual-service.yaml to enable automatic /katib/ UI routing for users deploying Katib with external databases.

Before: Users had to manually create Istio VirtualService after kustomize build manifests/v1beta1/installs/katib-external-db.
After: kustomize build automatically includes Istio integration

## Motivation
Users of `katib-external-db` must manually create VirtualService. This cherry-picks `katib-with-kubeflow/ui-virtual-service.yaml`.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
