### PR TITLE
chore: Enforcing LF Line Endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Always check-out / check-in files with LF line endings.
+* text=auto eol=lf


### PR DESCRIPTION
## Add .gitattributes to enforce LF line endings

Adds `.gitattributes` with `* text=auto eol=lf` to ensure consistent Unix-style line endings across all platforms.

This prevents issues with shell scripts and Makefiles that fail when CRLF endings are accidentally committed from Windows environments. The change only affects future commits and does not modify existing files.