### PR TITLE
feat: Add TrainerStatus Collector to surface TrainJob progress and persist convergence history

### DIFF
--- a/pkg/apis/controller/common/v1beta1/common_types.go
+++ b/pkg/apis/controller/common/v1beta1/common_types.go
@@ -233,6 +233,10 @@ const (
 	// directly, sidecar container isn't in need, and its kind is "pushCollector"
 	PushCollector CollectorKind = "Push"
 
+	// TrainerStatusCollector collects progress and metrics from the Trainer TrainJob
+	// status field (TrainJob.status.trainerStatus). It does not require sidecar injection.
+	TrainerStatusCollector CollectorKind = "TrainerStatus"
+
 	MetricsVolume = "metrics-volume"
 )
 

--- a/pkg/apis/controller/experiments/v1beta1/experiment_types.go
+++ b/pkg/apis/controller/experiments/v1beta1/experiment_types.go
@@ -118,6 +118,12 @@ type ExperimentStatus struct {
 	// Trials is the total number of trials owned by the experiment.
 	Trials int32 `json:"trials,omitempty"`
 
+	// TrialsProgress provides lightweight, real-time progress snapshots for Trials.
+	// This is primarily used with the TrainerStatus metrics collector.
+	// +listType=map
+	// +listMapKey=trialName
+	TrialsProgress []TrialProgress `json:"trialsProgress,omitempty"`
+
 	// How many trials have succeeded.
 	TrialsSucceeded int32 `json:"trialsSucceeded,omitempty"`
 
@@ -138,6 +144,18 @@ type ExperimentStatus struct {
 
 	// How many trials are currently metrics unavailable.
 	TrialMetricsUnavailable int32 `json:"trialMetricsUnavailable,omitempty"`
+}
+
+// +k8s:deepcopy-gen=true
+// TrialProgress contains real-time progress information for a Trial.
+type TrialProgress struct {
+	TrialName                 string       `json:"trialName,omitempty"`
+	ProgressPercentage        *int32       `json:"progressPercentage,omitempty"`
+	EstimatedRemainingSeconds *int32       `json:"estimatedRemainingSeconds,omitempty"`
+	CurrentLoss               string       `json:"currentLoss,omitempty"`
+	Status                    string       `json:"status,omitempty"`
+	EarlyStopReason           string       `json:"earlyStopReason,omitempty"`
+	LastUpdatedTime           *metav1.Time `json:"lastUpdatedTime,omitempty"`
 }
 
 // OptimalTrial is the metrics and assignments of the best trial.

--- a/pkg/apis/controller/trials/v1beta1/trial_types.go
+++ b/pkg/apis/controller/trials/v1beta1/trial_types.go
@@ -94,6 +94,29 @@ type TrialStatus struct {
 
 	// Results of the Trial - objectives and other metrics values.
 	Observation *common.Observation `json:"observation,omitempty"`
+
+	// TrainerStatus contains the latest progress and metrics snapshot reported by
+	// Kubeflow Trainer TrainJob (TrainJob.status.trainerStatus).
+	TrainerStatus *TrainerStatus `json:"trainerStatus,omitempty"`
+
+	// TrainerStatusLastReportedTime represents last time when Katib reported TrainerStatus
+	// metrics to Katib DB and updated Trial.status.trainerStatus.
+	TrainerStatusLastReportedTime *metav1.Time `json:"trainerStatusLastReportedTime,omitempty"`
+}
+
+// +k8s:deepcopy-gen=true
+// TrainerStatus mirrors the latest progress/metrics snapshot from Kubeflow Trainer.
+type TrainerStatus struct {
+	ProgressPercentage        *int32          `json:"progressPercentage,omitempty"`
+	EstimatedRemainingSeconds *int32          `json:"estimatedRemainingSeconds,omitempty"`
+	Metrics                   []TrainerMetric `json:"metrics,omitempty"`
+	LastUpdatedTime           *metav1.Time    `json:"lastUpdatedTime,omitempty"`
+}
+
+// +k8s:deepcopy-gen=true
+type TrainerMetric struct {
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/pkg/controller.v1beta1/experiment/util/status_util.go
+++ b/pkg/controller.v1beta1/experiment/util/status_util.go
@@ -65,6 +65,7 @@ func updateTrialsSummary(instance *experimentsv1beta1.Experiment, trials *trials
 	sts.KilledTrialList = nil
 	sts.EarlyStoppedTrialList = nil
 	sts.MetricsUnavailableTrialList = nil
+	sts.TrialsProgress = nil
 	bestTrialIndex := -1
 	isObjectiveGoalReached := false
 	var objectiveValueGoal float64
@@ -75,6 +76,19 @@ func updateTrialsSummary(instance *experimentsv1beta1.Experiment, trials *trials
 
 	for index, trial := range trials.Items {
 		sts.Trials++
+
+		if trial.Status.TrainerStatus != nil || trial.Spec.MetricsCollector.Collector.Kind == commonv1beta1.TrainerStatusCollector {
+			sts.TrialsProgress = append(sts.TrialsProgress, experimentsv1beta1.TrialProgress{
+				TrialName:                 trial.Name,
+				ProgressPercentage:        getTrainerStatusProgressPercentage(&trial),
+				EstimatedRemainingSeconds: getTrainerStatusEstimatedRemainingSeconds(&trial),
+				CurrentLoss:               getTrainerStatusLossValue(instance, &trial),
+				Status:                    getTrialStatusString(&trial),
+				EarlyStopReason:           getTrialEarlyStopReason(&trial),
+				LastUpdatedTime:           getTrainerStatusLastUpdatedTime(&trial),
+			})
+		}
+
 		if trial.IsKilled() {
 			sts.KilledTrialList = append(sts.KilledTrialList, trial.Name)
 		} else if trial.IsFailed() {
@@ -148,6 +162,89 @@ func updateTrialsSummary(instance *experimentsv1beta1.Experiment, trials *trials
 		sts.CurrentOptimalTrial.Observation.Metrics = append(sts.CurrentOptimalTrial.Observation.Metrics, bestTrial.Status.Observation.Metrics...)
 	}
 	return isObjectiveGoalReached
+}
+
+func getTrainerStatusProgressPercentage(trial *trialsv1beta1.Trial) *int32 {
+	if trial.Status.TrainerStatus == nil {
+		return nil
+	}
+	return trial.Status.TrainerStatus.ProgressPercentage
+}
+
+func getTrainerStatusEstimatedRemainingSeconds(trial *trialsv1beta1.Trial) *int32 {
+	if trial.Status.TrainerStatus == nil {
+		return nil
+	}
+	return trial.Status.TrainerStatus.EstimatedRemainingSeconds
+}
+
+func getTrainerStatusLastUpdatedTime(trial *trialsv1beta1.Trial) *metav1.Time {
+	if trial.Status.TrainerStatus == nil {
+		return nil
+	}
+	return trial.Status.TrainerStatus.LastUpdatedTime
+}
+
+func getTrainerStatusLossValue(exp *experimentsv1beta1.Experiment, trial *trialsv1beta1.Trial) string {
+	if trial.Status.TrainerStatus == nil {
+		return ""
+	}
+	// Prefer conventional name "loss", then fall back to objective metric name.
+	if v, ok := findTrainerMetricValue(trial.Status.TrainerStatus.Metrics, "loss"); ok {
+		return v
+	}
+	if exp != nil && exp.Spec.Objective != nil {
+		if v, ok := findTrainerMetricValue(trial.Status.TrainerStatus.Metrics, exp.Spec.Objective.ObjectiveMetricName); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+func findTrainerMetricValue(metrics []trialsv1beta1.TrainerMetric, name string) (string, bool) {
+	for _, m := range metrics {
+		if m.Name == name {
+			return m.Value, true
+		}
+	}
+	return "", false
+}
+
+func getTrialStatusString(trial *trialsv1beta1.Trial) string {
+	if trial.IsSucceeded() {
+		return string(trialsv1beta1.TrialSucceeded)
+	}
+	if trial.IsFailed() {
+		return string(trialsv1beta1.TrialFailed)
+	}
+	if trial.IsKilled() {
+		return string(trialsv1beta1.TrialKilled)
+	}
+	if trial.IsEarlyStopped() {
+		return string(trialsv1beta1.TrialEarlyStopped)
+	}
+	if trial.IsMetricsUnavailable() {
+		return string(trialsv1beta1.TrialMetricsUnavailable)
+	}
+	if trial.IsRunning() {
+		return string(trialsv1beta1.TrialRunning)
+	}
+	if trial.IsCreated() {
+		return string(trialsv1beta1.TrialCreated)
+	}
+	return ""
+}
+
+func getTrialEarlyStopReason(trial *trialsv1beta1.Trial) string {
+	if !trial.IsEarlyStopped() {
+		return ""
+	}
+	for _, c := range trial.Status.Conditions {
+		if c.Type == trialsv1beta1.TrialEarlyStopped {
+			return c.Reason
+		}
+	}
+	return ""
 }
 
 func getObjectiveMetricValue(trial trialsv1beta1.Trial) string {

--- a/pkg/controller.v1beta1/trial/trainerstatus_collector.go
+++ b/pkg/controller.v1beta1/trial/trainerstatus_collector.go
@@ -1,0 +1,105 @@
+package trial
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	commonapiv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
+	trialsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/trials/v1beta1"
+	api_pb "github.com/kubeflow/katib/pkg/apis/manager/v1beta1"
+)
+
+const (
+	defaultTrainerStatusReportInterval = 5 * time.Second
+	maxTrainerStatusMetrics            = 128
+)
+
+func (r *ReconcileTrial) UpdateTrialStatusTrainerStatus(instance *trialsv1beta1.Trial, deployedJob *unstructured.Unstructured) error {
+	if deployedJob == nil {
+		return nil
+	}
+	if instance.Spec.MetricsCollector.Collector.Kind != commonapiv1beta1.TrainerStatusCollector {
+		return nil
+	}
+
+	gvk := schema.FromAPIVersionAndKind(deployedJob.GetAPIVersion(), deployedJob.GetKind())
+	if gvk.Group != "trainer.kubeflow.org" || deployedJob.GetKind() != "TrainJob" {
+		return nil
+	}
+
+	statusMap, found, err := unstructured.NestedMap(deployedJob.Object, "status", "trainerStatus")
+	if err != nil {
+		return fmt.Errorf("get TrainJob.status.trainerStatus: %w", err)
+	}
+	if !found {
+		return nil
+	}
+
+	payloadBytes, err := json.Marshal(statusMap)
+	if err != nil {
+		return fmt.Errorf("marshal TrainJob.status.trainerStatus: %w", err)
+	}
+
+	var incoming trialsv1beta1.TrainerStatus
+	if err := json.Unmarshal(payloadBytes, &incoming); err != nil {
+		return fmt.Errorf("unmarshal TrainJob.status.trainerStatus: %w", err)
+	}
+
+	if incoming.LastUpdatedTime == nil {
+		// Trainer requires lastUpdatedTime when trainerStatus is present; if missing, ignore.
+		return nil
+	}
+
+	if instance.Status.TrainerStatus != nil && instance.Status.TrainerStatus.LastUpdatedTime != nil {
+		if instance.Status.TrainerStatus.LastUpdatedTime.Time.Equal(incoming.LastUpdatedTime.Time) {
+			return nil
+		}
+	}
+
+	if instance.Status.TrainerStatusLastReportedTime != nil {
+		if time.Since(instance.Status.TrainerStatusLastReportedTime.Time) < defaultTrainerStatusReportInterval {
+			return nil
+		}
+	}
+
+	// Report TrainerStatus metrics to Katib DB so Katib can build metric history.
+	if len(incoming.Metrics) > 0 {
+		metrics := incoming.Metrics
+		if len(metrics) > maxTrainerStatusMetrics {
+			metrics = metrics[:maxTrainerStatusMetrics]
+		}
+
+		timestamp := incoming.LastUpdatedTime.Time.UTC().Format(time.RFC3339Nano)
+		metricLogs := make([]*api_pb.MetricLog, 0, len(metrics))
+		for _, m := range metrics {
+			if m.Name == "" {
+				continue
+			}
+			metricLogs = append(metricLogs, &api_pb.MetricLog{
+				TimeStamp: timestamp,
+				Metric: &api_pb.Metric{
+					Name:  m.Name,
+					Value: m.Value,
+				},
+			})
+		}
+
+		if len(metricLogs) > 0 {
+			observationLog := &api_pb.ObservationLog{MetricLogs: metricLogs}
+			if _, err := r.ReportTrialObservationLog(instance, observationLog); err != nil {
+				return fmt.Errorf("%w: %w", errReportMetricsFailed, err)
+			}
+		}
+	}
+
+	instance.Status.TrainerStatus = &incoming
+	now := metav1.Now()
+	instance.Status.TrainerStatusLastReportedTime = &now
+
+	return nil
+}

--- a/pkg/controller.v1beta1/trial/trainerstatus_collector_test.go
+++ b/pkg/controller.v1beta1/trial/trainerstatus_collector_test.go
@@ -1,0 +1,116 @@
+package trial
+
+import (
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	commonv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/common/v1beta1"
+	trialsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/trials/v1beta1"
+	api_pb "github.com/kubeflow/katib/pkg/apis/manager/v1beta1"
+	managerclientmock "github.com/kubeflow/katib/pkg/mock/v1beta1/trial/managerclient"
+)
+
+type observationLogMatcher struct {
+	expectedTimestamp string
+	expectedMetrics   map[string]string
+}
+
+func (m observationLogMatcher) Matches(x any) bool {
+	obs, ok := x.(*api_pb.ObservationLog)
+	if !ok || obs == nil {
+		return false
+	}
+	if len(obs.MetricLogs) != len(m.expectedMetrics) {
+		return false
+	}
+	seen := map[string]string{}
+	for _, ml := range obs.MetricLogs {
+		if ml == nil || ml.Metric == nil {
+			return false
+		}
+		if ml.TimeStamp != m.expectedTimestamp {
+			return false
+		}
+		seen[ml.Metric.Name] = ml.Metric.Value
+	}
+	for k, v := range m.expectedMetrics {
+		if seen[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (m observationLogMatcher) String() string {
+	return "matches expected ObservationLog"
+}
+
+func TestUpdateTrialStatusTrainerStatus(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockManagerClient := managerclientmock.NewMockManagerClient(mockCtrl)
+
+	r := &ReconcileTrial{ManagerClient: mockManagerClient}
+
+	trial := &trialsv1beta1.Trial{}
+	trial.Name = "trial-1"
+	trial.Namespace = "default"
+	trial.Spec.Objective = &commonv1beta1.ObjectiveSpec{ObjectiveMetricName: "loss"}
+	trial.Spec.MetricsCollector = commonv1beta1.MetricsCollectorSpec{Collector: &commonv1beta1.CollectorSpec{Kind: commonv1beta1.TrainerStatusCollector}}
+
+	trainJob := &unstructured.Unstructured{}
+	trainJob.SetAPIVersion("trainer.kubeflow.org/v1alpha1")
+	trainJob.SetKind("TrainJob")
+	trainJob.SetName("trainjob-1")
+	trainJob.SetNamespace("default")
+	trainJob.Object = map[string]any{
+		"apiVersion": "trainer.kubeflow.org/v1alpha1",
+		"kind":       "TrainJob",
+		"metadata": map[string]any{
+			"name":      "trainjob-1",
+			"namespace": "default",
+		},
+		"status": map[string]any{
+			"trainerStatus": map[string]any{
+				"progressPercentage":        int64(42),
+				"estimatedRemainingSeconds": int64(120),
+				"metrics": []any{
+					map[string]any{"name": "loss", "value": "0.123"},
+					map[string]any{"name": "accuracy", "value": "0.99"},
+				},
+				"lastUpdatedTime": "2024-01-02T03:04:05Z",
+			},
+		},
+	}
+
+	mockManagerClient.EXPECT().ReportTrialObservationLog(gomock.Any(), observationLogMatcher{
+		expectedTimestamp: "2024-01-02T03:04:05Z",
+		expectedMetrics: map[string]string{
+			"loss":     "0.123",
+			"accuracy": "0.99",
+		},
+	}).Return(&api_pb.ReportObservationLogReply{}, nil).Times(1)
+
+	err := r.UpdateTrialStatusTrainerStatus(trial, trainJob)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(trial.Status.TrainerStatus).NotTo(gomega.BeNil())
+	g.Expect(trial.Status.TrainerStatus.ProgressPercentage).NotTo(gomega.BeNil())
+	g.Expect(*trial.Status.TrainerStatus.ProgressPercentage).To(gomega.Equal(int32(42)))
+	g.Expect(trial.Status.TrainerStatus.EstimatedRemainingSeconds).NotTo(gomega.BeNil())
+	g.Expect(*trial.Status.TrainerStatus.EstimatedRemainingSeconds).To(gomega.Equal(int32(120)))
+	g.Expect(trial.Status.TrainerStatus.LastUpdatedTime).NotTo(gomega.BeNil())
+	expectedTime, err := time.Parse(time.RFC3339, "2024-01-02T03:04:05Z")
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(trial.Status.TrainerStatus.LastUpdatedTime.Time).To(gomega.Equal(expectedTime))
+	g.Expect(trial.Status.TrainerStatusLastReportedTime).NotTo(gomega.BeNil())
+
+	// Dedupe: same lastUpdatedTime should not trigger another report.
+	err = r.UpdateTrialStatusTrainerStatus(trial, trainJob)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+}

--- a/pkg/controller.v1beta1/trial/trial_controller.go
+++ b/pkg/controller.v1beta1/trial/trial_controller.go
@@ -247,6 +247,14 @@ func (r *ReconcileTrial) reconcileTrial(instance *trialsv1beta1.Trial) error {
 			return nil
 		}
 
+		// Update Trial.status.trainerStatus and report metrics to Katib DB for Trainer TrainJobs.
+		if instance.Spec.MetricsCollector.Collector.Kind == commonapiv1beta1.TrainerStatusCollector {
+			if err := r.UpdateTrialStatusTrainerStatus(instance, deployedJob); err != nil {
+				logger.Error(err, "Update trial status trainerStatus error")
+				return err
+			}
+		}
+
 		// If Job status is succeeded or Trial is early stopped, update Trial observation.
 		if jobStatus.Condition == trialutil.JobSucceeded || instance.IsEarlyStopped() {
 			if err = r.UpdateTrialStatusObservation(instance); err != nil {
@@ -260,7 +268,8 @@ func (r *ReconcileTrial) reconcileTrial(instance *trialsv1beta1.Trial) error {
 		// We need to requeue reconcile when the Trial is succeeded, metrics collector's type is not `Push`, and metrics are not reported.
 		if jobStatus.Condition == trialutil.JobSucceeded &&
 			instance.Status.Observation == nil &&
-			instance.Spec.MetricsCollector.Collector.Kind != commonapiv1beta1.PushCollector {
+			instance.Spec.MetricsCollector.Collector.Kind != commonapiv1beta1.PushCollector &&
+			instance.Spec.MetricsCollector.Collector.Kind != commonapiv1beta1.TrainerStatusCollector {
 			logger.Info("Trial job is succeeded but metrics are not reported, reconcile requeued")
 			return errMetricsNotReported
 		}

--- a/pkg/controller.v1beta1/trial/trial_controller_util.go
+++ b/pkg/controller.v1beta1/trial/trial_controller_util.go
@@ -70,9 +70,10 @@ func (r *ReconcileTrial) UpdateTrialStatusCondition(instance *trialsv1beta1.Tria
 			msg := "Metrics are not available"
 			reason := TrialMetricsUnavailableReason
 
-			// If the type of metrics collector is Push, We should insert an unavailable value to Katib DB.
+			// If the type of metrics collector is Push or TrainerStatus, we should insert an unavailable value to Katib DB.
 			// We would retry reconciliation if some error occurs while we report unavailable metrics.
-			if instance.Spec.MetricsCollector.Collector.Kind == commonv1beta1.PushCollector {
+			if instance.Spec.MetricsCollector.Collector.Kind == commonv1beta1.PushCollector ||
+				instance.Spec.MetricsCollector.Collector.Kind == commonv1beta1.TrainerStatusCollector {
 				if err := r.reportUnavailableMetrics(instance); err != nil {
 					logger.Error(err, "Failed to insert unavailable value to Katib DB")
 					return fmt.Errorf("%w: %w", errReportMetricsFailed, err)

--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -502,6 +502,18 @@ func (g *DefaultValidator) validateMetricsCollector(inst *experimentsv1beta1.Exp
 	switch mcKind {
 	case commonapiv1beta1.PushCollector, commonapiv1beta1.StdOutCollector:
 		return allErrs
+	case commonapiv1beta1.TrainerStatusCollector:
+		if inst.Spec.TrialTemplate.TrialSpec == nil {
+			allErrs = append(allErrs, field.Required(trialTemplatePath.Child("trialSpec"),
+				"trialSpec is required for TrainerStatus metrics collector"))
+			return allErrs
+		}
+		gvk := inst.Spec.TrialTemplate.TrialSpec.GroupVersionKind()
+		if gvk.Group != "trainer.kubeflow.org" || gvk.Kind != "TrainJob" {
+			allErrs = append(allErrs, field.Invalid(trialTemplatePath.Child("trialSpec"),
+				gvk.String(), "TrainerStatus metrics collector is supported only for trainer.kubeflow.org/TrainJob"))
+		}
+		return allErrs
 	case commonapiv1beta1.FileCollector:
 		if mcSpec.Source == nil || mcSpec.Source.FileSystemPath == nil ||
 			mcSpec.Source.FileSystemPath.Kind != commonapiv1beta1.FileKind || !filepath.IsAbs(mcSpec.Source.FileSystemPath.Path) {

--- a/pkg/webhook/v1beta1/pod/inject_webhook.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook.go
@@ -162,8 +162,9 @@ func (s *SidecarInjector) Mutate(pod *v1.Pod, namespace string) (*v1.Pod, error)
 		return mutatedPod, nil
 	}
 
-	// If Metrics Collector is Push, skip the mutation.
-	if trial.Spec.MetricsCollector.Collector.Kind == common.PushCollector {
+	// If Metrics Collector doesn't require sidecar, skip the mutation.
+	if trial.Spec.MetricsCollector.Collector.Kind == common.PushCollector ||
+		trial.Spec.MetricsCollector.Collector.Kind == common.TrainerStatusCollector {
 		return mutatedPod, nil
 	}
 


### PR DESCRIPTION
## Overview

This PR integrates Katib with Kubeflow Trainer’s progress tracking (`TrainJob.status.trainerStatus`)(https://github.com/kubeflow/trainer/pull/3227) to enable real-time visibility into trial progress and convergence.

- Trainer acts as the **publisher** of live training progress  
- Katib becomes a **consumer**, surfacing progress and persisting metric history  

This removes the need for log scraping / sidecars and aligns with a push-based metrics model for HPO workflows.

---

## What’s included

- Added a new metrics collector: `TrainerStatus`
- During Trial reconciliation:
  - Read `TrainJob.status.trainerStatus`
  - Mirror latest snapshot into `Trial.status.trainerStatus`
  - Persist metrics as time-series (`MetricLog`) in Katib DB-manager
- Added `.status.trialsProgress` in Experiment for lightweight per-trial progress
- Disabled sidecar injection for this collector
- Validation restricts usage to Trainer `TrainJob` templates

---

## Metrics flow (single source of truth)

`TrainJob.status.trainerStatus` is treated as the **real-time source of truth**.

Katib:
- Reads latest snapshot from TrainJob status  
- Persists history to DB-manager for:
  - convergence visualization  
  - future scheduler / early stopping logic  

---

## Design clarification (metrics pipeline)

Current design discussions mix two push pipelines:

1. Training → **Katib DB-manager (SDK/gRPC)**
2. Training → **Trainer → TrainJob.status.trainerStatus**

This creates **two independent metric streams**, leading to:
- duplicate / inconsistent data  
- unclear source of truth  
- added complexity in merging/deduplication  

This PR adopts a clearer model:

> **TrainerStatus = source of truth (real-time)**  
> **Katib DB = archival layer (history)**

This aligns better with the proposed **OptimizationJob CRD**, where:
- Trainer owns execution + progress
- Katib focuses on orchestration, scheduling, and history

---

## Scope

This PR delivers a minimal vertical slice:
- Read TrainerStatus  
- Surface real-time progress  
- Persist metric history  

Follow-ups will include:
- Expanded testing (envtest, edge cases)  
- Convergence-aware schedulers (median, Hyperband, etc.)  
- UI support for convergence graphs  

---

## Notes

- Requires enabling the Trainer `TrainJobStatus` feature gate  
- If disabled, no progress will be emitted or collected  


@andreyvelich , @abhijeet-dhumal , @akshaychitneni 
Addresses the issue : https://github.com/kubeflow/katib/issues/2637