### PR TITLE
fix: inject Katib labels early to support PodDefaults for trial pods

### DIFF
--- a/pkg/controller.v1beta1/experiment/manifest/generator.go
+++ b/pkg/controller.v1beta1/experiment/manifest/generator.go
@@ -103,6 +103,11 @@ func (g *DefaultGenerator) GetRunSpecWithHyperParameters(experiment *experiments
 	runSpec.SetName(trialName)
 	runSpec.SetNamespace(trialNamespace)
 
+	// Inject Experiment labels into the RunSpec's Pod template.
+	if err := util.InjectLabelsToPodTemplate(runSpec, util.TrialLabels(experiment)); err != nil {
+		return nil, err
+	}
+
 	return runSpec, nil
 }
 

--- a/pkg/controller.v1beta1/trial/trial_controller.go
+++ b/pkg/controller.v1beta1/trial/trial_controller.go
@@ -48,6 +48,7 @@ import (
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/consts"
 	"github.com/kubeflow/katib/pkg/controller.v1beta1/trial/managerclient"
 	trialutil "github.com/kubeflow/katib/pkg/controller.v1beta1/trial/util"
+	"github.com/kubeflow/katib/pkg/controller.v1beta1/util"
 )
 
 const (
@@ -331,6 +332,17 @@ func (r *ReconcileTrial) getDesiredJobSpec(instance *trialsv1beta1.Trial) (*unst
 
 	if err := controllerutil.SetControllerReference(instance, desiredJobSpec, r.scheme); err != nil {
 		logger.Error(err, "Set controller reference error")
+		return nil, err
+	}
+
+	// Inject Trial labels into the RunSpec's Pod template.
+	labels := make(map[string]string)
+	for k, v := range instance.Labels {
+		labels[k] = v
+	}
+	labels[consts.LabelTrialName] = instance.GetName()
+	if err := util.InjectLabelsToPodTemplate(desiredJobSpec, labels); err != nil {
+		logger.Error(err, "Inject labels to pod template error")
 		return nil, err
 	}
 

--- a/pkg/controller.v1beta1/util/unstructured.go
+++ b/pkg/controller.v1beta1/util/unstructured.go
@@ -71,3 +71,74 @@ func ConvertObjectToUnstructured(in interface{}) (*unstructured.Unstructured, er
 
 	return out, nil
 }
+
+// InjectLabelsToPodTemplate injects labels into the Pod template for a given unstructured object.
+func InjectLabelsToPodTemplate(obj *unstructured.Unstructured, labels map[string]string) error {
+	if len(labels) == 0 {
+		return nil
+	}
+
+	currentLabels, _, _ := unstructured.NestedStringMap(obj.Object, "metadata", "labels")
+	if currentLabels == nil {
+		currentLabels = make(map[string]string)
+	}
+	for k, v := range labels {
+		currentLabels[k] = v
+	}
+	if err := unstructured.SetNestedStringMap(obj.Object, currentLabels, "metadata", "labels"); err != nil {
+		return err
+	}
+
+	templateLabels, found, err := unstructured.NestedStringMap(obj.Object, "spec", "template", "metadata", "labels")
+	if err == nil {
+		if !found || templateLabels == nil {
+			templateLabels = make(map[string]string)
+		}
+		for k, v := range labels {
+			templateLabels[k] = v
+		}
+		if err := unstructured.SetNestedStringMap(obj.Object, templateLabels, "spec", "template", "metadata", "labels"); err != nil {
+			return err
+		}
+	}
+
+	templateLabels, found, err = unstructured.NestedStringMap(obj.Object, "spec", "jobTemplate", "spec", "template", "metadata", "labels")
+	if err == nil {
+		if !found || templateLabels == nil {
+			templateLabels = make(map[string]string)
+		}
+		for k, v := range labels {
+			templateLabels[k] = v
+		}
+		if err := unstructured.SetNestedStringMap(obj.Object, templateLabels, "spec", "jobTemplate", "spec", "template", "metadata", "labels"); err != nil {
+			return err
+		}
+	}
+
+	replicaSpecs, found, err := unstructured.NestedMap(obj.Object, "spec", "replicaSpecs")
+	if err == nil && found {
+		for _, replicaSpec := range replicaSpecs {
+			rs, ok := replicaSpec.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			templateLabels, found, err = unstructured.NestedStringMap(rs, "template", "metadata", "labels")
+			if err == nil {
+				if !found || templateLabels == nil {
+					templateLabels = make(map[string]string)
+				}
+				for k, v := range labels {
+					templateLabels[k] = v
+				}
+				if err := unstructured.SetNestedStringMap(rs, templateLabels, "template", "metadata", "labels"); err != nil {
+					return err
+				}
+			}
+		}
+		if err := unstructured.SetNestedMap(obj.Object, replicaSpecs, "spec", "replicaSpecs"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller.v1beta1/util/unstructured_test.go
+++ b/pkg/controller.v1beta1/util/unstructured_test.go
@@ -1,0 +1,266 @@
+/*
+Copyright 2022 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestInjectLabelsToPodTemplate(t *testing.T) {
+	labels := map[string]string{
+		"katib.kubeflow.org/trial":      "test-trial",
+		"katib.kubeflow.org/experiment": "test-experiment",
+	}
+
+	cases := map[string]struct {
+		obj      *unstructured.Unstructured
+		expected *unstructured.Unstructured
+	}{
+		"Standard Job": {
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "batch/v1",
+					"kind":       "Job",
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"labels": map[string]interface{}{
+									"unaffected": "label",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "batch/v1",
+					"kind":       "Job",
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"katib.kubeflow.org/trial":      "test-trial",
+							"katib.kubeflow.org/experiment": "test-experiment",
+						},
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"labels": map[string]interface{}{
+									"unaffected":                    "label",
+									"katib.kubeflow.org/trial":      "test-trial",
+									"katib.kubeflow.org/experiment": "test-experiment",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"CronJob": {
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "batch/v1",
+					"kind":       "CronJob",
+					"spec": map[string]interface{}{
+						"jobTemplate": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "batch/v1",
+					"kind":       "CronJob",
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"katib.kubeflow.org/trial":      "test-trial",
+							"katib.kubeflow.org/experiment": "test-experiment",
+						},
+					},
+					"spec": map[string]interface{}{
+						"jobTemplate": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{
+											"katib.kubeflow.org/trial":      "test-trial",
+											"katib.kubeflow.org/experiment": "test-experiment",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"TFJob (Training Operator)": {
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "kubeflow.org/v1",
+					"kind":       "TFJob",
+					"spec": map[string]interface{}{
+						"replicaSpecs": map[string]interface{}{
+							"Worker": map[string]interface{}{
+								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{},
+									},
+								},
+							},
+							"PS": map[string]interface{}{
+								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "kubeflow.org/v1",
+					"kind":       "TFJob",
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"katib.kubeflow.org/trial":      "test-trial",
+							"katib.kubeflow.org/experiment": "test-experiment",
+						},
+					},
+					"spec": map[string]interface{}{
+						"replicaSpecs": map[string]interface{}{
+							"Worker": map[string]interface{}{
+								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{
+											"katib.kubeflow.org/trial":      "test-trial",
+											"katib.kubeflow.org/experiment": "test-experiment",
+										},
+									},
+								},
+							},
+							"PS": map[string]interface{}{
+								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{
+											"katib.kubeflow.org/trial":      "test-trial",
+											"katib.kubeflow.org/experiment": "test-experiment",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"Job with no initial labels": {
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "batch/v1",
+					"kind":       "Job",
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{},
+						},
+					},
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "batch/v1",
+					"kind":       "Job",
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"katib.kubeflow.org/trial":      "test-trial",
+							"katib.kubeflow.org/experiment": "test-experiment",
+						},
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"labels": map[string]interface{}{
+									"katib.kubeflow.org/trial":      "test-trial",
+									"katib.kubeflow.org/experiment": "test-experiment",
+								},
+							},
+							"spec": map[string]interface{}{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := InjectLabelsToPodTemplate(tc.obj, labels)
+			if err != nil {
+				t.Fatalf("InjectLabelsToPodTemplate failed: %v", err)
+			}
+
+			gotLabels, _, _ := unstructured.NestedStringMap(tc.obj.Object, "metadata", "labels")
+			for k, v := range labels {
+				if gotLabels[k] != v {
+					t.Errorf("%s: metadata.labels[%s] = %v, want %v", name, k, gotLabels[k], v)
+				}
+			}
+
+			if tc.obj.GetKind() == "Job" {
+				gotLabels, _, _ = unstructured.NestedStringMap(tc.obj.Object, "spec", "template", "metadata", "labels")
+				for k, v := range labels {
+					if gotLabels[k] != v {
+						t.Errorf("%s: spec.template.metadata.labels[%s] = %v, want %v", name, k, gotLabels[k], v)
+					}
+				}
+			}
+
+			if tc.obj.GetKind() == "CronJob" {
+				gotLabels, _, _ = unstructured.NestedStringMap(tc.obj.Object, "spec", "jobTemplate", "spec", "template", "metadata", "labels")
+				for k, v := range labels {
+					if gotLabels[k] != v {
+						t.Errorf("%s: spec.jobTemplate.spec.template.metadata.labels[%s] = %v, want %v", name, k, gotLabels[k], v)
+					}
+				}
+			}
+
+			if tc.obj.GetKind() == "TFJob" {
+				replicaSpecs, _, _ := unstructured.NestedMap(tc.obj.Object, "spec", "replicaSpecs")
+				for rName, rSpec := range replicaSpecs {
+					rs := rSpec.(map[string]interface{})
+					gotLabels, _, _ = unstructured.NestedStringMap(rs, "template", "metadata", "labels")
+					for k, v := range labels {
+						if gotLabels[k] != v {
+							t.Errorf("%s: replica %s labels[%s] = %v, want %v", name, rName, k, gotLabels[k], v)
+						}
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->
When a trial pod is created, Katib labels like `katib.kubeflow.org/trial` are added too late . They get added by a webhook that runs after the PodDefaults webhook has already finished checking. Because of this timing issue, PodDefaults that depend on Katib labels are never applied to trial pods.

This PR fixes it by adding the labels directly into the pod template before the pod is created, so PodDefaults can see them in time.


**Changes:**

- Added InjectLabelsToPodTemplate utility in pkg/controller.v1beta1/util/unstructured.go that injects labels into Pod templates across workload types (Job, CronJob, Training Operator replicaSpecs)
- Updated generator.go to inject experiment labels into the trial template early
- Updated trial_controller.go to inject trial name labels into the workload before creation
- Added unit tests covering all supported workload types, including edge case where no initial labels exist

Fixes #2548 
