### PR TITLE
chore: Add CODE_OF_CONDUCT.md in kubeflow/katib

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+## Community Code of Conduct
+
+This project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,6 @@
-## Community Code of Conduct
+# Kubeflow Community Code of Conduct
 
-This project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+Kubeflow follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting
+the [Kubeflow Steering Committee](https://github.com/kubeflow/community/tree/master/committee-steering).


### PR DESCRIPTION
Part of #[976](https://github.com/kubeflow/community/issues/976)

Adds a `CODE_OF_CONDUCT.md` file in the repository.