### PR TITLE
chore: Expose Katib control-plane version via public ConfigMap

### DIFF
--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -64,6 +64,9 @@ includes releases for the following components:
 - Manifest images with tags equal to the release
   (e.g [`v0.11.1`](https://github.com/kubeflow/katib/blob/v0.11.1/manifests/v1beta1/installs/katib-standalone/kustomization.yaml#L21-L33)).
 
+- Public ConfigMap version with tag equal to the release
+  (e.g `kubeflow_katib_version: v0.11.1` in all install kustomization.yaml files).
+
 - Katib Python SDK where version is in this format: `X.Y.Z` or `X.Y.ZrcN`
   (e.g [`0.11.1`](https://github.com/kubeflow/katib/blob/v0.11.1/sdk/python/v1beta1/setup.py#L22)).
 

--- a/manifests/v1beta1/components/rbac/kustomization.yaml
+++ b/manifests/v1beta1/components/rbac/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - public_configmap_role.yaml
+  - public_configmap_role_binding.yaml

--- a/manifests/v1beta1/components/rbac/public_configmap_role.yaml
+++ b/manifests/v1beta1/components/rbac/public_configmap_role.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubeflow-katib-public
+  namespace: kubeflow
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - kubeflow-katib-public
+    verbs:
+      - get
+      - list
+      - watch

--- a/manifests/v1beta1/components/rbac/public_configmap_role_binding.yaml
+++ b/manifests/v1beta1/components/rbac/public_configmap_role_binding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubeflow-katib-public
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubeflow-katib-public
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: system:authenticated

--- a/manifests/v1beta1/installs/katib-cert-manager/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-cert-manager/kustomization.yaml
@@ -16,6 +16,8 @@ resources:
 - ../../components/ui/
  # Katib webhooks.
 - ../../components/webhook/
+# Public ConfigMap RBAC.
+- ../../components/rbac/
 # Cert-manager certificate for webhooks
 - certificate.yaml
 images:
@@ -39,6 +41,12 @@ configMapGenerator:
   files:
   - katib-config.yaml
   name: katib-config
+  options:
+    disableNameSuffixHash: true
+# Public ConfigMap for the Katib SDK.
+- name: kubeflow-katib-public
+  literals:
+    - kubeflow_katib_version=dev
   options:
     disableNameSuffixHash: true
 patches:

--- a/manifests/v1beta1/installs/katib-external-db/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-external-db/kustomization.yaml
@@ -14,6 +14,8 @@ resources:
 - ../../components/ui/
 # Katib webhooks.
 - ../../components/webhook/
+# Public ConfigMap RBAC.
+- ../../components/rbac/
 images:
 - name: ghcr.io/kubeflow/katib/katib-controller
   newName: ghcr.io/kubeflow/katib/katib-controller
@@ -38,6 +40,12 @@ configMapGenerator:
   files:
   - katib-config.yaml
   name: katib-config
+  options:
+    disableNameSuffixHash: true
+# Public ConfigMap for the Katib SDK.
+- name: kubeflow-katib-public
+  literals:
+    - kubeflow_katib_version=dev
   options:
     disableNameSuffixHash: true
 patches:

--- a/manifests/v1beta1/installs/katib-openshift/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-openshift/kustomization.yaml
@@ -26,6 +26,8 @@ resources:
 - ../../components/ui/
 # Katib webhooks.
 - ../../components/webhook/
+# Public ConfigMap RBAC.
+- ../../components/rbac/
 images:
 - name: ghcr.io/kubeflow/katib/katib-controller
   newName: ghcr.io/kubeflow/katib/katib-controller
@@ -42,6 +44,12 @@ configMapGenerator:
   files:
   - katib-config.yaml
   name: katib-config
+  options:
+    disableNameSuffixHash: true
+# Public ConfigMap for the Katib SDK.
+- name: kubeflow-katib-public
+  literals:
+    - kubeflow_katib_version=dev
   options:
     disableNameSuffixHash: true
 patches:

--- a/manifests/v1beta1/installs/katib-standalone-postgres/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-standalone-postgres/kustomization.yaml
@@ -16,6 +16,8 @@ resources:
 - ../../components/ui/
 # Katib webhooks.
 - ../../components/webhook/
+# Public ConfigMap RBAC.
+- ../../components/rbac/
 images:
 - name: ghcr.io/kubeflow/katib/katib-controller
   newName: ghcr.io/kubeflow/katib/katib-controller
@@ -31,6 +33,12 @@ configMapGenerator:
   files:
   - katib-config.yaml
   name: katib-config
+  options:
+    disableNameSuffixHash: true
+# Public ConfigMap for the Katib SDK.
+- name: kubeflow-katib-public
+  literals:
+    - kubeflow_katib_version=dev
   options:
     disableNameSuffixHash: true
 # Secret for webhooks certs.

--- a/manifests/v1beta1/installs/katib-standalone/kustomization.yaml
+++ b/manifests/v1beta1/installs/katib-standalone/kustomization.yaml
@@ -17,6 +17,8 @@ resources:
   - ../../components/ui/
   # Katib webhooks.
   - ../../components/webhook/
+  # Public ConfigMap RBAC.
+  - ../../components/rbac/
 images:
   - name: ghcr.io/kubeflow/katib/katib-controller
     newName: ghcr.io/kubeflow/katib/katib-controller
@@ -32,6 +34,12 @@ configMapGenerator:
     behavior: create
     files:
       - katib-config.yaml
+    options:
+      disableNameSuffixHash: true
+  # Public ConfigMap for the Katib SDK.
+  - name: kubeflow-katib-public
+    literals:
+      - kubeflow_katib_version=dev
     options:
       disableNameSuffixHash: true
 # Secret for webhooks certs.


### PR DESCRIPTION
## Expose Katib control-plane version via public ConfigMap


### Motivation
This change follows the pattern established in [kubeflow/trainer#3083](https://github.com/kubeflow/trainer/pull/3083), [kubeflow/pipelines#12717](https://github.com/kubeflow/pipelines/pull/12717), and [kubeflow/spark-operator#2831](https://github.com/kubeflow/spark-operator/pull/2831) to support [kubeflow/sdk#221](https://github.com/kubeflow/sdk/issues/221).


### Changes
- **Added** `kubeflow-katib-public` ConfigMap via `configMapGenerator` in all install variants
- **Added** Role and RoleBinding granting `get/list/watch` access to `system:authenticated` users
- **Updated** release documentation to include ConfigMap version update during releases
- **Version**: Defaults to `dev` on master branch, updated to `vX.Y.Z` during release process

### Install Variants Updated
All Kustomize install variants now include the public ConfigMap:
- katib-standalone
- katib-cert-manager
- katib-with-kubeflow
- katib-standalone-postgres
- katib-external-db
- katib-openshift
- katib-leader-election

Fixes https://github.com/kubeflow/sdk/issues/221