### PR TITLE
Refactor Katib Context Management: Replace context.TODO() with Propagated context.Context

### DIFF
--- a/pkg/controller.v1beta1/experiment/experiment_controller.go
+++ b/pkg/controller.v1beta1/experiment/experiment_controller.go
@@ -234,7 +234,7 @@ func (r *ReconcileExperiment) Reconcile(ctx context.Context, request reconcile.R
 		msg := "Experiment is created"
 		instance.MarkExperimentStatusCreated(util.ExperimentCreatedReason, msg)
 	} else {
-		err := r.ReconcileExperiment(instance)
+		err := r.ReconcileExperiment(ctx, instance)
 		if err != nil {
 			logger.Error(err, "Reconcile experiment error")
 			r.recorder.Eventf(instance,
@@ -246,7 +246,7 @@ func (r *ReconcileExperiment) Reconcile(ctx context.Context, request reconcile.R
 
 	if !equality.Semantic.DeepEqual(original.Status, instance.Status) {
 		//assuming that only status change
-		err = r.updateStatusHandler(instance)
+		err = r.updateStatusHandler(ctx, instance)
 		if err != nil {
 			logger.Info("Update experiment instance status failed, reconciler requeued", "err", err)
 			return reconcile.Result{
@@ -259,12 +259,12 @@ func (r *ReconcileExperiment) Reconcile(ctx context.Context, request reconcile.R
 }
 
 // ReconcileExperiment is the main reconcile loop.
-func (r *ReconcileExperiment) ReconcileExperiment(instance *experimentsv1beta1.Experiment) error {
+func (r *ReconcileExperiment) ReconcileExperiment(ctx context.Context, instance *experimentsv1beta1.Experiment) error {
 	logger := log.WithValues("Experiment", types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()})
 	trials := &trialsv1beta1.TrialList{}
 	labels := map[string]string{consts.LabelExperimentName: instance.Name}
 
-	if err := r.List(context.TODO(), trials, client.InNamespace(instance.Namespace), client.MatchingLabels(labels)); err != nil {
+	if err := r.List(ctx, trials, client.InNamespace(instance.Namespace), client.MatchingLabels(labels)); err != nil {
 		logger.Error(err, "Trial List error")
 		return err
 	}
@@ -276,14 +276,14 @@ func (r *ReconcileExperiment) ReconcileExperiment(instance *experimentsv1beta1.E
 	}
 	reconcileRequired := !instance.IsCompleted()
 	if reconcileRequired {
-		return r.ReconcileTrials(instance, trials.Items)
+		return r.ReconcileTrials(ctx, instance, trials.Items)
 	}
 
 	return nil
 }
 
 // ReconcileTrials syncs trials.
-func (r *ReconcileExperiment) ReconcileTrials(instance *experimentsv1beta1.Experiment, trials []trialsv1beta1.Trial) error {
+func (r *ReconcileExperiment) ReconcileTrials(ctx context.Context, instance *experimentsv1beta1.Experiment, trials []trialsv1beta1.Trial) error {
 
 	logger := log.WithValues("Experiment", types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()})
 
@@ -296,7 +296,7 @@ func (r *ReconcileExperiment) ReconcileTrials(instance *experimentsv1beta1.Exper
 		if deleteCount > 0 {
 			//delete 'deleteCount' number of trails. Sort them?
 			logger.Info("DeleteTrials", "deleteCount", deleteCount)
-			if err := r.deleteTrials(instance, trials, deleteCount); err != nil {
+			if err := r.deleteTrials(ctx, instance, trials, deleteCount); err != nil {
 				logger.Error(err, "Delete trials error")
 				return err
 			}
@@ -330,7 +330,7 @@ func (r *ReconcileExperiment) ReconcileTrials(instance *experimentsv1beta1.Exper
 		//skip if no trials need to be created
 		if addCount > 0 {
 			//create "addCount" number of trials
-			if err := r.createTrials(instance, trials, addCount); err != nil {
+			if err := r.createTrials(ctx, instance, trials, addCount); err != nil {
 				logger.Error(err, "Create trials error")
 				return err
 			}
@@ -341,7 +341,7 @@ func (r *ReconcileExperiment) ReconcileTrials(instance *experimentsv1beta1.Exper
 
 }
 
-func (r *ReconcileExperiment) createTrials(instance *experimentsv1beta1.Experiment, trialList []trialsv1beta1.Trial, addCount int32) error {
+func (r *ReconcileExperiment) createTrials(ctx context.Context, instance *experimentsv1beta1.Experiment, trialList []trialsv1beta1.Trial, addCount int32) error {
 
 	logger := log.WithValues("Experiment", types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()})
 	logger.Info("Reconcile Suggestion", "addCount", addCount)
@@ -358,7 +358,7 @@ func (r *ReconcileExperiment) createTrials(instance *experimentsv1beta1.Experime
 			return err
 		}
 		// Due to unsynchronised policy of Kubernetes controllers, trial creation can fail.
-		if err = r.Create(context.TODO(), trialInstance); err != nil {
+		if err = r.Create(ctx, trialInstance); err != nil {
 			logger.Error(err, "Trial create error", "Trial name", trial.Name)
 			continue
 		}
@@ -371,7 +371,7 @@ func (r *ReconcileExperiment) createTrials(instance *experimentsv1beta1.Experime
 	return nil
 }
 
-func (r *ReconcileExperiment) deleteTrials(instance *experimentsv1beta1.Experiment,
+func (r *ReconcileExperiment) deleteTrials(ctx context.Context, instance *experimentsv1beta1.Experiment,
 	trials []trialsv1beta1.Trial,
 	expectedDeletions int32) error {
 	logger := log.WithValues("Experiment", types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()})
@@ -392,7 +392,7 @@ func (r *ReconcileExperiment) deleteTrials(instance *experimentsv1beta1.Experime
 	}
 	deletedNames := []string{}
 	for i := 0; i < expected; i++ {
-		if err := r.Delete(context.TODO(), &trialSlice[i]); err != nil {
+		if err := r.Delete(ctx, &trialSlice[i]); err != nil {
 			logger.Error(err, "Trial Delete error")
 			return err
 		}
@@ -406,7 +406,7 @@ func (r *ReconcileExperiment) deleteTrials(instance *experimentsv1beta1.Experime
 	for _, name := range deletedNames {
 		var err error
 		for !errors.IsNotFound(err) && time.Now().Before(endTime) {
-			err = r.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: instance.GetNamespace()}, &trialsv1beta1.Trial{})
+			err = r.Get(ctx, types.NamespacedName{Name: name, Namespace: instance.GetNamespace()}, &trialsv1beta1.Trial{})
 		}
 		// If trials were deleted, err == IsNotFound, return error if timeout is out
 		if !errors.IsNotFound(err) {
@@ -416,7 +416,7 @@ func (r *ReconcileExperiment) deleteTrials(instance *experimentsv1beta1.Experime
 
 	// We have to delete trials from suggestion status and update SuggestionCount
 	suggestion := &suggestionsv1beta1.Suggestion{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}, suggestion)
+	err := r.Get(ctx, types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}, suggestion)
 	if err != nil {
 		logger.Error(err, "Suggestion Get error")
 		return err

--- a/pkg/controller.v1beta1/experiment/experiment_controller_status.go
+++ b/pkg/controller.v1beta1/experiment/experiment_controller_status.go
@@ -22,10 +22,10 @@ import (
 	experimentsv1beta1 "github.com/kubeflow/katib/pkg/apis/controller/experiments/v1beta1"
 )
 
-type updateStatusFunc func(instance *experimentsv1beta1.Experiment) error
+type updateStatusFunc func(ctx context.Context, instance *experimentsv1beta1.Experiment) error
 
-func (r *ReconcileExperiment) updateStatus(instance *experimentsv1beta1.Experiment) error {
-	err := r.Status().Update(context.TODO(), instance)
+func (r *ReconcileExperiment) updateStatus(ctx context.Context, instance *experimentsv1beta1.Experiment) error {
+	err := r.Status().Update(ctx, instance)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller.go
@@ -148,11 +148,11 @@ func (r *ReconcileSuggestion) Reconcile(ctx context.Context, request reconcile.R
 	instance := oldS.DeepCopy()
 	// Suggestion will be succeeded if ResumePolicy = Never or ResumePolicy = FromVolume
 	if instance.IsSucceeded() {
-		err = r.deleteDeployment(instance, request.NamespacedName)
+		err = r.deleteDeployment(ctx, instance, request.NamespacedName)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		err = r.deleteService(instance, request.NamespacedName)
+		err = r.deleteService(ctx, instance, request.NamespacedName)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -166,7 +166,7 @@ func (r *ReconcileSuggestion) Reconcile(ctx context.Context, request reconcile.R
 		msg := "Suggestion is created"
 		instance.MarkSuggestionStatusCreated(SuggestionCreatedReason, msg)
 	} else {
-		err := r.ReconcileSuggestion(instance)
+		err := r.ReconcileSuggestion(ctx, instance)
 		if err != nil {
 			r.recorder.Eventf(instance, corev1.EventTypeWarning,
 				consts.ReconcileErrorReason, err.Error())
@@ -174,13 +174,13 @@ func (r *ReconcileSuggestion) Reconcile(ctx context.Context, request reconcile.R
 			// Try updating just the status condition when possible
 			// Status conditions might need to be updated even in error
 			// Ignore all other status fields else it will be inconsistent during retry
-			_ = r.updateStatusCondition(instance, oldS)
+			_ = r.updateStatusCondition(ctx, instance, oldS)
 			logger.Error(err, "Reconcile Suggestion error")
 			return reconcile.Result{}, err
 		}
 	}
 
-	if err := r.updateStatus(instance, oldS); err != nil {
+	if err := r.updateStatus(ctx, instance, oldS); err != nil {
 		logger.Info("Update suggestion instance status failed, reconciler requeued", "err", err)
 		return reconcile.Result{
 			Requeue: true,
@@ -190,7 +190,7 @@ func (r *ReconcileSuggestion) Reconcile(ctx context.Context, request reconcile.R
 }
 
 // ReconcileSuggestion is the main reconcile loop for suggestion CR.
-func (r *ReconcileSuggestion) ReconcileSuggestion(instance *suggestionsv1beta1.Suggestion) error {
+func (r *ReconcileSuggestion) ReconcileSuggestion(ctx context.Context, instance *suggestionsv1beta1.Suggestion) error {
 	suggestionNsName := types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
 	logger := log.WithValues("Suggestion", suggestionNsName)
 
@@ -202,7 +202,7 @@ func (r *ReconcileSuggestion) ReconcileSuggestion(instance *suggestionsv1beta1.S
 		}
 
 		// Reconcile PVC and PV
-		_, _, err = r.reconcileVolume(pvc, pv, suggestionNsName)
+		_, _, err = r.reconcileVolume(ctx, pvc, pv, suggestionNsName)
 		if err != nil {
 			return err
 		}
@@ -213,7 +213,7 @@ func (r *ReconcileSuggestion) ReconcileSuggestion(instance *suggestionsv1beta1.S
 	if err != nil {
 		return err
 	}
-	_, err = r.reconcileService(service, suggestionNsName)
+	_, err = r.reconcileService(ctx, service, suggestionNsName)
 	if err != nil {
 		return err
 	}
@@ -234,13 +234,13 @@ func (r *ReconcileSuggestion) ReconcileSuggestion(instance *suggestionsv1beta1.S
 		}
 
 		// Reconcile ServiceAccount, Role and RoleBinding
-		err = r.reconcileRBAC(serviceAccount, role, roleBinding, suggestionNsName)
+		err = r.reconcileRBAC(ctx, serviceAccount, role, roleBinding, suggestionNsName)
 		if err != nil {
 			return err
 		}
 	}
 
-	if foundDeploy, err := r.reconcileDeployment(deploy, suggestionNsName); err != nil {
+	if foundDeploy, err := r.reconcileDeployment(ctx, deploy, suggestionNsName); err != nil {
 		return err
 	} else {
 		if !r.checkDeploymentReady(foundDeploy) {
@@ -257,14 +257,14 @@ func (r *ReconcileSuggestion) ReconcileSuggestion(instance *suggestionsv1beta1.S
 	experiment := &experimentsv1beta1.Experiment{}
 	trials := &trialsv1beta1.TrialList{}
 
-	if err := r.Get(context.TODO(), types.NamespacedName{
+	if err := r.Get(ctx, types.NamespacedName{
 		Name:      instance.Name,
 		Namespace: instance.Namespace,
 	}, experiment); err != nil {
 		return err
 	}
 
-	if err := r.List(context.TODO(), trials, client.MatchingLabels(util.TrialLabels(experiment))); err != nil {
+	if err := r.List(ctx, trials, client.MatchingLabels(util.TrialLabels(experiment))); err != nil {
 		return err
 	}
 	// TODO (andreyvelich): Do we want to run ValidateAlgorithmSettings when Experiment is restarting?

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller_status.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller_status.go
@@ -31,21 +31,21 @@ const (
 	SuggestionFailedReason       = "SuggestionFailed"
 )
 
-func (r *ReconcileSuggestion) updateStatus(s *suggestionsv1beta1.Suggestion, oldS *suggestionsv1beta1.Suggestion) error {
+func (r *ReconcileSuggestion) updateStatus(ctx context.Context, s *suggestionsv1beta1.Suggestion, oldS *suggestionsv1beta1.Suggestion) error {
 	if !equality.Semantic.DeepEqual(s.Status, oldS.Status) {
-		if err := r.Status().Update(context.TODO(), s); err != nil {
+		if err := r.Status().Update(ctx, s); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (r *ReconcileSuggestion) updateStatusCondition(s *suggestionsv1beta1.Suggestion, oldS *suggestionsv1beta1.Suggestion) error {
+func (r *ReconcileSuggestion) updateStatusCondition(ctx context.Context, s *suggestionsv1beta1.Suggestion, oldS *suggestionsv1beta1.Suggestion) error {
 	if !equality.Semantic.DeepEqual(s.Status.Conditions, oldS.Status.Conditions) {
 		newConditions := s.Status.Conditions
 		s.Status = oldS.Status
 		s.Status.Conditions = newConditions
-		if err := r.Status().Update(context.TODO(), s); err != nil {
+		if err := r.Status().Update(ctx, s); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller.v1beta1/suggestion/suggestion_controller_util.go
+++ b/pkg/controller.v1beta1/suggestion/suggestion_controller_util.go
@@ -28,13 +28,13 @@ import (
 	"github.com/kubeflow/katib/pkg/apis/controller/suggestions/v1beta1"
 )
 
-func (r *ReconcileSuggestion) reconcileDeployment(deploy *appsv1.Deployment, suggestionNsName types.NamespacedName) (*appsv1.Deployment, error) {
+func (r *ReconcileSuggestion) reconcileDeployment(ctx context.Context, deploy *appsv1.Deployment, suggestionNsName types.NamespacedName) (*appsv1.Deployment, error) {
 	logger := log.WithValues("Suggestion", suggestionNsName)
 	foundDeploy := &appsv1.Deployment{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}, foundDeploy)
+	err := r.Get(ctx, types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}, foundDeploy)
 	if err != nil && errors.IsNotFound(err) {
 		logger.Info("Creating Deployment", "name", deploy.Name)
-		err = r.Create(context.TODO(), deploy)
+		err = r.Create(ctx, deploy)
 		return nil, err
 	} else if err != nil {
 		return nil, err
@@ -42,13 +42,13 @@ func (r *ReconcileSuggestion) reconcileDeployment(deploy *appsv1.Deployment, sug
 	return foundDeploy, nil
 }
 
-func (r *ReconcileSuggestion) reconcileService(service *corev1.Service, suggestionNsName types.NamespacedName) (*corev1.Service, error) {
+func (r *ReconcileSuggestion) reconcileService(ctx context.Context, service *corev1.Service, suggestionNsName types.NamespacedName) (*corev1.Service, error) {
 	logger := log.WithValues("Suggestion", suggestionNsName)
 	foundService := &corev1.Service{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, foundService)
+	err := r.Get(ctx, types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, foundService)
 	if err != nil && errors.IsNotFound(err) {
 		logger.Info("Creating Service", "name", service.Name)
-		err = r.Create(context.TODO(), service)
+		err = r.Create(ctx, service)
 		return nil, err
 	} else if err != nil {
 		return nil, err
@@ -57,6 +57,7 @@ func (r *ReconcileSuggestion) reconcileService(service *corev1.Service, suggesti
 }
 
 func (r *ReconcileSuggestion) reconcileVolume(
+	ctx context.Context,
 	pvc *corev1.PersistentVolumeClaim,
 	pv *corev1.PersistentVolume,
 	suggestionNsName types.NamespacedName) (*corev1.PersistentVolumeClaim, *corev1.PersistentVolume, error) {
@@ -67,10 +68,10 @@ func (r *ReconcileSuggestion) reconcileVolume(
 
 	// Try to find/create PV, if PV has to be created.
 	if pv != nil {
-		err := r.Get(context.TODO(), types.NamespacedName{Name: pv.Name}, foundPV)
+		err := r.Get(ctx, types.NamespacedName{Name: pv.Name}, foundPV)
 		if err != nil && errors.IsNotFound(err) {
 			logger.Info("Creating Persistent Volume", "name", pv.Name)
-			err = r.Create(context.TODO(), pv)
+			err = r.Create(ctx, pv)
 			// Return only if Create was failed, otherwise try to find/create PVC.
 			if err != nil {
 				return nil, nil, err
@@ -81,10 +82,10 @@ func (r *ReconcileSuggestion) reconcileVolume(
 	}
 
 	// Try to find/create PVC.
-	err := r.Get(context.TODO(), types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, foundPVC)
+	err := r.Get(ctx, types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, foundPVC)
 	if err != nil && errors.IsNotFound(err) {
 		logger.Info("Creating Persistent Volume Claim", "name", pvc.Name)
-		err = r.Create(context.TODO(), pvc)
+		err = r.Create(ctx, pvc)
 		return nil, nil, err
 	} else if err != nil {
 		return nil, nil, err
@@ -93,6 +94,7 @@ func (r *ReconcileSuggestion) reconcileVolume(
 }
 
 func (r *ReconcileSuggestion) reconcileRBAC(
+	ctx context.Context,
 	sa *corev1.ServiceAccount,
 	role *rbacv1.Role,
 	roleBinding *rbacv1.RoleBinding,
@@ -105,10 +107,10 @@ func (r *ReconcileSuggestion) reconcileRBAC(
 	foundRoleBinding := &rbacv1.RoleBinding{}
 
 	// Try to find/create ServiceAccount
-	err := r.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: sa.Namespace}, foundSA)
+	err := r.Get(ctx, types.NamespacedName{Name: sa.Name, Namespace: sa.Namespace}, foundSA)
 	if err != nil && errors.IsNotFound(err) {
 		logger.Info("Creating Service Account", "name", sa.Name)
-		err = r.Create(context.TODO(), sa)
+		err = r.Create(ctx, sa)
 		// Return only if Create was failed, otherwise try to find/create Role and RoleBinding
 		if err != nil {
 			return err
@@ -118,10 +120,10 @@ func (r *ReconcileSuggestion) reconcileRBAC(
 	}
 
 	// Try to find/create Role
-	err = r.Get(context.TODO(), types.NamespacedName{Name: role.Name, Namespace: role.Namespace}, foundRole)
+	err = r.Get(ctx, types.NamespacedName{Name: role.Name, Namespace: role.Namespace}, foundRole)
 	if err != nil && errors.IsNotFound(err) {
 		logger.Info("Creating Role", "name", role.Name)
-		err = r.Create(context.TODO(), role)
+		err = r.Create(ctx, role)
 		if err != nil {
 			return err
 		}
@@ -130,10 +132,10 @@ func (r *ReconcileSuggestion) reconcileRBAC(
 	}
 
 	// Try to find/create RoleBinding
-	err = r.Get(context.TODO(), types.NamespacedName{Name: roleBinding.Name, Namespace: roleBinding.Namespace}, foundRoleBinding)
+	err = r.Get(ctx, types.NamespacedName{Name: roleBinding.Name, Namespace: roleBinding.Namespace}, foundRoleBinding)
 	if err != nil && errors.IsNotFound(err) {
 		logger.Info("Creating Role Binding", "name", roleBinding.Name)
-		err = r.Create(context.TODO(), roleBinding)
+		err = r.Create(ctx, roleBinding)
 		if err != nil {
 			return err
 		}
@@ -143,14 +145,14 @@ func (r *ReconcileSuggestion) reconcileRBAC(
 	return nil
 }
 
-func (r *ReconcileSuggestion) deleteDeployment(instance *v1beta1.Suggestion, suggestionNsName types.NamespacedName) error {
+func (r *ReconcileSuggestion) deleteDeployment(ctx context.Context, instance *v1beta1.Suggestion, suggestionNsName types.NamespacedName) error {
 	logger := log.WithValues("Suggestion", suggestionNsName)
 	deploy, err := r.DesiredDeployment(instance)
 	if err != nil {
 		return err
 	}
 	realDeploy := &appsv1.Deployment{}
-	err = r.Get(context.TODO(), types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}, realDeploy)
+	err = r.Get(ctx, types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}, realDeploy)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil
@@ -159,7 +161,7 @@ func (r *ReconcileSuggestion) deleteDeployment(instance *v1beta1.Suggestion, sug
 	}
 	logger.Info("Deleting Suggestion Deployment", "name", realDeploy.Name)
 
-	err = r.Delete(context.TODO(), realDeploy)
+	err = r.Delete(ctx, realDeploy)
 	if err != nil {
 		return err
 	}
@@ -167,14 +169,14 @@ func (r *ReconcileSuggestion) deleteDeployment(instance *v1beta1.Suggestion, sug
 	return nil
 }
 
-func (r *ReconcileSuggestion) deleteService(instance *v1beta1.Suggestion, suggestionNsName types.NamespacedName) error {
+func (r *ReconcileSuggestion) deleteService(ctx context.Context, instance *v1beta1.Suggestion, suggestionNsName types.NamespacedName) error {
 	logger := log.WithValues("Suggestion", suggestionNsName)
 	service, err := r.DesiredService(instance)
 	if err != nil {
 		return err
 	}
 	realService := &corev1.Service{}
-	err = r.Get(context.TODO(), types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, realService)
+	err = r.Get(ctx, types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, realService)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil
@@ -183,7 +185,7 @@ func (r *ReconcileSuggestion) deleteService(instance *v1beta1.Suggestion, sugges
 	}
 	logger.Info("Deleting Suggestion Service", "name", realService.Name)
 
-	err = r.Delete(context.TODO(), realService)
+	err = r.Delete(ctx, realService)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller.v1beta1/trial/trial_controller.go
+++ b/pkg/controller.v1beta1/trial/trial_controller.go
@@ -174,7 +174,7 @@ func (r *ReconcileTrial) Reconcile(ctx context.Context, request reconcile.Reques
 	instance := original.DeepCopy()
 
 	if needUpdate, finalizers := needUpdateFinalizers(instance); needUpdate {
-		return r.updateFinalizers(instance, finalizers)
+		return r.updateFinalizers(ctx, instance, finalizers)
 	}
 
 	if !instance.IsCreated() {
@@ -188,7 +188,7 @@ func (r *ReconcileTrial) Reconcile(ctx context.Context, request reconcile.Reques
 		msg := "Trial is created"
 		instance.MarkTrialStatusCreated(TrialCreatedReason, msg)
 	} else {
-		err := r.reconcileTrial(instance)
+		err := r.reconcileTrial(ctx, instance)
 		if err != nil {
 			if errors.Is(err, errMetricsNotReported) || errors.Is(err, errReportMetricsFailed) {
 				return reconcile.Result{
@@ -205,7 +205,7 @@ func (r *ReconcileTrial) Reconcile(ctx context.Context, request reconcile.Reques
 
 	if !equality.Semantic.DeepEqual(original.Status, instance.Status) {
 		//assuming that only status change
-		err = r.updateStatusHandler(instance)
+		err = r.updateStatusHandler(ctx, instance)
 		if err != nil {
 			logger.Info("Update trial instance status failed, reconcile requeued", "err", err)
 			return reconcile.Result{
@@ -217,7 +217,7 @@ func (r *ReconcileTrial) Reconcile(ctx context.Context, request reconcile.Reques
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileTrial) reconcileTrial(instance *trialsv1beta1.Trial) error {
+func (r *ReconcileTrial) reconcileTrial(ctx context.Context, instance *trialsv1beta1.Trial) error {
 
 	var err error
 	logger := log.WithValues("Trial", types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()})
@@ -227,7 +227,7 @@ func (r *ReconcileTrial) reconcileTrial(instance *trialsv1beta1.Trial) error {
 		return err
 	}
 
-	deployedJob, err := r.reconcileJob(instance, desiredJob)
+	deployedJob, err := r.reconcileJob(ctx, instance, desiredJob)
 	if err != nil {
 		logger.Error(err, "Reconcile job error")
 		return err
@@ -274,7 +274,7 @@ func (r *ReconcileTrial) reconcileTrial(instance *trialsv1beta1.Trial) error {
 	return nil
 }
 
-func (r *ReconcileTrial) reconcileJob(instance *trialsv1beta1.Trial, desiredJob *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+func (r *ReconcileTrial) reconcileJob(ctx context.Context, instance *trialsv1beta1.Trial, desiredJob *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	var err error
 	logger := log.WithValues("Trial", types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()})
 	apiVersion := desiredJob.GetAPIVersion()
@@ -283,7 +283,7 @@ func (r *ReconcileTrial) reconcileJob(instance *trialsv1beta1.Trial, desiredJob 
 
 	deployedJob := &unstructured.Unstructured{}
 	deployedJob.SetGroupVersionKind(gvk)
-	err = r.Get(context.TODO(), types.NamespacedName{Name: desiredJob.GetName(), Namespace: desiredJob.GetNamespace()}, deployedJob)
+	err = r.Get(ctx, types.NamespacedName{Name: desiredJob.GetName(), Namespace: desiredJob.GetNamespace()}, deployedJob)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			if instance.IsCompleted() {
@@ -292,7 +292,7 @@ func (r *ReconcileTrial) reconcileJob(instance *trialsv1beta1.Trial, desiredJob 
 
 			logger.Info("Creating Job", "kind", kind,
 				"name", desiredJob.GetName())
-			err = r.Create(context.TODO(), desiredJob)
+			err = r.Create(ctx, desiredJob)
 			if err != nil {
 				logger.Error(err, "Create job error")
 				return nil, err
@@ -309,7 +309,7 @@ func (r *ReconcileTrial) reconcileJob(instance *trialsv1beta1.Trial, desiredJob 
 		}
 	} else {
 		if instance.IsCompleted() && !instance.Spec.RetainRun {
-			if err = r.Delete(context.TODO(), desiredJob, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
+			if err = r.Delete(ctx, desiredJob, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
 				logger.Error(err, "Delete job error")
 				return nil, err
 			} else {

--- a/pkg/controller.v1beta1/trial/trial_controller_status.go
+++ b/pkg/controller.v1beta1/trial/trial_controller_status.go
@@ -39,10 +39,10 @@ const (
 	JobRunningReason            = "JobRunning"
 )
 
-type updateStatusFunc func(instance *trialsv1beta1.Trial) error
+type updateStatusFunc func(ctx context.Context, instance *trialsv1beta1.Trial) error
 
-func (r *ReconcileTrial) updateStatus(instance *trialsv1beta1.Trial) error {
-	err := r.Status().Update(context.TODO(), instance)
+func (r *ReconcileTrial) updateStatus(ctx context.Context, instance *trialsv1beta1.Trial) error {
+	err := r.Status().Update(ctx, instance)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller.v1beta1/trial/trial_controller_test.go
+++ b/pkg/controller.v1beta1/trial/trial_controller_test.go
@@ -149,7 +149,7 @@ func TestReconcileBatchJob(t *testing.T) {
 		collector:     trialutil.NewTrialsCollector(mgr.GetCache(), prometheus.NewRegistry()),
 	}
 
-	r.updateStatusHandler = func(instance *trialsv1beta1.Trial) error {
+	r.updateStatusHandler = func(ctx context.Context, instance *trialsv1beta1.Trial) error {
 		var err error = errors.NewBadRequest("fake-error")
 		// Try to update status until it be succeeded
 		for err != nil {
@@ -159,7 +159,7 @@ func TestReconcileBatchJob(t *testing.T) {
 				continue
 			}
 			updatedInstance.Status = instance.Status
-			err = r.updateStatus(updatedInstance)
+			err = r.updateStatus(ctx, updatedInstance)
 		}
 		return err
 	}
@@ -395,7 +395,7 @@ func TestReconcileBatchJob(t *testing.T) {
 
 	t.Run("Update status for empty Trial", func(t *testing.T) {
 		g := gomega.NewGomegaWithT(t)
-		g.Expect(r.updateStatus(&trialsv1beta1.Trial{})).To(gomega.HaveOccurred())
+		g.Expect(r.updateStatus(context.TODO(), &trialsv1beta1.Trial{})).To(gomega.HaveOccurred())
 	})
 
 }

--- a/pkg/controller.v1beta1/trial/trial_controller_util.go
+++ b/pkg/controller.v1beta1/trial/trial_controller_util.go
@@ -149,7 +149,7 @@ func (r *ReconcileTrial) UpdateTrialStatusObservation(instance *trialsv1beta1.Tr
 	return nil
 }
 
-func (r *ReconcileTrial) updateFinalizers(instance *trialsv1beta1.Trial, finalizers []string) (reconcile.Result, error) {
+func (r *ReconcileTrial) updateFinalizers(ctx context.Context, instance *trialsv1beta1.Trial, finalizers []string) (reconcile.Result, error) {
 	isDelete := true
 	if !instance.ObjectMeta.DeletionTimestamp.IsZero() {
 		if _, err := r.DeleteTrialObservationLog(instance); err != nil {
@@ -159,7 +159,7 @@ func (r *ReconcileTrial) updateFinalizers(instance *trialsv1beta1.Trial, finaliz
 		isDelete = false
 	}
 	instance.SetFinalizers(finalizers)
-	if err := r.Update(context.TODO(), instance); err != nil {
+	if err := r.Update(ctx, instance); err != nil {
 		return reconcile.Result{}, err
 	} else {
 		if isDelete {

--- a/pkg/webhook/v1beta1/pod/inject_webhook.go
+++ b/pkg/webhook/v1beta1/pod/inject_webhook.go
@@ -84,7 +84,7 @@ func (s *SidecarInjector) Handle(ctx context.Context, req admission.Request) adm
 	}
 
 	// Check whether the pod need to be mutated
-	needMutate, err := s.MutationRequired(pod, namespace)
+	needMutate, err := s.MutationRequired(ctx, pod, namespace)
 	if err != nil {
 		log.Info("Unable to run MutationRequired", "Error", err)
 		return admission.Errored(http.StatusInternalServerError, err)
@@ -93,7 +93,7 @@ func (s *SidecarInjector) Handle(ctx context.Context, req admission.Request) adm
 	}
 
 	// Do mutation
-	mutatedPod, err := s.Mutate(pod, namespace)
+	mutatedPod, err := s.Mutate(ctx, pod, namespace)
 	if err != nil {
 		log.Error(err, "Failed to mutate Trial's pod")
 		return admission.Errored(http.StatusBadRequest, err)
@@ -107,28 +107,28 @@ func (s *SidecarInjector) Handle(ctx context.Context, req admission.Request) adm
 	return admission.PatchResponseFromRaw(req.AdmissionRequest.Object.Raw, marshaledPod)
 }
 
-func (s *SidecarInjector) MutationRequired(pod *v1.Pod, ns string) (bool, error) {
+func (s *SidecarInjector) MutationRequired(ctx context.Context, pod *v1.Pod, ns string) (bool, error) {
 	object, err := util.ConvertObjectToUnstructured(pod)
 	if err != nil {
 		return false, err
 	}
 
 	// Try to get Katib Job name from mutating pod
-	_, jobName, err := s.getKatibJob(object, ns)
+	_, jobName, err := s.getKatibJob(ctx, object, ns)
 	if err != nil {
 		return false, nil
 	}
 
 	trial := &trialsv1beta1.Trial{}
 	// Job name and Trial name is equal
-	if err := s.client.Get(context.TODO(), apitypes.NamespacedName{Name: jobName, Namespace: ns}, trial); err != nil {
+	if err := s.client.Get(ctx, apitypes.NamespacedName{Name: jobName, Namespace: ns}, trial); err != nil {
 		return false, err
 	}
 
 	return true, nil
 }
 
-func (s *SidecarInjector) Mutate(pod *v1.Pod, namespace string) (*v1.Pod, error) {
+func (s *SidecarInjector) Mutate(ctx context.Context, pod *v1.Pod, namespace string) (*v1.Pod, error) {
 	mutatedPod := pod.DeepCopy()
 
 	object, err := util.ConvertObjectToUnstructured(pod)
@@ -137,11 +137,11 @@ func (s *SidecarInjector) Mutate(pod *v1.Pod, namespace string) (*v1.Pod, error)
 	}
 
 	// Try to get Katib job kind and job name from mutating pod
-	_, jobName, _ := s.getKatibJob(object, namespace)
+	_, jobName, _ := s.getKatibJob(ctx, object, namespace)
 
 	trial := &trialsv1beta1.Trial{}
 	// jobName and Trial name is equal
-	if err := s.client.Get(context.TODO(), apitypes.NamespacedName{Name: jobName, Namespace: namespace}, trial); err != nil {
+	if err := s.client.Get(ctx, apitypes.NamespacedName{Name: jobName, Namespace: namespace}, trial); err != nil {
 		return nil, err
 	}
 
@@ -168,14 +168,14 @@ func (s *SidecarInjector) Mutate(pod *v1.Pod, namespace string) (*v1.Pod, error)
 	}
 
 	// Create metrics sidecar container spec
-	injectContainer, err := s.getMetricsCollectorContainer(trial, pod)
+	injectContainer, err := s.getMetricsCollectorContainer(ctx, trial, pod)
 	if err != nil {
 		return nil, err
 	}
 	mutatedPod.Spec.Containers = append(mutatedPod.Spec.Containers, *injectContainer)
 
 	// Enable shared volume between suggestion <> trial
-	if err = s.mutateSuggestionVolume(mutatedPod, injectContainer.Name, trial); err != nil {
+	if err = s.mutateSuggestionVolume(ctx, mutatedPod, injectContainer.Name, trial); err != nil {
 		return nil, err
 	}
 
@@ -203,7 +203,7 @@ func (s *SidecarInjector) Mutate(pod *v1.Pod, namespace string) (*v1.Pod, error)
 	return mutatedPod, nil
 }
 
-func (s *SidecarInjector) getMetricsCollectorContainer(trial *trialsv1beta1.Trial, originalPod *v1.Pod) (*v1.Container, error) {
+func (s *SidecarInjector) getMetricsCollectorContainer(ctx context.Context, trial *trialsv1beta1.Trial, originalPod *v1.Pod) (*v1.Container, error) {
 	mc := trial.Spec.MetricsCollector
 	if mc.Collector.Kind == common.CustomCollector {
 		return mc.Collector.CustomCollector, nil
@@ -226,7 +226,7 @@ func (s *SidecarInjector) getMetricsCollectorContainer(trial *trialsv1beta1.Tria
 		return nil, err
 	}
 
-	args, err := s.getMetricsCollectorArgs(trial, metricNames, mc, metricsCollectorConfigData, earlyStoppingRules)
+	args, err := s.getMetricsCollectorArgs(ctx, trial, metricNames, mc, metricsCollectorConfigData, earlyStoppingRules)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func (s *SidecarInjector) getMetricsCollectorContainer(trial *trialsv1beta1.Tria
 	return &injectContainer, nil
 }
 
-func (s *SidecarInjector) getKatibJob(object *unstructured.Unstructured, namespace string) (string, string, error) {
+func (s *SidecarInjector) getKatibJob(ctx context.Context, object *unstructured.Unstructured, namespace string) (string, string, error) {
 	owners := object.GetOwnerReferences()
 	// jobKind and jobName points to the object kind and name that Trial is created
 	jobKind := ""
@@ -285,12 +285,12 @@ func (s *SidecarInjector) getKatibJob(object *unstructured.Unstructured, namespa
 			nestedJob.SetGroupVersionKind(gvk)
 			// Get nested object from cluster.
 			// Nested object namespace must be equal to object namespace
-			err = s.client.Get(context.TODO(), apitypes.NamespacedName{Name: owners[i].Name, Namespace: namespace}, nestedJob)
+			err = s.client.Get(ctx, apitypes.NamespacedName{Name: owners[i].Name, Namespace: namespace}, nestedJob)
 			if err != nil {
 				return "", "", fmt.Errorf("%w: %w", errFailedToGetTrialTemplateJob, err)
 			}
 			// Recursively search for Trial ownership in nested object
-			jobKind, jobName, err = s.getKatibJob(nestedJob, namespace)
+			jobKind, jobName, err = s.getKatibJob(ctx, nestedJob, namespace)
 			if err != nil && jobKind != "" {
 				return "", "", err
 			}
@@ -306,7 +306,7 @@ func (s *SidecarInjector) getKatibJob(object *unstructured.Unstructured, namespa
 	return jobKind, jobName, nil
 }
 
-func (s *SidecarInjector) getMetricsCollectorArgs(trial *trialsv1beta1.Trial, metricNames string, mc common.MetricsCollectorSpec, metricsCollectorConfigData configv1beta1.MetricsCollectorConfig, esRules []string) ([]string, error) {
+func (s *SidecarInjector) getMetricsCollectorArgs(ctx context.Context, trial *trialsv1beta1.Trial, metricNames string, mc common.MetricsCollectorSpec, metricsCollectorConfigData configv1beta1.MetricsCollectorConfig, esRules []string) ([]string, error) {
 	args := []string{"-t", trial.Name, "-m", metricNames, "-o-type", string(trial.Spec.Objective.Type), "-s-db", katibmanagerv1beta1.GetDBManagerAddr()}
 	if mountPath, _ := getMountPath(mc); mountPath != "" {
 		args = append(args, "-path", mountPath)
@@ -335,7 +335,7 @@ func (s *SidecarInjector) getMetricsCollectorArgs(trial *trialsv1beta1.Trial, me
 		// Get suggestion to set early stopping service endpoint
 		suggestionName := trial.ObjectMeta.Labels[consts.LabelExperimentName]
 		suggestion := &suggestionsv1beta1.Suggestion{}
-		err := s.client.Get(context.TODO(), apitypes.NamespacedName{Name: suggestionName, Namespace: trial.Namespace}, suggestion)
+		err := s.client.Get(ctx, apitypes.NamespacedName{Name: suggestionName, Namespace: trial.Namespace}, suggestion)
 		if err != nil {
 			return nil, fmt.Errorf("%w: %w", errInvalidSuggestionName, err)
 		}
@@ -346,16 +346,16 @@ func (s *SidecarInjector) getMetricsCollectorArgs(trial *trialsv1beta1.Trial, me
 }
 
 // Mutate trial container with shared Suggestions PVC when algorithm settings contains suggestion_trial_dir
-func (s *SidecarInjector) mutateSuggestionVolume(pod *v1.Pod, primaryContainerName string, trial *trialsv1beta1.Trial) error {
+func (s *SidecarInjector) mutateSuggestionVolume(ctx context.Context, pod *v1.Pod, primaryContainerName string, trial *trialsv1beta1.Trial) error {
 	// Suggestion name == Experiment name
 	// Suggestion namespace == Trial namespace
 	experimentName := trial.ObjectMeta.Labels[consts.LabelExperimentName]
 	experiment := &experimentsv1beta1.Experiment{}
-	if err := s.client.Get(context.TODO(), apitypes.NamespacedName{Name: experimentName, Namespace: trial.Namespace}, experiment); err != nil {
+	if err := s.client.Get(ctx, apitypes.NamespacedName{Name: experimentName, Namespace: trial.Namespace}, experiment); err != nil {
 		return err
 	}
 	suggestion := &suggestionsv1beta1.Suggestion{}
-	if err := s.client.Get(context.TODO(), apitypes.NamespacedName{Name: experimentName, Namespace: trial.Namespace}, suggestion); err != nil {
+	if err := s.client.Get(ctx, apitypes.NamespacedName{Name: experimentName, Namespace: trial.Namespace}, suggestion); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
There are ~30 instances in production code (excluding tests and generated files) where context.TODO() is used as a placeholder. This is not suitable for production, as it prevents proper context propagation, including cancellation, deadlines, and request-scoped values.

In controller logic, the reconciler already receives a context.Context via:

Reconcile(ctx context.Context, ...)

However, this context was not consistently passed down through the call chain and into Kubernetes API calls.

Changes
Replaced all occurrences of context.TODO() in production code with the appropriate propagated ctx.
Ensured the ctx received in Reconcile is threaded through all downstream function calls.
Updated Kubernetes client/API calls to use the propagated context.
Benefits
Enables proper cancellation and timeout handling.
Aligns with Go best practices for context usage.
Improves observability and tracing capabilities.
Removes placeholder code that could lead to unintended behavior in production.