### PR TITLE
fix: File-Metrics-Collector race condition

### DIFF
--- a/pkg/metricscollector/v1beta1/common/pns.go
+++ b/pkg/metricscollector/v1beta1/common/pns.go
@@ -43,20 +43,21 @@ func WaitMainProcesses(opts WaitPidsOpts) error {
 		return fmt.Errorf("platform '%s' unsupported", runtime.GOOS)
 	}
 
-	pids, mainPid, err := GetMainProcesses(opts.CompletedMarkedDirPath)
+	// Check for existing completion marker before PID detection.
+	// This handles the race condition where training exits before
+	// the collector can detect it via /proc.
+	completed, err := isAlreadyCompleted(opts.CompletedMarkedDirPath)
+	if err != nil {
+		return fmt.Errorf("failed to check completion marker: %v", err)
+	}
+	if completed {
+		klog.Info("Training already completed (detected via marker file)")
+		return nil
+	}
 
-	// Fallback: If main process not found (race condition where training
-	// exits before we can detect it), check for existing completion marker
-	if err != nil || mainPid == 0 {
-		klog.Infof("Main process not found, checking for existing completion marker")
-		if isAlreadyCompleted(opts.CompletedMarkedDirPath) {
-			klog.Info("Training already completed (detected via marker file)")
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		return fmt.Errorf("unable to find main process or completion marker")
+	pids, mainPid, err := GetMainProcesses(opts.CompletedMarkedDirPath)
+	if err != nil {
+		return err
 	}
 
 	return WaitPIDs(pids, mainPid, opts)
@@ -66,32 +67,30 @@ func WaitMainProcesses(opts WaitPidsOpts) error {
 // for existing .pid marker files with "completed" content.
 // This handles the race condition where training exits before the collector
 // can detect it via /proc.
-func isAlreadyCompleted(completedMarkedDirPath string) bool {
+func isAlreadyCompleted(completedMarkedDirPath string) (bool, error) {
 	if completedMarkedDirPath == "" {
-		return false
+		return false, nil
 	}
 
 	pattern := filepath.Join(completedMarkedDirPath, "*.pid")
 	files, err := filepath.Glob(pattern)
 	if err != nil {
-		klog.Warningf("Failed to glob for pid files: %v", err)
-		return false
+		return false, fmt.Errorf("failed to glob for pid files in %s: %v", completedMarkedDirPath, err)
 	}
 
 	for _, f := range files {
 		contents, err := os.ReadFile(f)
 		if err != nil {
-			klog.Warningf("Failed to read marker file %s: %v", f, err)
-			continue
+			return false, fmt.Errorf("failed to read marker file %s: %v", f, err)
 		}
 
 		marker := strings.TrimSpace(string(contents))
 		if marker == TrainingCompleted {
 			klog.Infof("Found existing completion marker in %s", f)
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // GetMainProcesses returns array with all running processes pids

--- a/pkg/metricscollector/v1beta1/common/pns.go
+++ b/pkg/metricscollector/v1beta1/common/pns.go
@@ -168,6 +168,13 @@ func WaitPIDs(pids map[int]bool, mainPid int, opts WaitPidsOpts) error {
 	// Start main wait loop
 	// We should exit when timeout is out or notFinishedPids is empty
 	for (timeout == 0 || time.Now().Before(endTime)) && len(notFinishedPids) > 0 {
+		// Check completion marker each iteration.
+		if opts.CompletedMarkedDirPath != "" {
+			if completed, _ := isAlreadyCompleted(opts.CompletedMarkedDirPath); completed {
+				klog.Info("Training completed detected via marker during wait loop")
+				return nil
+			}
+		}
 		// Start loop over not finished pids
 		for pid := range notFinishedPids {
 			// If pid is completed /proc/<pid> dir doesn't exist

--- a/pkg/metricscollector/v1beta1/common/pns.go
+++ b/pkg/metricscollector/v1beta1/common/pns.go
@@ -44,11 +44,54 @@ func WaitMainProcesses(opts WaitPidsOpts) error {
 	}
 
 	pids, mainPid, err := GetMainProcesses(opts.CompletedMarkedDirPath)
-	if err != nil {
-		return err
+
+	// Fallback: If main process not found (race condition where training
+	// exits before we can detect it), check for existing completion marker
+	if err != nil || mainPid == 0 {
+		klog.Infof("Main process not found, checking for existing completion marker")
+		if isAlreadyCompleted(opts.CompletedMarkedDirPath) {
+			klog.Info("Training already completed (detected via marker file)")
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("unable to find main process or completion marker")
 	}
 
 	return WaitPIDs(pids, mainPid, opts)
+}
+
+// isAlreadyCompleted checks if training has already finished by scanning
+// for existing .pid marker files with "completed" content.
+// This handles the race condition where training exits before the collector
+// can detect it via /proc.
+func isAlreadyCompleted(completedMarkedDirPath string) bool {
+	if completedMarkedDirPath == "" {
+		return false
+	}
+
+	pattern := filepath.Join(completedMarkedDirPath, "*.pid")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		klog.Warningf("Failed to glob for pid files: %v", err)
+		return false
+	}
+
+	for _, f := range files {
+		contents, err := os.ReadFile(f)
+		if err != nil {
+			klog.Warningf("Failed to read marker file %s: %v", f, err)
+			continue
+		}
+
+		marker := strings.TrimSpace(string(contents))
+		if marker == TrainingCompleted {
+			klog.Infof("Found existing completion marker in %s", f)
+			return true
+		}
+	}
+	return false
 }
 
 // GetMainProcesses returns array with all running processes pids

--- a/pkg/metricscollector/v1beta1/common/pns_test.go
+++ b/pkg/metricscollector/v1beta1/common/pns_test.go
@@ -19,34 +19,41 @@ package common
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 )
 
 func TestIsAlreadyCompleted(t *testing.T) {
 	tests := []struct {
-		name     string
-		files    map[string]string // filename -> content
-		expected bool
+		name        string
+		files       map[string]string // filename -> content
+		expected    bool
+		expectError bool
 	}{
 		{
-			name:     "No marker files",
-			files:    map[string]string{},
-			expected: false,
+			name:        "No marker files",
+			files:       map[string]string{},
+			expected:    false,
+			expectError: false,
 		},
 		{
-			name:     "Completed marker exists",
-			files:    map[string]string{"123.pid": "completed"},
-			expected: true,
+			name:        "Completed marker exists",
+			files:       map[string]string{"123.pid": "completed"},
+			expected:    true,
+			expectError: false,
 		},
 		{
-			name:     "Early-stopped marker only",
-			files:    map[string]string{"123.pid": "early-stopped"},
-			expected: false,
+			name:        "Early-stopped marker only",
+			files:       map[string]string{"123.pid": "early-stopped"},
+			expected:    false,
+			expectError: false,
 		},
 		{
-			name:     "Empty directory path",
-			files:    nil,
-			expected: false,
+			name:        "Empty directory path",
+			files:       nil,
+			expected:    false,
+			expectError: false,
 		},
 		{
 			name: "Multiple pid files with one completed (Istio sidecar scenario)",
@@ -54,7 +61,8 @@ func TestIsAlreadyCompleted(t *testing.T) {
 				"45.pid": "completed",
 				"52.pid": "early-stopped",
 			},
-			expected: true,
+			expected:    true,
+			expectError: false,
 		},
 		{
 			name: "Multiple early-stopped files, no completed",
@@ -62,12 +70,14 @@ func TestIsAlreadyCompleted(t *testing.T) {
 				"45.pid": "early-stopped",
 				"52.pid": "early-stopped",
 			},
-			expected: false,
+			expected:    false,
+			expectError: false,
 		},
 		{
-			name:     "Completed marker with whitespace",
-			files:    map[string]string{"123.pid": "  completed  \n"},
-			expected: true,
+			name:        "Completed marker with whitespace",
+			files:       map[string]string{"123.pid": "  completed  \n"},
+			expected:    true,
+			expectError: false,
 		},
 	}
 
@@ -89,10 +99,78 @@ func TestIsAlreadyCompleted(t *testing.T) {
 			if tt.files != nil {
 				dirPath = tmpDir
 			}
-			result := isAlreadyCompleted(dirPath)
+			result, err := isAlreadyCompleted(dirPath)
 
+			if (err != nil) != tt.expectError {
+				t.Errorf("isAlreadyCompleted(%q) unexpected error: %v", dirPath, err)
+			}
 			if result != tt.expected {
 				t.Errorf("isAlreadyCompleted(%q) = %v, want %v", dirPath, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWaitMainProcesses(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("WaitMainProcesses only works on linux")
+	}
+
+	tests := []struct {
+		name        string
+		files       map[string]string
+		expectError bool
+	}{
+		{
+			name:        "Main process exited but completed marker exists",
+			files:       map[string]string{"45.pid": "completed"},
+			expectError: false,
+		},
+		{
+			name:        "No process and no marker",
+			files:       map[string]string{},
+			expectError: true,
+		},
+		{
+			name:        "Main process exited with early-stopped only",
+			files:       map[string]string{"45.pid": "early-stopped"},
+			expectError: true,
+		},
+		{
+			name: "Sidecar still running but completed marker exists (Istio scenario)",
+			files: map[string]string{
+				"45.pid": "completed",
+				"52.pid": "early-stopped",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			for name, content := range tt.files {
+				err := os.WriteFile(filepath.Join(tmpDir, name), []byte(content), 0644)
+				if err != nil {
+					t.Fatalf("Failed to write test file: %v", err)
+				}
+			}
+
+			opts := WaitPidsOpts{
+				PollInterval:           100 * time.Millisecond,
+				Timeout:                1 * time.Second,
+				WaitAll:                false,
+				CompletedMarkedDirPath: tmpDir,
+			}
+
+			err := WaitMainProcesses(opts)
+
+			if tt.expectError && err == nil {
+				t.Errorf("WaitMainProcesses() expected error but got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("WaitMainProcesses() unexpected error: %v", err)
 			}
 		})
 	}

--- a/pkg/metricscollector/v1beta1/common/pns_test.go
+++ b/pkg/metricscollector/v1beta1/common/pns_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2022 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsAlreadyCompleted(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    map[string]string // filename -> content
+		expected bool
+	}{
+		{
+			name:     "No marker files",
+			files:    map[string]string{},
+			expected: false,
+		},
+		{
+			name:     "Completed marker exists",
+			files:    map[string]string{"123.pid": "completed"},
+			expected: true,
+		},
+		{
+			name:     "Early-stopped marker only",
+			files:    map[string]string{"123.pid": "early-stopped"},
+			expected: false,
+		},
+		{
+			name:     "Empty directory path",
+			files:    nil,
+			expected: false,
+		},
+		{
+			name: "Multiple pid files with one completed (Istio sidecar scenario)",
+			files: map[string]string{
+				"45.pid": "completed",
+				"52.pid": "early-stopped",
+			},
+			expected: true,
+		},
+		{
+			name: "Multiple early-stopped files, no completed",
+			files: map[string]string{
+				"45.pid": "early-stopped",
+				"52.pid": "early-stopped",
+			},
+			expected: false,
+		},
+		{
+			name:     "Completed marker with whitespace",
+			files:    map[string]string{"123.pid": "  completed  \n"},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp directory
+			tmpDir := t.TempDir()
+
+			// Create test files
+			for name, content := range tt.files {
+				err := os.WriteFile(filepath.Join(tmpDir, name), []byte(content), 0644)
+				if err != nil {
+					t.Fatalf("Failed to write test file: %v", err)
+				}
+			}
+
+			// Test
+			var dirPath string
+			if tt.files != nil {
+				dirPath = tmpDir
+			}
+			result := isAlreadyCompleted(dirPath)
+
+			if result != tt.expected {
+				t.Errorf("isAlreadyCompleted(%q) = %v, want %v", dirPath, result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/metricscollector/v1beta1/common/pns_test.go
+++ b/pkg/metricscollector/v1beta1/common/pns_test.go
@@ -175,3 +175,65 @@ func TestWaitMainProcesses(t *testing.T) {
 		})
 	}
 }
+
+func TestWaitPIDsWithMarkerCheck(t *testing.T) {
+	tests := []struct {
+		name        string
+		files       map[string]string
+		expectError bool
+	}{
+		{
+			name:        "Non-existent PID with completed marker exits immediately",
+			files:       map[string]string{"99999.pid": "completed"},
+			expectError: false,
+		},
+		{
+			name:        "Non-existent PID without marker times out",
+			files:       map[string]string{},
+			expectError: true,
+		},
+		{
+			name:        "Non-existent PID with early-stopped marker times out",
+			files:       map[string]string{"99999.pid": "early-stopped"},
+			expectError: true,
+		},
+		{
+			name: "Non-existent PID with sidecar and completed marker exits",
+			files: map[string]string{
+				"99999.pid": "completed",
+				"88888.pid": "early-stopped",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			for name, content := range tt.files {
+				err := os.WriteFile(filepath.Join(tmpDir, name), []byte(content), 0644)
+				if err != nil {
+					t.Fatalf("Failed to write test file: %v", err)
+				}
+			}
+
+			fakePids := map[int]bool{99999: true}
+			opts := WaitPidsOpts{
+				PollInterval:           100 * time.Millisecond,
+				Timeout:                1 * time.Second,
+				WaitAll:                false,
+				CompletedMarkedDirPath: tmpDir,
+			}
+
+			err := WaitPIDs(fakePids, 99999, opts)
+
+			if tt.expectError && err == nil {
+				t.Errorf("WaitPIDs() expected error but got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("WaitPIDs() unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->
 **Description**

This PR fixes a race condition in the file-metrics-collector where the sidecar may fail to exit if the main training container finishes before the collector can detect its PID. This commonly occurs with fast-running training jobs or when sidecars present, leaving the Trial Pod stuck in a Running state and blocking experiment completion.

To address this, a hybrid fallback mechanism is introduced. The collector first attempts the standard PID-based detection via /proc. If the main process is not found, it falls back to scanning the /katib directory for existing .pid marker files (for example, 45.pid containing completed). When a valid completion marker is detected, the collector safely proceeds to collect metrics and exits cleanly instead of waiting indefinitely.

**Changes Included**

 pkg/metricscollector/v1beta1/common/pns.go

- Added isAlreadyCompleted helper to scan the marker directory for .pid files containing a completed status.
- Updated WaitMainProcesses to introduce fallback logic when GetMainProcesses fails or no mainPid is detected.
- Improved error handling so PID detection errors are returned only when no valid completion marker is found.

pkg/metricscollector/v1beta1/common/pns_test.go (new)

- Added comprehensive unit tests covering:
       -  Absence of marker files
       -  Detection of a valid completed marker
       -  Ignoring early-stopped markers
      - Multi-process environments (e.g. Istio sidecars with multiple .pid files)
      - Marker files with whitespace and newline variations
      
**Verification**

- Added unit tests covering fast-exit and multiple PID marker scenarios.
- Reproduced the race condition locally using Docker and confirmed clean exit when a completion marker exists.

Fixes #2614 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
