### PR TITLE
Fail loudly on unsupported Optuna parameter distributions

### DIFF
--- a/pkg/suggestion/v1beta1/optuna/base_service.py
+++ b/pkg/suggestion/v1beta1/optuna/base_service.py
@@ -129,6 +129,13 @@ class BaseOptunaService(object):
                         log=True,
                         step=1,
                     )
+                else:
+                    raise ValueError(
+                        f"Unsupported distribution "
+                        f"{api_pb2.Distribution.Name(param.distribution)} for parameter "
+                        f"{param.name}. The Optuna suggestion service supports only UNIFORM "
+                        f"and LOG_UNIFORM for int parameters."
+                    )
 
             elif param.type == DOUBLE:
                 if param.distribution in [api_pb2.UNIFORM, None]:
@@ -147,6 +154,13 @@ class BaseOptunaService(object):
                         high=float(param.max),
                         log=True,
                         step=None,
+                    )
+                else:
+                    raise ValueError(
+                        f"Unsupported distribution "
+                        f"{api_pb2.Distribution.Name(param.distribution)} for parameter "
+                        f"{param.name}. The Optuna suggestion service supports only UNIFORM "
+                        f"and LOG_UNIFORM for double parameters."
                     )
 
             elif param.type in [CATEGORICAL, DISCRETE]:

--- a/test/unit/v1beta1/suggestion/test_optuna_service.py
+++ b/test/unit/v1beta1/suggestion/test_optuna_service.py
@@ -18,6 +18,12 @@ import pytest
 import utils
 
 from pkg.apis.manager.v1beta1.python import api_pb2
+from pkg.suggestion.v1beta1.internal import constant
+from pkg.suggestion.v1beta1.internal.search_space import (
+    HyperParameter,
+    HyperParameterSearchSpace,
+)
+from pkg.suggestion.v1beta1.optuna.base_service import BaseOptunaService
 from pkg.suggestion.v1beta1.optuna.service import OptunaService
 
 
@@ -113,7 +119,10 @@ class TestOptuna:
                             name="param-7",
                             parameter_type=api_pb2.INT,
                             feasible_space=api_pb2.FeasibleSpace(
-                                max="5", min="1", step="2", distribution=api_pb2.LOG_UNIFORM
+                                max="5",
+                                min="1",
+                                step="2",
+                                distribution=api_pb2.LOG_UNIFORM,
                             ),
                         ),
                         api_pb2.ParameterSpec(
@@ -127,14 +136,20 @@ class TestOptuna:
                             name="param-9",
                             parameter_type=api_pb2.DOUBLE,
                             feasible_space=api_pb2.FeasibleSpace(
-                                max="11", min="1", step="2.5", distribution=api_pb2.UNIFORM
+                                max="11",
+                                min="1",
+                                step="2.5",
+                                distribution=api_pb2.UNIFORM,
                             ),
                         ),
                         api_pb2.ParameterSpec(
                             name="param-10",
                             parameter_type=api_pb2.DOUBLE,
                             feasible_space=api_pb2.FeasibleSpace(
-                                max="11", min="1", step="2.5", distribution=api_pb2.LOG_UNIFORM
+                                max="11",
+                                min="1",
+                                step="2.5",
+                                distribution=api_pb2.LOG_UNIFORM,
                             ),
                         ),
                         api_pb2.ParameterSpec(
@@ -550,6 +565,39 @@ class TestOptuna:
         )
         _, _, code, _ = utils.call_validate(self.test_server, experiment_spec)
         assert code == result
+
+
+class TestOptunaUnsupportedDistribution:
+    @pytest.mark.parametrize(
+        ["param_type", "distribution"],
+        [
+            ["double", api_pb2.NORMAL],
+            ["double", api_pb2.LOG_NORMAL],
+            ["int", api_pb2.NORMAL],
+            ["int", api_pb2.LOG_NORMAL],
+        ],
+    )
+    def test_unsupported_distribution_raises(self, param_type, distribution):
+        # The Optuna suggestion service only maps UNIFORM and LOG_UNIFORM. A param
+        # with NORMAL or LOG_NORMAL used to be dropped from the search space without
+        # any error, so the hyperparameter was silently never tuned (#2665). It must
+        # now fail loudly instead.
+        search_space = HyperParameterSearchSpace()
+        search_space.goal = constant.MAX_GOAL
+        if param_type == "double":
+            param = HyperParameter.double("x", "0.1", "0.9", "", distribution)
+        else:
+            param = HyperParameter.int("x", "1", "9", "1", distribution)
+        search_space.params = [param]
+
+        service = BaseOptunaService(
+            algorithm_name="random",
+            algorithm_config={},
+            search_space=search_space,
+        )
+
+        with pytest.raises(ValueError, match="Unsupported distribution"):
+            service.get_suggestions([], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**What this PR does / why we need it**:

The Optuna suggestion service maps only `UNIFORM` and `LOG_UNIFORM` for `int` and `double` parameters. In `_get_optuna_search_space()` (`pkg/suggestion/v1beta1/optuna/base_service.py`), a parameter declaring `NORMAL` or `LOG_NORMAL` matched neither branch and was left out of the returned search space. Optuna then never sampled that parameter, so the hyperparameter was silently dropped from tuning with no error and no log line. The experiment completed with results that quietly ignored the parameter.

The `Distribution` enum in `api.proto` defines all four values, and the `hyperopt` suggestion service already handles `NORMAL` and `LOG_NORMAL`. So these are valid inputs that one backend honors and the Optuna backend silently discarded.

Optuna has no native normal or log-normal distribution (it offers uniform, log-uniform via the `log` flag, and categorical), so the backend cannot faithfully honor `NORMAL`/`LOG_NORMAL`. This PR adds an explicit `else` branch for `int` and `double` that raises a `ValueError` naming the parameter and the unsupported distribution, turning a silent correctness bug into an actionable error. Implementing real support can be a follow-up if a faithful mapping is agreed on.

**Which issue(s) this PR fixes**:

Fixes #2665

**Checklist:**

- [ ] Docs included if any changes are user facing
- [x] Unit tests added that prove the fix is effective
- [x] `make pytest` style local run passes (`pytest test/unit/v1beta1/suggestion/test_optuna_service.py`: 29 passed)

**Testing**:

Added `TestOptunaUnsupportedDistribution`, a parametrized regression test covering `NORMAL` and `LOG_NORMAL` for both `int` and `double` parameters. It asserts `get_suggestions` raises `ValueError`. The four cases fail on master (`DID NOT RAISE`, confirming the silent drop) and pass with this change. The existing 25 Optuna tests continue to pass. `black`, `isort --profile black`, and `flake8` are clean on both changed files.