### PR TITLE
Validate positive range for log-scale distribution parameters

### DIFF
--- a/pkg/webhook/v1beta1/experiment/validator/validator.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator.go
@@ -289,6 +289,19 @@ func (g *DefaultValidator) validateParameters(parameters []experimentsv1beta1.Pa
 					allErrs = append(allErrs, field.Required(parametersPath.Index(i).Child("feasibleSpace").Child("max"),
 						fmt.Sprintf("feasibleSpace.max or feasibleSpace.min must be specified for parameterType: %v", param.ParameterType)))
 				}
+				if param.FeasibleSpace.Distribution == experimentsv1beta1.DistributionLogUniform ||
+					param.FeasibleSpace.Distribution == experimentsv1beta1.DistributionLogNormal {
+					// Log-scale distributions are only defined for a strictly positive range,
+					// so a non-positive min or max would crash the suggestion service at math.log.
+					if v, err := strconv.ParseFloat(param.FeasibleSpace.Min, 64); err == nil && v <= 0 {
+						allErrs = append(allErrs, field.Invalid(parametersPath.Index(i).Child("feasibleSpace").Child("min"),
+							param.FeasibleSpace.Min, fmt.Sprintf("feasibleSpace.min must be greater than 0 for distribution: %v", param.FeasibleSpace.Distribution)))
+					}
+					if v, err := strconv.ParseFloat(param.FeasibleSpace.Max, 64); err == nil && v <= 0 {
+						allErrs = append(allErrs, field.Invalid(parametersPath.Index(i).Child("feasibleSpace").Child("max"),
+							param.FeasibleSpace.Max, fmt.Sprintf("feasibleSpace.max must be greater than 0 for distribution: %v", param.FeasibleSpace.Distribution)))
+					}
+				}
 
 			} else if param.ParameterType == experimentsv1beta1.ParameterTypeCategorical || param.ParameterType == experimentsv1beta1.ParameterTypeDiscrete {
 				if param.FeasibleSpace.Max != "" || param.FeasibleSpace.Min != "" || param.FeasibleSpace.Step != "" {

--- a/pkg/webhook/v1beta1/experiment/validator/validator_test.go
+++ b/pkg/webhook/v1beta1/experiment/validator/validator_test.go
@@ -478,6 +478,18 @@ func TestValidateParameters(t *testing.T) {
 			testDescription: "Invalid distribution type",
 		},
 		{
+			parameters: func() []experimentsv1beta1.ParameterSpec {
+				ps := newFakeInstance().Spec.Parameters
+				ps[0].FeasibleSpace.Min = "0"
+				ps[0].FeasibleSpace.Distribution = experimentsv1beta1.DistributionLogUniform
+				return ps
+			}(),
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("parameters").Index(0).Child("feasibleSpace").Child("min"), "", ""),
+			},
+			testDescription: "Non-positive min for logUniform distribution",
+		},
+		{
 			parameters:      newFakeInstance().Spec.Parameters,
 			wantErr:         nil,
 			testDescription: "Valid parameters case",


### PR DESCRIPTION
## What this PR does / why we need it

Fixes #2678.

A parameter with a `logUniform` or `logNormal` distribution and a non-positive `min` or `max` is currently admitted by the webhook and then crashes the suggestion service at `math.log` (hyperopt `create_hyperopt_domain`, and skopt's hardcoded log-uniform prior) with `ValueError: math domain error`.

`validateParameters` now rejects `logUniform` / `logNormal` parameters whose `min` or `max` parses to a value `<= 0`, with a clear field error, so the experiment is refused at admission instead of crashing the suggestion pod. This matches how the validator already rejects other invalid `feasibleSpace` values, and follows the same fail-at-admission approach as #2666.

The check only fires when the value parses as a float and is `<= 0`, so non-numeric min/max are left to the existing handling.

## Test

Added a `TestValidateParameters` case (non-positive min for `logUniform`).

```
go test ./pkg/webhook/v1beta1/experiment/validator/ -run TestValidateParameters
ok  github.com/kubeflow/katib/pkg/webhook/v1beta1/experiment/validator
```

/kind bug