### PR TITLE
fix(controller): Correct error formatting in trial controller package

### DIFF
--- a/pkg/controller.v1beta1/trial/trial_controller.go
+++ b/pkg/controller.v1beta1/trial/trial_controller.go
@@ -58,9 +58,9 @@ const (
 var (
 	log = logf.Log.WithName(ControllerName)
 	// errMetricsNotReported is the error when Trial job is succeeded but metrics are not reported yet
-	errMetricsNotReported = fmt.Errorf("metrics are not reported yet")
+	errMetricsNotReported = errors.New("metrics are not reported yet")
 	// errReportMetricsFailed is the error when `unavailable` metrics value can't be inserted to the Katib DB.
-	errReportMetricsFailed = fmt.Errorf("failed to report unavailable metrics")
+	errReportMetricsFailed = errors.New("failed to report unavailable metrics")
 )
 
 // Add creates a new Trial Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller

--- a/pkg/controller.v1beta1/trial/trial_controller_util.go
+++ b/pkg/controller.v1beta1/trial/trial_controller_util.go
@@ -226,7 +226,7 @@ func getMetrics(metricLogs []*api_pb.MetricLog, strategies []commonv1beta1.Metri
 		}
 		currentTime, err := time.Parse(time.RFC3339Nano, metricLog.TimeStamp)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse timestamps %s: %e", metricLog.TimeStamp, err)
+			return nil, fmt.Errorf("failed to parse timestamps %s: %w", metricLog.TimeStamp, err)
 		}
 		timestamp := timestamps[metricLog.Metric.Name]
 		if timestamp == nil || !timestamp.After(currentTime) {

--- a/pkg/controller.v1beta1/trial/util/job_util.go
+++ b/pkg/controller.v1beta1/trial/util/job_util.go
@@ -79,7 +79,7 @@ func GetDeployedJobStatus(trial *trialsv1beta1.Trial, deployedJob *unstructured.
 		// Unmarshal condition to Trial Job representation to get message and reason if it exists
 		err := json.Unmarshal([]byte(strCondition), &trialJobStatus)
 		if err != nil {
-			return nil, fmt.Errorf("unmarshal failure condition to Trial Job status failed %v", err)
+			return nil, fmt.Errorf("unmarshal failure condition to Trial Job status failed: %w", err)
 		}
 
 		// Job condition is failed
@@ -100,7 +100,7 @@ func GetDeployedJobStatus(trial *trialsv1beta1.Trial, deployedJob *unstructured.
 
 		err := json.Unmarshal([]byte(strCondition), &trialJobStatus)
 		if err != nil {
-			return nil, fmt.Errorf("unmarshal success condition to Trial Job status failed %v", err)
+			return nil, fmt.Errorf("unmarshal success condition to Trial Job status failed: %w", err)
 		}
 
 		// Job condition is succeeded


### PR DESCRIPTION
**What this PR does / why we need it**:                                                                                                                                                                                              
  Fixes three error formatting issues in `pkg/controller.v1beta1/trial/`:                                                                                                                                                              
                                                                                                                                                                                                                                       
  1. `trial_controller_util.go:229` uses `%e` (scientific notation for floats) instead of `%w`, producing garbled output like `&{%!e(string=...)}` on timestamp parse errors.                                                          
  2. `trial_controller.go:61-63` uses `fmt.Errorf()` for sentinel errors that are compared with `errors.Is()`. Changed to `errors.New()` for immutability.                                                                             
  3. `trial/util/job_util.go:82,103` uses `%v` instead of `%w`, which breaks the error chain for `errors.Is()`/`errors.As()` callers.                                                                                                  
                                                                                                                                                                                                                                       
  **Which issue(s) this PR fixes**:                                                                                                                                                                                                    
  Fixes #2628                                                                                                                                                                                                                          
                                                                                                                                                                                                                                       
  **Checklist:**                                                                                                                                                                                                                       
                                                                                                                                                                                                                                       
  - [x] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing                                                                                                                                
    - N/A: internal error handling only, no user facing changes                             