### PR TITLE
feat(katib-sdk): support node_selector in Katib Python SDK

### DIFF
--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -220,7 +220,159 @@ class KatibClient(object):
         trial_active_deadline_seconds: Optional[int] = None,
         node_selector: Optional[Dict[str, str]] = None,
     ):
-        """Tune hyperparameters using Katib."""
+        """
+        Create HyperParameter Tuning Katib Experiment using one of the following
+        options:
+
+        1. External models and datasets
+        Parameters: `model_provider_parameters` + `dataset_provider_parameters` +
+            `trainer_parameters`.
+        Usage: Specify both `model_provider_parameters` and
+            `dataset_provider_parameters` to download models and datasets from external
+            platforms (currently support HuggingFace and Amazon S3) using the Storage
+            Initializer. The `trainer_parameters` should be of type
+            `HuggingFaceTrainerParams` to set the hyperparameters search space. This API
+            will automatically define the "Trainer" in HuggingFace with the provided
+            parameters and utilize `Trainer.train()` from HuggingFace to obtain the metrics
+            for optimizing hyperparameters.
+
+        2. Custom objective function
+        Parameters: `objective` + `base_image` + `parameters`.
+        Usage: Specify the `objective` parameter to define your own objective function.
+            The `base_image` parameter will be used to execute the objective function. The
+            `parameters` should be a dictionary to define the search space for these
+            parameters.
+
+        Args:
+            name: Name for the Experiment.
+            model_provider_parameters: Parameters for the model provider in the Storage
+                Initializer.
+                For example, HuggingFace model name and Transformer type for that model,
+                like: AutoModelForSequenceClassification. This argument must be the type
+                of `kubeflow.storage_initializer.hugging_face.HuggingFaceModelParams`.
+            dataset_provider_parameters: Parameters for the dataset provider in the
+                Storage Initializer.
+                For example, name of the HuggingFace dataset or AWS S3 configuration.
+                This argument must be the type of `kubeflow.storage_initializer.hugging_face.
+                HuggingFaceDatasetParams` or `kubeflow.storage_initializer.s3.S3DatasetParams`.
+            trainer_parameters: Parameters for configuring the training process,
+                including settings for the hyperparameters search space. It should be of
+                type `HuggingFaceTrainerParams`. You should use the Katib SDK to define
+                the search space for these parameters. For example:
+                ```
+                trainer_parameters = HuggingFaceTrainerParams(
+                    training_parameters = transformers.TrainingArguments(
+                        learning_rate = katib.search.double(min=0.1, max=0.2),
+                    ),
+                ),
+                ```
+                Also, you can use these parameters to define input for training the
+                models.
+            storage_config: Configuration for Storage Initializer PVC to download
+                pre-trained model and dataset. You can configure PVC size and storage
+                class name in this argument.
+            objective: Objective function that Katib uses to train the model. This
+                function must be Callable and it must have only one dict argument. Katib
+                uses this argument to send HyperParameters to the function. The function
+                should not use any code declared outside of the function definition.
+                Import statements must be added inside the function.
+            base_image: Image to use when executing the objective function.
+            parameters: Dict of HyperParameters to tune your Experiment if you choose a custom
+                objective function. You should use Katib SDK to define the search space for these
+                parameters. For example:
+                `parameters = {"lr": katib.search.double(min=0.1, max=0.2)}`
+
+                Also, you can use these parameters to define input for your objective function.
+            namespace: Namespace for the Experiment.
+            env_per_trial: Environment variable(s) to be attached to each trial container.
+                You can specify a dictionary as a mapping object representing the environment
+                variables. Otherwise, you can specify a list, in which the element can either
+                be a kubernetes.client.models.V1EnvVar (documented here:
+                https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1EnvVar.md)
+                or a kubernetes.client.models.V1EnvFromSource (documented here:
+                https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1EnvFromSource.md)
+            algorithm_name: Search algorithm for the HyperParameter tuning.
+            algorithm_settings: Settings for the search algorithm given.
+                For available fields, check this doc:
+                https://www.kubeflow.org/docs/components/katib/experiment/#search-algorithms-in-detail.
+            objective_metric_name: Objective metric that Katib optimizes.
+            additional_metric_names: List of metrics that Katib collects from the
+                objective function in addition to objective metric.
+            objective_type: Type for the Experiment optimization for the objective metric.
+                Must be one of `minimize` or `maximize`.
+            objective_goal: Objective goal that Experiment should reach to be Succeeded.
+            max_trial_count: Maximum number of Trials to run. For the default
+                values check this doc:
+                https://www.kubeflow.org/docs/components/katib/experiment/#configuration-spec.
+            parallel_trial_count: Number of Trials that Experiment runs in parallel.
+            max_failed_trial_count: Maximum number of Trials allowed to fail.
+            resources_per_trial: A parameter that lets you specify how much resources
+                each trial container should have.
+                For custom objective function, you can either specify a kubernetes.client.
+                V1ResourceRequirements object (documented here:
+                https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1ResourceRequirements.md)
+                or a dictionary that includes one or more of the following keys: `cpu`,
+                `memory`, or `gpu` (other keys will be ignored). Appropriate values
+                for these keys are documented here:
+                https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/.
+                For example:
+                {
+                    "cpu": "1",
+                    "gpu": "1",
+                    "memory": "2Gi",
+                }
+                Please note, `gpu` specifies a resource request with a key of
+                `nvidia.com/gpu`, i.e. an NVIDIA GPU. If you need a different type of
+                GPU, pass in a V1ResourceRequirement instance instead, since it's more
+                flexible. This parameter is optional and defaults to None.
+
+                You should specify a TrainerResources as Trial resources if you use PyTorchJob as
+                Katib Trial for distributed training. This is mandatory parameter if you use
+                LLM `trainer_parameters`. The TrainerResources includes `num_workers`,
+                `num_procs_per_worker`, and `resources_per_worker`.
+                For example:
+                ```
+                resources_per_trial = TrainerResources(
+                    num_workers=4,
+                    num_procs_per_worker=2,
+                    resources_per_worker={
+                        "gpu": "2",
+                        "cpu": "5",
+                        "memory": "10Gi"
+                    }
+                )
+                ```
+                - num_workers: Number of PyTorchJob workers.
+                - num_procs_per_worker: Number of processes per PyTorchJob worker for
+                  `torchrun` CLI. You can use this parameter if you want to use more than 1 GPU
+                  per PyTorchJob worker.
+                - resources_per_worker: A parameter that lets you specify how much resources
+                  each PyTorchJob worker container should have. You can either specify
+                  a kubernetes.client.V1ResourceRequirements object or a dictionary, same as
+                  resources specified under the option of custom objective function.
+            retain_trials: Whether Trials' resources (e.g. pods) are deleted after Succeeded state.
+            packages_to_install: List of Python packages to install in addition
+                to the base image packages. These packages are installed before
+                executing the objective function.
+            pip_index_urls: List of PyPI urls from which to install Python packages.
+            metrics_collector_config: Specify the config of metrics collector,
+                for example, `metrics_collector_config = {"kind": "Push"}`.
+                Currently, we only support `StdOut` and `Push` metrics collector.
+            trial_active_deadline_seconds: Optional timeout in seconds for each trial.
+                If None, no timeout is applied. For Job-based trials, this sets the
+                activeDeadlineSeconds field. For PyTorchJob-based trials, this sets the
+                activeDeadlineSeconds field on the Master replica. This prevents individual
+                trials from running indefinitely and consuming resources.
+            node_selector: Optional dictionary of node labels to constrain trial pod
+                scheduling. Pods will only be scheduled to nodes with matching labels.
+                For example: `{"accelerator": "nvidia-a100", "zone": "us-west1-a"}`.
+                This is useful for targeting specific hardware or node pools.
+
+        Raises:
+            ValueError: Function arguments have incorrect type or value.
+            TimeoutError: Timeout to create Katib Experiment.
+            RuntimeError: Failed to create Katib Experiment.
+        """
 
         # Validate node_selector
         if node_selector is not None:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->
Description

This PR adds support for configuring Kubernetes `nodeSelector` in the Katib Python SDK.

Currently, users cannot control node placement for Katib trial pods when using the Python SDK, even though Kubernetes supports nodeSelector at the Pod level. This is especially limiting for workloads that require specific nodes (e.g. GPU, high-memory, or custom-labeled nodes).

The change introduces an optional `node_selector` parameter to `KatibClient.tune()`, which injects the provided nodeSelector into the TrialTemplate PodSpec. The scheduling is then handled natively by Kubernetes without requiring any backend changes.

This improves flexibility and brings the Python SDK closer to feature parity with Kubernetes-native workflows.

**Changes  Included**

       sdk/python/v1beta1/kubeflow/katib/api/katib_client.py:
             Added a node_selector parameter to the tune method to allow users to specify node or hardware constraints.
             Added validation to ensure node_selector is a dictionary of string key-value pairs.
             Updated Trial template generation to inject nodeSelector into the Pod spec for both Job and PyTorchJob trials.

        
**Tests Included**

       sdk/python/v1beta1/kubeflow/katib/api/katib_client_test.py:
             Validation Unit Tests: Added cases to test_tune_data to verify that node_selector only accepts a dict of strings.
             Functional Tests for Jobs: Added verification in test_tune to ensure node selectors are correctly injected into the Pod specification for standard Jobs.
             Functional Tests for Distributed Training: Added verification in test_tune to ensure node selectors are correctly applied to all replicas (Master and Workers) in PyTorchJob templates.

**Manual Verification**

Installed Katib in a local Minikube cluster.

Labeled the node with a custom label (e.g. gpu=nvidia-a100).

Created a Katib experiment using KatibClient.tune() with the node_selector parameter.

Verified that Trial Pods were scheduled only on nodes matching the specified node selector using:
     ` kubectl get pods -n kubeflow -o `

Confirmed that the nodeSelector field was correctly injected into the generated Trial PodSpec.

Fixes #2603


**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
