### PR TITLE
fix(controller): wrap trial status errors

### DIFF
--- a/pkg/controller.v1beta1/trial/trial_controller.go
+++ b/pkg/controller.v1beta1/trial/trial_controller.go
@@ -58,9 +58,9 @@ const (
 var (
 	log = logf.Log.WithName(ControllerName)
 	// errMetricsNotReported is the error when Trial job is succeeded but metrics are not reported yet
-	errMetricsNotReported = fmt.Errorf("metrics are not reported yet")
+	errMetricsNotReported = errors.New("metrics are not reported yet")
 	// errReportMetricsFailed is the error when `unavailable` metrics value can't be inserted to the Katib DB.
-	errReportMetricsFailed = fmt.Errorf("failed to report unavailable metrics")
+	errReportMetricsFailed = errors.New("failed to report unavailable metrics")
 )
 
 // Add creates a new Trial Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller

--- a/pkg/controller.v1beta1/trial/trial_controller_test.go
+++ b/pkg/controller.v1beta1/trial/trial_controller_test.go
@@ -18,6 +18,7 @@ package trial
 
 import (
 	"context"
+	stderrors "errors"
 	"testing"
 	"time"
 
@@ -27,7 +28,7 @@ import (
 	"go.uber.org/mock/gomock"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -150,7 +151,7 @@ func TestReconcileBatchJob(t *testing.T) {
 	}
 
 	r.updateStatusHandler = func(instance *trialsv1beta1.Trial) error {
-		var err error = errors.NewBadRequest("fake-error")
+		var err error = apierrors.NewBadRequest("fake-error")
 		// Try to update status until it be succeeded
 		for err != nil {
 			updatedInstance := &trialsv1beta1.Trial{}
@@ -241,7 +242,7 @@ func TestReconcileBatchJob(t *testing.T) {
 		// BatchJob can't be deleted because GC doesn't work in envtest and BatchJob stuck in termination phase.
 		// Ref: https://book.kubebuilder.io/reference/testing/envtest.html#testing-considerations.
 		g.Eventually(func(g gomega.Gomega) {
-			g.Expect(errors.IsNotFound(c.Get(ctx, trialKey, &trialsv1beta1.Trial{}))).Should(gomega.BeTrue())
+			g.Expect(apierrors.IsNotFound(c.Get(ctx, trialKey, &trialsv1beta1.Trial{}))).Should(gomega.BeTrue())
 		}, timeout).Should(gomega.Succeed())
 	})
 
@@ -314,7 +315,7 @@ func TestReconcileBatchJob(t *testing.T) {
 
 		// Expect that Trial is deleted
 		g.Eventually(func(g gomega.Gomega) {
-			g.Expect(errors.IsNotFound(c.Get(ctx, trialKey, &trialsv1beta1.Trial{}))).Should(gomega.BeTrue())
+			g.Expect(apierrors.IsNotFound(c.Get(ctx, trialKey, &trialsv1beta1.Trial{}))).Should(gomega.BeTrue())
 		}, timeout).Should(gomega.Succeed())
 	})
 
@@ -348,7 +349,7 @@ func TestReconcileBatchJob(t *testing.T) {
 
 		// Expect that Trial is deleted
 		g.Eventually(func(g gomega.Gomega) {
-			g.Expect(errors.IsNotFound(c.Get(ctx, trialKey, &trialsv1beta1.Trial{}))).Should(gomega.BeTrue())
+			g.Expect(apierrors.IsNotFound(c.Get(ctx, trialKey, &trialsv1beta1.Trial{}))).Should(gomega.BeTrue())
 		}, timeout).Should(gomega.Succeed())
 	})
 
@@ -389,7 +390,7 @@ func TestReconcileBatchJob(t *testing.T) {
 
 		// Expect that Trial is deleted
 		g.Eventually(func(g gomega.Gomega) {
-			g.Expect(errors.IsNotFound(c.Get(ctx, trialKey, &trialsv1beta1.Trial{}))).Should(gomega.BeTrue())
+			g.Expect(apierrors.IsNotFound(c.Get(ctx, trialKey, &trialsv1beta1.Trial{}))).Should(gomega.BeTrue())
 		}, timeout).Should(gomega.Succeed())
 	})
 
@@ -456,6 +457,8 @@ func TestGetObjectiveMetricValue(t *testing.T) {
 	}
 	_, err = getMetrics(invalidLogs, metricStrategies)
 	g.Expect(err).To(gomega.HaveOccurred())
+	var parseErr *time.ParseError
+	g.Expect(stderrors.As(err, &parseErr)).To(gomega.BeTrue())
 }
 
 func newFakeTrialBatchJob(mcType commonv1beta1.CollectorKind, trialName, jobName string) *trialsv1beta1.Trial {

--- a/pkg/controller.v1beta1/trial/trial_controller_util.go
+++ b/pkg/controller.v1beta1/trial/trial_controller_util.go
@@ -226,7 +226,7 @@ func getMetrics(metricLogs []*api_pb.MetricLog, strategies []commonv1beta1.Metri
 		}
 		currentTime, err := time.Parse(time.RFC3339Nano, metricLog.TimeStamp)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse timestamps %s: %e", metricLog.TimeStamp, err)
+			return nil, fmt.Errorf("failed to parse timestamps %s: %w", metricLog.TimeStamp, err)
 		}
 		timestamp := timestamps[metricLog.Metric.Name]
 		if timestamp == nil || !timestamp.After(currentTime) {

--- a/pkg/controller.v1beta1/trial/util/job_util.go
+++ b/pkg/controller.v1beta1/trial/util/job_util.go
@@ -79,7 +79,7 @@ func GetDeployedJobStatus(trial *trialsv1beta1.Trial, deployedJob *unstructured.
 		// Unmarshal condition to Trial Job representation to get message and reason if it exists
 		err := json.Unmarshal([]byte(strCondition), &trialJobStatus)
 		if err != nil {
-			return nil, fmt.Errorf("unmarshal failure condition to Trial Job status failed %v", err)
+			return nil, fmt.Errorf("unmarshal failure condition to Trial Job status failed: %w", err)
 		}
 
 		// Job condition is failed
@@ -100,7 +100,7 @@ func GetDeployedJobStatus(trial *trialsv1beta1.Trial, deployedJob *unstructured.
 
 		err := json.Unmarshal([]byte(strCondition), &trialJobStatus)
 		if err != nil {
-			return nil, fmt.Errorf("unmarshal success condition to Trial Job status failed %v", err)
+			return nil, fmt.Errorf("unmarshal success condition to Trial Job status failed: %w", err)
 		}
 
 		// Job condition is succeeded

--- a/pkg/controller.v1beta1/trial/util/job_util_test.go
+++ b/pkg/controller.v1beta1/trial/util/job_util_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package util
 
 import (
+	"encoding/json"
+	"errors"
 	"testing"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -149,4 +151,56 @@ func newFakeDeployedJob(job interface{}) *unstructured.Unstructured {
 
 	jobUnstructured, _ := util.ConvertObjectToUnstructured(job)
 	return jobUnstructured
+}
+
+func TestGetDeployedJobStatusWrapsFailureConditionUnmarshalError(t *testing.T) {
+	trial := &trialsv1beta1.Trial{}
+	trial.Spec.FailureCondition = "status.failed"
+	deployedJob := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "trial-job",
+			},
+			"status": map[string]interface{}{
+				"failed": map[string]interface{}{
+					"message": 1,
+				},
+			},
+		},
+	}
+
+	_, err := GetDeployedJobStatus(trial, deployedJob)
+	if err == nil {
+		t.Fatal("expected unmarshal error")
+	}
+	var unmarshalTypeErr *json.UnmarshalTypeError
+	if !errors.As(err, &unmarshalTypeErr) {
+		t.Fatalf("expected wrapped *json.UnmarshalTypeError, got %T: %v", err, err)
+	}
+}
+
+func TestGetDeployedJobStatusWrapsSuccessConditionUnmarshalError(t *testing.T) {
+	trial := &trialsv1beta1.Trial{}
+	trial.Spec.SuccessCondition = "status.succeeded"
+	deployedJob := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "trial-job",
+			},
+			"status": map[string]interface{}{
+				"succeeded": map[string]interface{}{
+					"reason": true,
+				},
+			},
+		},
+	}
+
+	_, err := GetDeployedJobStatus(trial, deployedJob)
+	if err == nil {
+		t.Fatal("expected unmarshal error")
+	}
+	var unmarshalTypeErr *json.UnmarshalTypeError
+	if !errors.As(err, &unmarshalTypeErr) {
+		t.Fatalf("expected wrapped *json.UnmarshalTypeError, got %T: %v", err, err)
+	}
 }


### PR DESCRIPTION
Fixes #2628.

This tightens the trial controller error wrapping so callers can use errors.Is / errors.As on the underlying failures:

- use errors.New for sentinel trial-controller errors
- wrap metric timestamp parse failures with %w
- wrap deployed job success/failure condition unmarshal errors with %w
- add regression coverage for the parse and JSON unmarshal error chains

Tested:
- go test ./pkg/controller.v1beta1/trial/util
- KUBEBUILDER_ASSETS=C:\Users\lin\AppData\Local\kubebuilder-envtest\k8s\1.34.0-windows-amd64 go test ./pkg/controller.v1beta1/trial ./pkg/controller.v1beta1/trial/util

The second command reaches PASS for the controller package tests on this Windows machine, then the command exits 1 because envtest cannot signal the local kube-apiserver and etcd processes to stop (`not supported by windows`).