### PR TITLE
fix: Resolve JSONDecodeError in LLM fine-tuning tune() API

### DIFF
--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -619,7 +619,6 @@ class KatibClient(object):
                     "Trainer parameters must be an instance of HuggingFaceTrainerParams."
                 )
 
-            # Validate that training_parameters is provided (fixes issue #2587)
             if not trainer_parameters.training_parameters:
                 raise ValueError(
                     "trainer_parameters.training_parameters must be provided. "

--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -619,6 +619,14 @@ class KatibClient(object):
                     "Trainer parameters must be an instance of HuggingFaceTrainerParams."
                 )
 
+            # Validate that training_parameters is provided (fixes issue #2587)
+            if not trainer_parameters.training_parameters:
+                raise ValueError(
+                    "trainer_parameters.training_parameters must be provided. "
+                    "Please use transformers.TrainingArguments(...) to configure training. "
+                    "See: https://www.kubeflow.org/docs/components/katib/user-guides/hp-tuning/configure-experiment/#tune-api"
+                )
+
             # Iterate over input parameters and do substitutions.
             experiment_parameters = []
             trial_parameters = []
@@ -665,9 +673,9 @@ class KatibClient(object):
                     "--dataset_dir",
                     VOLUME_PATH_DATASET,
                     "--lora_config",
-                    f"'{lora_config}'",
+                    json.dumps(lora_config) if isinstance(lora_config, dict) else lora_config,
                     "--training_parameters",
-                    f"'{training_args}'",
+                    json.dumps(training_args) if isinstance(training_args, dict) else training_args,
                 ],
                 volume_mounts=[STORAGE_INITIALIZER_VOLUME_MOUNT],
                 resources=(

--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client.py
@@ -622,8 +622,9 @@ class KatibClient(object):
             if not trainer_parameters.training_parameters:
                 raise ValueError(
                     "trainer_parameters.training_parameters must be provided. "
-                    "Please use transformers.TrainingArguments(...) to configure training. "
-                    "See: https://www.kubeflow.org/docs/components/katib/user-guides/hp-tuning/configure-experiment/#tune-api"
+                    "Please use transformers.TrainingArguments(...) to configure "
+                    "training. See: https://www.kubeflow.org/docs/components/katib/"
+                    "user-guides/hp-tuning/configure-experiment/#tune-api"
                 )
 
             # Iterate over input parameters and do substitutions.
@@ -672,9 +673,17 @@ class KatibClient(object):
                     "--dataset_dir",
                     VOLUME_PATH_DATASET,
                     "--lora_config",
-                    json.dumps(lora_config) if isinstance(lora_config, dict) else lora_config,
+                    (
+                        json.dumps(lora_config)
+                        if isinstance(lora_config, dict)
+                        else lora_config
+                    ),
                     "--training_parameters",
-                    json.dumps(training_args) if isinstance(training_args, dict) else training_args,
+                    (
+                        json.dumps(training_args)
+                        if isinstance(training_args, dict)
+                        else training_args
+                    ),
                 ],
                 volume_mounts=[STORAGE_INITIALIZER_VOLUME_MOUNT],
                 resources=(

--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client_test.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client_test.py
@@ -459,6 +459,30 @@ test_tune_data = [
         ValueError,
     ),
     (
+        "missing training_parameters in HuggingFaceTrainerParams - issue #2587",
+        {
+            "name": "tune_test",
+            "model_provider_parameters": HuggingFaceModelParams(
+                model_uri="hf://google-bert/bert-base-cased",
+                transformer_type=transformers.AutoModelForSequenceClassification,
+                num_labels=5,
+            ),
+            "dataset_provider_parameters": HuggingFaceDatasetParams(
+                repo_id="yelp_review_full",
+                split="train[:3000]",
+            ),
+            "trainer_parameters": HuggingFaceTrainerParams(
+                training_parameters=None,
+            ),
+            "resources_per_trial": types.TrainerResources(
+                num_workers=2,
+                num_procs_per_worker=2,
+                resources_per_worker={"gpu": "2"},
+            ),
+        },
+        ValueError,
+    ),
+    (
         "pvc creation failed",
         {
             "name": "tune_test",
@@ -880,6 +904,29 @@ def test_tune(katib_client, test_name, kwargs, expected_output):
                         objective_metric_name="train_loss",
                         additional_metric_names=[],
                     )
+
+                    # Verify JSON serialization fix (issue #2587)
+                    # Container args should NOT have extra shell quotes like '{"key": "value"}'
+                    container_args = (
+                        experiment.spec.trial_template.trial_spec.spec.pytorch_replica_specs[
+                            "Master"
+                        ]
+                        .template.spec.containers[0]
+                        .args
+                    )
+                    for i, arg in enumerate(container_args):
+                        if arg in ("--training_parameters", "--lora_config"):
+                            assert i + 1 < len(container_args), (
+                                f"Missing value for {arg} in container args"
+                            )
+                            next_arg = container_args[i + 1]
+                            # Should NOT start/end with extra single quotes
+                            assert not (
+                                next_arg.startswith("'") and next_arg.endswith("'")
+                            ), (
+                                f"{arg} value should not be wrapped with extra quotes. "
+                                f"Got: {next_arg[:50]}..."
+                            )
 
                 elif test_name == "valid flow with pip_index_urls":
                     # Verify pip install command in container args.

--- a/sdk/python/v1beta1/kubeflow/katib/api/katib_client_test.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/katib_client_test.py
@@ -905,7 +905,7 @@ def test_tune(katib_client, test_name, kwargs, expected_output):
                         additional_metric_names=[],
                     )
 
-                    # Verify JSON serialization fix (issue #2587)
+                    # Verify JSON serialization fix
                     # Container args should NOT have extra shell quotes like '{"key": "value"}'
                     container_args = (
                         experiment.spec.trial_template.trial_spec.spec.pytorch_replica_specs[
@@ -916,9 +916,9 @@ def test_tune(katib_client, test_name, kwargs, expected_output):
                     )
                     for i, arg in enumerate(container_args):
                         if arg in ("--training_parameters", "--lora_config"):
-                            assert i + 1 < len(container_args), (
-                                f"Missing value for {arg} in container args"
-                            )
+                            assert i + 1 < len(
+                                container_args
+                            ), f"Missing value for {arg} in container args"
                             next_arg = container_args[i + 1]
                             # Should NOT start/end with extra single quotes
                             assert not (


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->
### **Description**
This PR fixes a bug in the Katib Python SDK where LLM training parameters were passed as an improperly quoted JSON string when using the tune() API. The extra shell quoting caused the LLM worker pod (PyTorch container) to fail with a JSONDecodeError, preventing fine-tuning experiments from running correctly.

**The implementation ensures that**:

- training_parameters and lora_config are serialized as valid JSON without extra quotes before being passed to the container.
-  A validation check is added to ensure trainer_parameters.training_parameters is not empty, raising a helpful error if missing.
-  Unit tests are added to verify both the JSON serialization and the validation behavior.


This resolves the LLM fine-tuning errors in the worker pod, allowing experiments using the tune() API to initialize and run successfully.

**Changes Included**

sdk/python/v1beta1/kubeflow/katib/api/katib_client.py:

- Fixed JSON serialization for training_parameters and lora_config container args by removing extra shell quoting.
- Added type-safe json.dumps() conversion to ensure Kubernetes args are always strings.
- Added early validation for missing training_parameters with a user-friendly error message linking to documentation.

sdk/python/v1beta1/kubeflow/katib/api/katib_client_test.py

- Added a test case for missing training_parameters.
- Added a test case to verify correct JSON serialization format in container arguments.

**Testing:**

- All 25 existing tests pass.
- New unit tests verify that the bug is fixed and the container receives correctly formatted JSON.

Fixes #2587 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
