### PR TITLE
Fix: specify list positional argument within search.categorical

### DIFF
--- a/sdk/python/v1beta1/kubeflow/katib/api/search.py
+++ b/sdk/python/v1beta1/kubeflow/katib/api/search.py
@@ -62,5 +62,5 @@ def categorical(list: List):
 
     return models.V1beta1ParameterSpec(
         parameter_type="categorical",
-        feasible_space=models.V1beta1FeasibleSpace(list),
+        feasible_space=models.V1beta1FeasibleSpace(list=list),
     )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines https://www.kubeflow.org/docs/about/contributing
2. To know more about Katib components, check developer guide https://github.com/kubeflow/katib/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
`katib.search.categorical()` incorrectly constructs `V1beta1FeasibleSpace` by passing the `list` value as positional argument mapping it to the `distribution` argument instead of `list` argument.

**Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
Fixes #2625 

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/katib/) included if any changes are user facing
