### PR TITLE
fix(ui): clarify server log to indicate Katib UI is accessible at /katib

### DIFF
--- a/cmd/ui/v1beta1/main.go
+++ b/cmd/ui/v1beta1/main.go
@@ -69,7 +69,7 @@ func main() {
 	http.HandleFunc("/katib/fetch_namespaces", kuh.FetchNamespaces)
 	http.HandleFunc("/katib/fetch_trial_logs/", kuh.FetchTrialLogs)
 
-	log.Printf("Serving at %s:%s", *host, *port)
+	log.Printf("Serving Katib UI at %s:%s/katib/", *host, *port)
 	if err := http.ListenAndServe(fmt.Sprintf("%s:%s", *host, *port), nil); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
- This PR is to make a clarity on root path of katib UI so that user donot need to go to code base to see the root path which is `/katib`

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #2611 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
