### PR TITLE
feat: Add automatic container image security scanning using Trivy

### DIFF
--- a/.github/workflows/template-publish-image/action.yaml
+++ b/.github/workflows/template-publish-image/action.yaml
@@ -64,6 +64,8 @@ runs:
         load: true
         tags: ${{ steps.meta.outputs.tags }}
         platforms: linux/amd64
+        cache-from: type=gha,scope=${{ inputs.dockerfile }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.dockerfile }}
 
     - name: Run Trivy Vulnerability Scanner
       if: inputs.scan-image == 'true'
@@ -76,7 +78,7 @@ runs:
         ignore-unfixed: true
 
     - name: Upload Trivy Scan Results
-      if: inputs.scan-image == 'true'
+      if: inputs.scan-image == 'true' && always()
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: 'trivy-image-results.sarif'
@@ -89,6 +91,6 @@ runs:
         file: ${{ inputs.dockerfile }}
         push: ${{ inputs.push }}
         tags: ${{ steps.meta.outputs.tags }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max,ignore-error=true
+        cache-from: type=gha,scope=${{ inputs.dockerfile }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.dockerfile }},ignore-error=true
         platforms: ${{ inputs.platforms }}

--- a/.github/workflows/template-publish-image/action.yaml
+++ b/.github/workflows/template-publish-image/action.yaml
@@ -15,6 +15,10 @@ inputs:
   push:
     required: true
     description: whether to push container images or not
+  scan-image:
+    required: false
+    default: 'true'
+    description: whether to scan container images for vulnerabilities
 
 runs:
   using: composite
@@ -49,6 +53,34 @@ runs:
         tags: |
           type=raw,latest
           type=sha,prefix=v1beta1-
+
+    - name: Build Image for Scanning
+      if: inputs.scan-image == 'true'
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ${{ inputs.dockerfile }}
+        push: false
+        load: true
+        tags: ${{ steps.meta.outputs.tags }}
+        platforms: linux/amd64
+
+    - name: Run Trivy Vulnerability Scanner
+      if: inputs.scan-image == 'true'
+      uses: aquasecurity/trivy-action@0.28.0
+      with:
+        image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+        format: 'sarif'
+        output: 'trivy-image-results.sarif'
+        severity: 'CRITICAL,HIGH'
+        ignore-unfixed: true
+
+    - name: Upload Trivy Scan Results
+      if: inputs.scan-image == 'true'
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: 'trivy-image-results.sarif'
+        category: 'container-image-scan'
 
     - name: Build and Push
       uses: docker/build-push-action@v5


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Implements automatic container image vulnerability scanning using Trivy in the CI/CD pipeline. Every image built by the project will now be scanned for security vulnerabilities before being pushed to the registry.

This addresses the need for regular, automated security scanning rather than relying on manual scans before releases.
Fixes #2095 
## Changes

### Modified: `.github/workflows/template-publish-image/action.yaml`

- Added `scan-image` input parameter (default: `true`) to enable/disable scanning
- Added "Build Image for Scanning" step - builds single-arch image locally for Trivy
- Added "Run Trivy Vulnerability Scanner" step - scans for CRITICAL and HIGH severity vulnerabilities
- Added "Upload Trivy Scan Results" step - uploads SARIF results to GitHub Security tab

## How it works

```
Build (amd64) → Trivy Scan → Upload SARIF → Multi-arch Build → Push
```

## Configuration

| Setting | Value | Reason |
|---------|-------|--------|
| Severity | `CRITICAL,HIGH` | Focus on actionable vulnerabilities |
| `ignore-unfixed` | `true` | Skip vulnerabilities without available fixes |
| Format | `sarif` | GitHub Code Scanning integration |
| Scan arch | `linux/amd64` | Speed optimization (vulns are consistent across architectures) |

**Note**: This implementation is non-blocking by default - scan results are uploaded for visibility but do not fail the build. This can be changed to a blocking gate by adding `exit-code: '1'` to the Trivy action configuration.

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
