### PR TITLE
fix(metricscollector): parse fractional UNIX timestamps in JSON logs

### DIFF
--- a/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector.go
+++ b/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector.go
@@ -217,17 +217,23 @@ func parseTimestamp(timestamp interface{}) string {
 		}
 
 		stringTimestamp = strconv.FormatFloat(floatTimestamp, 'f', -1, 64)
-		t := strings.Split(stringTimestamp, ".")
+		secPart, fracPart, hasFrac := strings.Cut(stringTimestamp, ".")
 
-		sec, err := strconv.ParseInt(t[0], 10, 64)
+		sec, err := strconv.ParseInt(secPart, 10, 64)
 		if err != nil {
 			klog.Warningf("Failed to parse timestamp; %v", err)
 			return ""
 		}
 
-		var nanoSec int64 = 0
-		if len(t) == 2 {
-			nanoSec, err = strconv.ParseInt(t[1], 10, 64)
+		var nanoSec int64
+		if hasFrac && fracPart != "" {
+			if len(fracPart) > 9 {
+				fracPart = fracPart[:9]
+			} else if len(fracPart) < 9 {
+				fracPart += strings.Repeat("0", 9-len(fracPart))
+			}
+
+			nanoSec, err = strconv.ParseInt(fracPart, 10, 64)
 			if err != nil {
 				klog.Warningf("Failed to parse timestamp; %v", err)
 				return ""

--- a/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
+++ b/pkg/metricscollector/v1beta1/file-metricscollector/file-metricscollector_test.go
@@ -51,14 +51,14 @@ func TestCollectObservationLog(t *testing.T) {
 			expected: &v1beta1.ObservationLog{
 				MetricLogs: []*v1beta1.MetricLog{
 					{
-						TimeStamp: "2021-12-02T05:27:27.000028721Z",
+						TimeStamp: "2021-12-02T05:27:27.28721Z",
 						Metric: &v1beta1.Metric{
 							Name:  "loss",
 							Value: "0.22082142531871796",
 						},
 					},
 					{
-						TimeStamp: "2021-12-02T05:27:27.000287801Z",
+						TimeStamp: "2021-12-02T05:27:27.287801Z",
 						Metric: &v1beta1.Metric{
 							Name:  "acc",
 							Value: "0.9349666833877563",
@@ -325,5 +325,14 @@ invalid INFO     {metricName: loss, metricValue: 0.3634}`,
 				t.Errorf("Unexpected parsed result (-want,+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestParseTimestampUnixFloat(t *testing.T) {
+	got := parseTimestamp(1638422847.28721)
+	want := "2021-12-02T05:27:27.28721Z"
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("Unexpected timestamp (-want,+got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
What this PR does / why we need it

`file-metricscollector` supports JSON logs, but numeric UNIX timestamps with fractions were parsed wrong. The fractional part was treated like raw nanoseconds, so `1638422847.28721` became `2021-12-02T05:27:27.000028721Z` instead of `2021-12-02T05:27:27.28721Z`.

This patch keeps the fractional seconds when building the RFC3339 timestamp. String timestamps and integer UNIX timestamps stay the same. This is a small fix, but it is pretty easy to hit on the JSON log path.

Related to #944
Follow-up to #1765

How to reproduce

1. Run `go test ./pkg/metricscollector/v1beta1/file-metricscollector -count=1`
2. Before this patch, the JSON fixture in `TestCollectObservationLog` stored `1638422847.28721` as `2021-12-02T05:27:27.000028721Z`
3. With this patch, it stores `2021-12-02T05:27:27.28721Z`

Checklist:

- [ ] Docs included if any changes are user facing